### PR TITLE
RE1-T114 Fix tf is not defined error by disabling esbuild minification

### DIFF
--- a/Web/Resgrid.Web/Areas/User/Apps/vite.config.ts
+++ b/Web/Resgrid.Web/Areas/User/Apps/vite.config.ts
@@ -17,6 +17,7 @@ export default defineConfig(({ mode }) => {
       target: 'es2022',
       outDir: 'dist/core',
       emptyOutDir: true,
+      minify: false,
       sourcemap: mode !== 'production',
       cssCodeSplit: false,
       modulePreload: {
@@ -30,7 +31,7 @@ export default defineConfig(({ mode }) => {
       rollupOptions: {
         output: {
           entryFileNames: 'react-elements.js',
-          chunkFileNames: 'chunks/[name]-[hash].js',
+          chunkFileNames: 'chunks/[name]-[hash].min.js',
           assetFileNames: (assetInfo) => {
             if (assetInfo.name?.endsWith('.css')) {
               return 'react-elements.css';

--- a/Web/Resgrid.Web/Dockerfile
+++ b/Web/Resgrid.Web/Dockerfile
@@ -17,7 +17,7 @@ FROM mcr.microsoft.com/dotnet/sdk:9.0.202-noble-amd64 AS build
 #COPY --from=node_base /usr/local/bin /usr/local/bin
 RUN apt-get update
 RUN apt-get install -y ca-certificates curl gnupg
-RUN curl -sL https://deb.nodesource.com/setup_18.x  | bash -
+RUN curl -sL https://deb.nodesource.com/setup_20.x  | bash -
 RUN apt-get -y install nodejs
 ARG BUILD_VERSION
 WORKDIR /src


### PR DESCRIPTION
- Add minify: false to vite.config.ts to prevent esbuild from renaming React variables, which caused a naming collision where React's Component constructor was renamed to 'tf' - the same name already used for Symbol.for('react.portal') in React's production bundle.
- Upgrade Dockerfile Node.js from 18.x (EOL) to 20.x LTS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node.js runtime to version 20.x for improved compatibility and performance.
  * Adjusted build configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->