### PR TITLE
RE1-T113 Set pw on first login

### DIFF
--- a/Core/Resgrid.Localization/Areas/User/Personnel/Person.ar.resx
+++ b/Core/Resgrid.Localization/Areas/User/Personnel/Person.ar.resx
@@ -53,6 +53,12 @@
   <data name="NotificationOptionsLabel" xml:space="preserve"><value>خيارات الإشعارات</value></data>
   <data name="NotifyUser" xml:space="preserve"><value>إشعار المستخدم؟</value></data>
   <data name="NotifyWarning" xml:space="preserve"><value>أزل التحديد إذا كنت لا تريد من Resgrid إشعار المستخدم بإنشاء هذا الحساب.</value></data>
+  <data name="RequirePasswordChange" xml:space="preserve">
+    <value>Require Password Change</value>
+  </data>
+  <data name="RequirePasswordChangeHelp" xml:space="preserve">
+    <value>User will be required to change their password on first login.</value>
+  </data>
   <data name="NoUnGroupedPersonnel" xml:space="preserve"><value>لا يوجد أفراد غير منتمين لمجموعة</value></data>
   <data name="PersonnelHeader" xml:space="preserve"><value>الأفراد</value></data>
   <data name="PhoneNumbers" xml:space="preserve"><value>أرقام الهاتف</value></data>

--- a/Core/Resgrid.Localization/Areas/User/Personnel/Person.de.resx
+++ b/Core/Resgrid.Localization/Areas/User/Personnel/Person.de.resx
@@ -212,6 +212,12 @@
   <data name="NotifyWarning" xml:space="preserve">
     <value>Uncheck if you don't want Resgrid to notify the user of this account creation.</value>
   </data>
+  <data name="RequirePasswordChange" xml:space="preserve">
+    <value>Passwortaenderung erforderlich</value>
+  </data>
+  <data name="RequirePasswordChangeHelp" xml:space="preserve">
+    <value>Der Benutzer muss sein Passwort bei der ersten Anmeldung aendern.</value>
+  </data>
   <data name="NoUnGroupedPersonnel" xml:space="preserve">
     <value>No UnGrouped Personnel</value>
   </data>

--- a/Core/Resgrid.Localization/Areas/User/Personnel/Person.en.resx
+++ b/Core/Resgrid.Localization/Areas/User/Personnel/Person.en.resx
@@ -261,6 +261,12 @@
   <data name="NotifyWarning" xml:space="preserve">
     <value>Uncheck if you don't want Resgrid to notify the user of this account creation.</value>
   </data>
+  <data name="RequirePasswordChange" xml:space="preserve">
+    <value>Require Password Change</value>
+  </data>
+  <data name="RequirePasswordChangeHelp" xml:space="preserve">
+    <value>User will be required to change their password on first login.</value>
+  </data>
   <data name="NoUnGroupedPersonnel" xml:space="preserve">
     <value>No UnGrouped Personnel</value>
   </data>

--- a/Core/Resgrid.Localization/Areas/User/Personnel/Person.es.resx
+++ b/Core/Resgrid.Localization/Areas/User/Personnel/Person.es.resx
@@ -261,6 +261,12 @@
   <data name="NotifyWarning" xml:space="preserve">
     <value>Desmarque si no desea que Resgrid notifique al usuario sobre la creación de esta cuenta.</value>
   </data>
+  <data name="RequirePasswordChange" xml:space="preserve">
+    <value>Requerir cambio de contrasena</value>
+  </data>
+  <data name="RequirePasswordChangeHelp" xml:space="preserve">
+    <value>El usuario debera cambiar su contrasena en el primer inicio de sesion.</value>
+  </data>
   <data name="NoUnGroupedPersonnel" xml:space="preserve">
     <value>Sin Personal Desagrupado</value>
   </data>

--- a/Core/Resgrid.Localization/Areas/User/Personnel/Person.fr.resx
+++ b/Core/Resgrid.Localization/Areas/User/Personnel/Person.fr.resx
@@ -212,6 +212,12 @@
   <data name="NotifyWarning" xml:space="preserve">
     <value>Uncheck if you don't want Resgrid to notify the user of this account creation.</value>
   </data>
+  <data name="RequirePasswordChange" xml:space="preserve">
+    <value>Exiger le changement de mot de passe</value>
+  </data>
+  <data name="RequirePasswordChangeHelp" xml:space="preserve">
+    <value>L'utilisateur devra changer son mot de passe lors de la premiere connexion.</value>
+  </data>
   <data name="NoUnGroupedPersonnel" xml:space="preserve">
     <value>No UnGrouped Personnel</value>
   </data>

--- a/Core/Resgrid.Localization/Areas/User/Personnel/Person.it.resx
+++ b/Core/Resgrid.Localization/Areas/User/Personnel/Person.it.resx
@@ -212,6 +212,12 @@
   <data name="NotifyWarning" xml:space="preserve">
     <value>Uncheck if you don't want Resgrid to notify the user of this account creation.</value>
   </data>
+  <data name="RequirePasswordChange" xml:space="preserve">
+    <value>Richiedi cambio password</value>
+  </data>
+  <data name="RequirePasswordChangeHelp" xml:space="preserve">
+    <value>L'utente dovra cambiare la password al primo accesso.</value>
+  </data>
   <data name="NoUnGroupedPersonnel" xml:space="preserve">
     <value>No UnGrouped Personnel</value>
   </data>

--- a/Core/Resgrid.Localization/Areas/User/Personnel/Person.pl.resx
+++ b/Core/Resgrid.Localization/Areas/User/Personnel/Person.pl.resx
@@ -212,6 +212,12 @@
   <data name="NotifyWarning" xml:space="preserve">
     <value>Uncheck if you don't want Resgrid to notify the user of this account creation.</value>
   </data>
+  <data name="RequirePasswordChange" xml:space="preserve">
+    <value>Wymagaj zmiany hasla</value>
+  </data>
+  <data name="RequirePasswordChangeHelp" xml:space="preserve">
+    <value>Uzytkownik bedzie musial zmienic haslo przy pierwszym logowaniu.</value>
+  </data>
   <data name="NoUnGroupedPersonnel" xml:space="preserve">
     <value>No UnGrouped Personnel</value>
   </data>

--- a/Core/Resgrid.Localization/Areas/User/Personnel/Person.sv.resx
+++ b/Core/Resgrid.Localization/Areas/User/Personnel/Person.sv.resx
@@ -212,6 +212,12 @@
   <data name="NotifyWarning" xml:space="preserve">
     <value>Uncheck if you don't want Resgrid to notify the user of this account creation.</value>
   </data>
+  <data name="RequirePasswordChange" xml:space="preserve">
+    <value>Krav pa losenordsbyte</value>
+  </data>
+  <data name="RequirePasswordChangeHelp" xml:space="preserve">
+    <value>Anvandaren maste byta losenord vid forsta inloggningen.</value>
+  </data>
   <data name="NoUnGroupedPersonnel" xml:space="preserve">
     <value>No UnGrouped Personnel</value>
   </data>

--- a/Core/Resgrid.Localization/Areas/User/Personnel/Person.uk.resx
+++ b/Core/Resgrid.Localization/Areas/User/Personnel/Person.uk.resx
@@ -212,6 +212,12 @@
   <data name="NotifyWarning" xml:space="preserve">
     <value>Uncheck if you don't want Resgrid to notify the user of this account creation.</value>
   </data>
+  <data name="RequirePasswordChange" xml:space="preserve">
+    <value>Vymahaty zminu parolya</value>
+  </data>
+  <data name="RequirePasswordChangeHelp" xml:space="preserve">
+    <value>Korystuvach povynen zminyty parol pid chas pershoho vkhodu.</value>
+  </data>
   <data name="NoUnGroupedPersonnel" xml:space="preserve">
     <value>No UnGrouped Personnel</value>
   </data>

--- a/Core/Resgrid.Localization/Areas/User/Profile/Profile.ar.resx
+++ b/Core/Resgrid.Localization/Areas/User/Profile/Profile.ar.resx
@@ -31,6 +31,12 @@
   <data name="EditStaffingScheduleHeader" xml:space="preserve"><value>تعديل جدول التأمين</value></data>
   <data name="EmailUser" xml:space="preserve"><value>إرسال بريد إلكتروني للمستخدم؟</value></data>
   <data name="EmailUserInfo" xml:space="preserve"><value>حدد هذا المربع إذا أردت إرسال بريد إلكتروني للمستخدم يحتوي على اسم المستخدم وكلمة المرور الجديدة.</value></data>
+  <data name="RequirePasswordChange" xml:space="preserve">
+    <value>Require Password Change</value>
+  </data>
+  <data name="RequirePasswordChangeHelp" xml:space="preserve">
+    <value>User will be required to change their password on next login.</value>
+  </data>
   <data name="ExpiresOn" xml:space="preserve"><value>تنتهي في</value></data>
   <data name="ExpiresOnLabel" xml:space="preserve"><value>تنتهي في</value></data>
   <data name="IssuedByLabel" xml:space="preserve"><value>صادرة عن</value></data>

--- a/Core/Resgrid.Localization/Areas/User/Profile/Profile.de.resx
+++ b/Core/Resgrid.Localization/Areas/User/Profile/Profile.de.resx
@@ -146,6 +146,12 @@
   <data name="EmailUserInfo" xml:space="preserve">
     <value>Check this box if you want the user Emailed with their UserName and new Password.</value>
   </data>
+  <data name="RequirePasswordChange" xml:space="preserve">
+    <value>Passwortaenderung erforderlich</value>
+  </data>
+  <data name="RequirePasswordChangeHelp" xml:space="preserve">
+    <value>Der Benutzer muss sein Passwort bei der naechsten Anmeldung aendern.</value>
+  </data>
   <data name="ExpiresOn" xml:space="preserve">
     <value>Expires On</value>
   </data>

--- a/Core/Resgrid.Localization/Areas/User/Profile/Profile.en.resx
+++ b/Core/Resgrid.Localization/Areas/User/Profile/Profile.en.resx
@@ -195,6 +195,12 @@
   <data name="EmailUserInfo" xml:space="preserve">
     <value>Check this box if you want the user Emailed with their UserName and new Password.</value>
   </data>
+  <data name="RequirePasswordChange" xml:space="preserve">
+    <value>Require Password Change</value>
+  </data>
+  <data name="RequirePasswordChangeHelp" xml:space="preserve">
+    <value>User will be required to change their password on next login.</value>
+  </data>
   <data name="ExpiresOn" xml:space="preserve">
     <value>Expires On</value>
   </data>

--- a/Core/Resgrid.Localization/Areas/User/Profile/Profile.es.resx
+++ b/Core/Resgrid.Localization/Areas/User/Profile/Profile.es.resx
@@ -195,6 +195,12 @@
   <data name="EmailUserInfo" xml:space="preserve">
     <value>Marque esta casilla si desea que el usuario envíe un correo electrónico con su nombre de usuario y su nueva contraseña.</value>
   </data>
+  <data name="RequirePasswordChange" xml:space="preserve">
+    <value>Requerir cambio de contrasena</value>
+  </data>
+  <data name="RequirePasswordChangeHelp" xml:space="preserve">
+    <value>El usuario debera cambiar su contrasena en el proximo inicio de sesion.</value>
+  </data>
   <data name="ExpiresOn" xml:space="preserve">
     <value>Expira el</value>
   </data>

--- a/Core/Resgrid.Localization/Areas/User/Profile/Profile.fr.resx
+++ b/Core/Resgrid.Localization/Areas/User/Profile/Profile.fr.resx
@@ -146,6 +146,12 @@
   <data name="EmailUserInfo" xml:space="preserve">
     <value>Check this box if you want the user Emailed with their UserName and new Password.</value>
   </data>
+  <data name="RequirePasswordChange" xml:space="preserve">
+    <value>Exiger le changement de mot de passe</value>
+  </data>
+  <data name="RequirePasswordChangeHelp" xml:space="preserve">
+    <value>L'utilisateur devra changer son mot de passe lors de la prochaine connexion.</value>
+  </data>
   <data name="ExpiresOn" xml:space="preserve">
     <value>Expires On</value>
   </data>

--- a/Core/Resgrid.Localization/Areas/User/Profile/Profile.it.resx
+++ b/Core/Resgrid.Localization/Areas/User/Profile/Profile.it.resx
@@ -146,6 +146,12 @@
   <data name="EmailUserInfo" xml:space="preserve">
     <value>Check this box if you want the user Emailed with their UserName and new Password.</value>
   </data>
+  <data name="RequirePasswordChange" xml:space="preserve">
+    <value>Richiedi cambio password</value>
+  </data>
+  <data name="RequirePasswordChangeHelp" xml:space="preserve">
+    <value>L'utente dovra cambiare la password al prossimo accesso.</value>
+  </data>
   <data name="ExpiresOn" xml:space="preserve">
     <value>Expires On</value>
   </data>

--- a/Core/Resgrid.Localization/Areas/User/Profile/Profile.pl.resx
+++ b/Core/Resgrid.Localization/Areas/User/Profile/Profile.pl.resx
@@ -146,6 +146,12 @@
   <data name="EmailUserInfo" xml:space="preserve">
     <value>Check this box if you want the user Emailed with their UserName and new Password.</value>
   </data>
+  <data name="RequirePasswordChange" xml:space="preserve">
+    <value>Wymagaj zmiany hasla</value>
+  </data>
+  <data name="RequirePasswordChangeHelp" xml:space="preserve">
+    <value>Uzytkownik bedzie musial zmienic haslo przy nastepnym logowaniu.</value>
+  </data>
   <data name="ExpiresOn" xml:space="preserve">
     <value>Expires On</value>
   </data>

--- a/Core/Resgrid.Localization/Areas/User/Profile/Profile.sv.resx
+++ b/Core/Resgrid.Localization/Areas/User/Profile/Profile.sv.resx
@@ -146,6 +146,12 @@
   <data name="EmailUserInfo" xml:space="preserve">
     <value>Check this box if you want the user Emailed with their UserName and new Password.</value>
   </data>
+  <data name="RequirePasswordChange" xml:space="preserve">
+    <value>Krav pa losenordsbyte</value>
+  </data>
+  <data name="RequirePasswordChangeHelp" xml:space="preserve">
+    <value>Anvandaren maste byta losenord vid naesta inloggning.</value>
+  </data>
   <data name="ExpiresOn" xml:space="preserve">
     <value>Expires On</value>
   </data>

--- a/Core/Resgrid.Localization/Areas/User/Profile/Profile.uk.resx
+++ b/Core/Resgrid.Localization/Areas/User/Profile/Profile.uk.resx
@@ -146,6 +146,12 @@
   <data name="EmailUserInfo" xml:space="preserve">
     <value>Check this box if you want the user Emailed with their UserName and new Password.</value>
   </data>
+  <data name="RequirePasswordChange" xml:space="preserve">
+    <value>Vymahaty zminu parolya</value>
+  </data>
+  <data name="RequirePasswordChangeHelp" xml:space="preserve">
+    <value>Korystuvach povynen zminyty parol pid chas nastupnoho vkhodu.</value>
+  </data>
   <data name="ExpiresOn" xml:space="preserve">
     <value>Expires On</value>
   </data>

--- a/Core/Resgrid.Model/DepartmentMember.cs
+++ b/Core/Resgrid.Model/DepartmentMember.cs
@@ -80,6 +80,13 @@ namespace Resgrid.Model
 		/// </summary>
 		public DateTime? PasswordLastSetOn { get; set; }
 
+		/// <summary>
+		/// When true the user must change their password on next login.
+		/// Set by admins when creating accounts or resetting passwords.
+		/// Cleared automatically after the user completes the forced password change.
+		/// </summary>
+		public bool MustChangePassword { get; set; }
+
 		[NotMapped]
 		public string TableName => "DepartmentMembers";
 

--- a/Core/Resgrid.Model/DepartmentMember.cs
+++ b/Core/Resgrid.Model/DepartmentMember.cs
@@ -85,6 +85,7 @@ namespace Resgrid.Model
 		/// Set by admins when creating accounts or resetting passwords.
 		/// Cleared automatically after the user completes the forced password change.
 		/// </summary>
+		[ProtoMember(13)]
 		public bool MustChangePassword { get; set; }
 
 		[NotMapped]

--- a/Core/Resgrid.Services/DepartmentsService.cs
+++ b/Core/Resgrid.Services/DepartmentsService.cs
@@ -289,7 +289,7 @@ namespace Resgrid.Services
 			if (member != null)
 			{
 				member.IsDeleted = true;
-				var savedMember = _departmentMembersRepository.SaveOrUpdateAsync(member, cancellationToken);
+				await _departmentMembersRepository.SaveOrUpdateAsync(member, cancellationToken);
 
 				var member2 = await _departmentMembersRepository.GetDepartmentMemberByDepartmentIdAndUserIdAsync(departmentId, userIdToDelete);
 

--- a/Core/Resgrid.Services/UsersService.cs
+++ b/Core/Resgrid.Services/UsersService.cs
@@ -97,7 +97,7 @@ namespace Resgrid.Services
 			var user = await GetUserByNameAsync(userName);
 			var memberships = await _departmentMembersRepository.GetAllByUserIdAsync(user.UserId);
 
-			return memberships.Any(x => x.IsDeleted == false);
+			return memberships.Any(x => x.IsDeleted == false && (x.IsDisabled == null || x.IsDisabled == false));
 		}
 
 		public IdentityUser GetUserById(string userId, bool bypassCache = true)

--- a/Providers/Resgrid.Providers.Migrations/Migrations/M0064_AddingMustChangePassword.cs
+++ b/Providers/Resgrid.Providers.Migrations/Migrations/M0064_AddingMustChangePassword.cs
@@ -1,0 +1,19 @@
+using FluentMigrator;
+
+namespace Resgrid.Providers.Migrations.Migrations
+{
+	[Migration(64)]
+	public class M0064_AddingMustChangePassword : Migration
+	{
+		public override void Up()
+		{
+			Alter.Table("DepartmentMembers")
+				.AddColumn("MustChangePassword").AsBoolean().NotNullable().WithDefaultValue(false);
+		}
+
+		public override void Down()
+		{
+			Delete.Column("MustChangePassword").FromTable("DepartmentMembers");
+		}
+	}
+}

--- a/Providers/Resgrid.Providers.MigrationsPg/Migrations/M0064_AddingMustChangePasswordPg.cs
+++ b/Providers/Resgrid.Providers.MigrationsPg/Migrations/M0064_AddingMustChangePasswordPg.cs
@@ -1,0 +1,19 @@
+using FluentMigrator;
+
+namespace Resgrid.Providers.MigrationsPg.Migrations
+{
+	[Migration(64)]
+	public class M0064_AddingMustChangePasswordPg : Migration
+	{
+		public override void Up()
+		{
+			Alter.Table("DepartmentMembers".ToLower())
+				.AddColumn("MustChangePassword".ToLower()).AsBoolean().NotNullable().WithDefaultValue(false);
+		}
+
+		public override void Down()
+		{
+			Delete.Column("MustChangePassword".ToLower()).FromTable("DepartmentMembers".ToLower());
+		}
+	}
+}

--- a/Web/Resgrid.Web/Areas/User/Controllers/PersonnelController.cs
+++ b/Web/Resgrid.Web/Areas/User/Controllers/PersonnelController.cs
@@ -547,6 +547,16 @@ namespace Resgrid.Web.Areas.User.Controllers
 
 					await _departmentsService.AddUserToDepartmentAsync(DepartmentId, user.UserId, false, cancellationToken);
 
+					if (model.MustChangePasswordOnLogin)
+					{
+						var member = await _departmentsService.GetDepartmentMemberAsync(user.UserId, DepartmentId);
+						if (member != null)
+						{
+							member.MustChangePassword = true;
+							await _departmentsService.SaveDepartmentMemberAsync(member, cancellationToken);
+						}
+					}
+
 					var userObject = _usersService.GetUserById(user.UserId);
 
 					_eventAggregator.SendMessage<UserCreatedEvent>(new UserCreatedEvent() { DepartmentId = DepartmentId, Name = string.Format("{0} {1}", model.FirstName, model.LastName), User = userObject });

--- a/Web/Resgrid.Web/Areas/User/Controllers/ProfileController.cs
+++ b/Web/Resgrid.Web/Areas/User/Controllers/ProfileController.cs
@@ -962,6 +962,7 @@ namespace Resgrid.Web.Areas.User.Controllers
 			model.Email = user.Email;
 			model.Username = user.UserName;
 			model.MinPasswordLength = await _departmentSsoService.GetEffectiveMinPasswordLengthAsync(DepartmentId);
+			model.MustChangePasswordOnLogin = true;
 
 			return View(model);
 		}

--- a/Web/Resgrid.Web/Areas/User/Controllers/ProfileController.cs
+++ b/Web/Resgrid.Web/Areas/User/Controllers/ProfileController.cs
@@ -1000,6 +1000,13 @@ namespace Resgrid.Web.Areas.User.Controllers
 			{
 				await _departmentSsoService.RecordPasswordChangedAsync(DepartmentId, model.UserId);
 
+				var member = await _departmentsService.GetDepartmentMemberAsync(model.UserId, DepartmentId);
+				if (member != null)
+				{
+					member.MustChangePassword = model.MustChangePasswordOnLogin;
+					await _departmentsService.SaveDepartmentMemberAsync(member);
+				}
+
 				if (model.EmailUser)
 					await _emailService.SendPasswordResetEmail(model.Email, model.Name, user.UserName, model.Password, userDepartment.Name);
 

--- a/Web/Resgrid.Web/Areas/User/Models/AddPersonModel.cs
+++ b/Web/Resgrid.Web/Areas/User/Models/AddPersonModel.cs
@@ -63,5 +63,7 @@ namespace Resgrid.Web.Areas.User.Models
 		public string ConfirmPassword { get; set; }
 
 		public bool SendAccountCreationNotification { get; set; }
+
+		public bool MustChangePasswordOnLogin { get; set; }
 	}
 }

--- a/Web/Resgrid.Web/Areas/User/Models/Profile/ResetPasswordForUserView.cs
+++ b/Web/Resgrid.Web/Areas/User/Models/Profile/ResetPasswordForUserView.cs
@@ -25,5 +25,7 @@ namespace Resgrid.Web.Areas.User.Models.Profile
 		[Display(Name = "Confirm password")]
 		[System.ComponentModel.DataAnnotations.Compare("Password", ErrorMessage = "The password and confirmation password do not match.")]
 		public string ConfirmPassword { get; set; }
+
+		public bool MustChangePasswordOnLogin { get; set; }
 	}
 }

--- a/Web/Resgrid.Web/Areas/User/Views/Personnel/AddPerson.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Personnel/AddPerson.cshtml
@@ -185,6 +185,17 @@
               </div>
             </div>
 
+            <div class="form-group">
+              <label class="col-sm-2 control-label">Require Password Change</label>
+              <div class="col-sm-10">
+                <div class="checkbox checkbox-primary">
+                  <input type="checkbox" class="checkbox checkbox-primary" asp-for="MustChangePasswordOnLogin">
+                  <label></label>
+                </div>
+                <p class="help-block">User will be required to change their password on first login.</p>
+              </div>
+            </div>
+
             @if (!string.IsNullOrEmpty(Model.UdfFormHtml))
             {
               <div class="hr-line-dashed"></div>

--- a/Web/Resgrid.Web/Areas/User/Views/Personnel/AddPerson.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Personnel/AddPerson.cshtml
@@ -186,13 +186,13 @@
             </div>
 
             <div class="form-group">
-              <label class="col-sm-2 control-label">Require Password Change</label>
+              <label class="col-sm-2 control-label">@localizer["RequirePasswordChange"]</label>
               <div class="col-sm-10">
                 <div class="checkbox checkbox-primary">
                   <input type="checkbox" class="checkbox checkbox-primary" asp-for="MustChangePasswordOnLogin">
                   <label></label>
                 </div>
-                <p class="help-block">User will be required to change their password on first login.</p>
+                <p class="help-block">@localizer["RequirePasswordChangeHelp"]</p>
               </div>
             </div>
 

--- a/Web/Resgrid.Web/Areas/User/Views/Profile/ResetPasswordForUser.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Profile/ResetPasswordForUser.cshtml
@@ -97,13 +97,13 @@
                             </div>
                         </div>
                         <div class="form-group">
-                            <label class="col-sm-2 control-label">Require Password Change</label>
+                            <label class="col-sm-2 control-label">@localizer["RequirePasswordChange"]</label>
                             <div class="col-sm-10">
                                 <div class="checkbox checkbox-primary">
-                                    <input type="checkbox" class="checkbox checkbox-primary" asp-for="MustChangePasswordOnLogin" checked="checked">
+                                    <input type="checkbox" class="checkbox checkbox-primary" asp-for="MustChangePasswordOnLogin">
                                     <label></label>
                                 </div>
-                                <span class="help-block m-b-none">User will be required to change their password on next login.</span>
+                                <span class="help-block m-b-none">@localizer["RequirePasswordChangeHelp"]</span>
                             </div>
                         </div>
                         <div class="hr-line-dashed"></div>

--- a/Web/Resgrid.Web/Areas/User/Views/Profile/ResetPasswordForUser.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Profile/ResetPasswordForUser.cshtml
@@ -96,6 +96,16 @@
                                 <span class="help-block m-b-none">@localizer["EmailUserInfo"]</span>
                             </div>
                         </div>
+                        <div class="form-group">
+                            <label class="col-sm-2 control-label">Require Password Change</label>
+                            <div class="col-sm-10">
+                                <div class="checkbox checkbox-primary">
+                                    <input type="checkbox" class="checkbox checkbox-primary" asp-for="MustChangePasswordOnLogin" checked="checked">
+                                    <label></label>
+                                </div>
+                                <span class="help-block m-b-none">User will be required to change their password on next login.</span>
+                            </div>
+                        </div>
                         <div class="hr-line-dashed"></div>
                         <div class="form-group">
                             <div class="col-sm-4 col-sm-offset-2">

--- a/Web/Resgrid.Web/Controllers/AccountController.cs
+++ b/Web/Resgrid.Web/Controllers/AccountController.cs
@@ -163,10 +163,19 @@ namespace Resgrid.Web.Controllers
 									var department = await _departmentsService.GetDepartmentForUserAsync(model.Username);
 									if (department != null)
 									{
+										var member = await _departmentsService.GetDepartmentMemberAsync(identityUser.Id, department.DepartmentId);
+
+										// Check if admin flagged this user to change password on next login
+										if (member != null && member.MustChangePassword)
+										{
+											HttpContext.Session.SetString("ForcePasswordChangeUserId", identityUser.Id);
+											HttpContext.Session.SetString("ForcePasswordChangeDeptId", department.DepartmentId.ToString());
+											return RedirectToAction(nameof(ForcePasswordChange));
+										}
+
 										var policy = await _departmentSsoService.GetSecurityPolicyForDepartmentAsync(department.DepartmentId, cancellationToken);
 										if (policy != null && policy.PasswordExpirationDays > 0)
 										{
-											var member = await _departmentsService.GetDepartmentMemberAsync(identityUser.Id, department.DepartmentId);
 											if (_departmentSsoService.IsPasswordExpired(policy, member?.PasswordLastSetOn))
 											{
 												HttpContext.Session.SetString("ForcePasswordChangeUserId", identityUser.Id);
@@ -554,6 +563,15 @@ namespace Resgrid.Web.Controllers
 
 			// Record the password change and clear the forced-change session flags
 			await _departmentSsoService.RecordPasswordChangedAsync(deptId, userId, cancellationToken);
+
+			// Clear the must-change-password flag if it was set by an admin
+			var member = await _departmentsService.GetDepartmentMemberAsync(userId, deptId);
+			if (member != null && member.MustChangePassword)
+			{
+				member.MustChangePassword = false;
+				await _departmentsService.SaveDepartmentMemberAsync(member, cancellationToken);
+			}
+
 			HttpContext.Session.Remove("ForcePasswordChangeUserId");
 			HttpContext.Session.Remove("ForcePasswordChangeDeptId");
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Administrators can now require users to change their password on the next login when creating new accounts or resetting passwords.
  * Users required to change their password are prompted to do so immediately upon login, with the requirement automatically cleared after the password change is completed.

* **Bug Fixes**
  * Fixed async operation handling in department member deletion process.
  * Improved active department membership validation to properly account for disabled memberships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->