### PR TITLE
Fix: Replace empty divs with proper Bootstrap modals for Respond to Call/Station

### DIFF
--- a/Web/Resgrid.Web/Areas/User/Views/Home/Dashboard.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Home/Dashboard.cshtml
@@ -222,8 +222,30 @@
   </div>
 </div>
 
-<div class="respondToACallWindow" id="respondToACallWindow"></div>
-<div class="respondToAStationWindow" id="respondToAStationWindow"></div>
+<div class="modal fade" tabindex="-1" role="dialog" id="respondToACallWindow">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+        <h4 class="modal-title">@localizer["RespondToCall"]</h4>
+      </div>
+      <div class="modal-body">
+      </div>
+    </div>
+  </div>
+</div>
+<div class="modal fade" tabindex="-1" role="dialog" id="respondToAStationWindow">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+        <h4 class="modal-title">@localizer["RespondToStation"]</h4>
+      </div>
+      <div class="modal-body">
+      </div>
+    </div>
+  </div>
+</div>
 
 @section Scripts
 {


### PR DESCRIPTION
## Summary

This PR fixes the "Respond to a Call" functionality that was broken after the KendoUI removal in commit RE1-T104.

## Problem

When clicking "Responding" → "Respond to a Call" (issue #317):
- The screen would go dark (modal backdrop appeared)
- But no modal content was displayed

## Root Cause

Commit RE1-T104 switched from Kendo UI Windows to Bootstrap modals but didn't add the required modal HTML structure:
- Kendo's `kendoWindow()` could auto-create the window on empty divs
- Bootstrap modals require actual HTML with `.modal`, `.modal-dialog`, `.modal-content` classes
- The empty `<div id="respondToACallWindow"></div>` had no modal structure

## Fix

Added proper Bootstrap modal HTML structure for both:
- `respondToACallWindow` - for responding to calls
- `respondToAStationWindow` - for responding to stations

The modal bodies are empty initially; content is loaded dynamically via JavaScript when the modal opens.

## Testing

- Modal structure now matches Bootstrap conventions (same pattern as `confirmSetAllToStandbyModal` in the same file)
- JavaScript handlers for `show.bs.modal` will now find `.modal-body` elements to load content into

Fixes #317

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced the respond-to-call and respond-to-station dialog interfaces with properly structured headers containing close buttons and localized titles, providing users with a more intuitive and professional interaction experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->