### PR TITLE
Fix Twilio request validation URL scheme mismatch

### DIFF
--- a/Web/Resgrid.Web.Services/Startup.cs
+++ b/Web/Resgrid.Web.Services/Startup.cs
@@ -165,6 +165,11 @@ namespace Resgrid.Web.ServicesCore
 			{
 				options.AuthToken = NumberProviderConfig.TwilioAuthToken;
 				options.AllowLocal = false;
+				// BaseUrlOverride ensures the URL used for signature validation matches
+				// what Twilio used when signing the request, regardless of any scheme
+				// override applied by upstream middleware (e.g. http → https rewrites).
+				if (!string.IsNullOrWhiteSpace(Config.SystemBehaviorConfig.ResgridApiBaseUrl))
+					options.BaseUrlOverride = Config.SystemBehaviorConfig.ResgridApiBaseUrl;
 			});
 
 			services.AddApiVersioning(x =>


### PR DESCRIPTION
The UseTwilioRequestValidation() middleware was validating requests using the overridden 'https://' scheme (set by upstream middleware) while Twilio signed the webhook with the actual configured URL scheme (e.g. 'http://' in QA). This caused signature validation to fail for IncomingMessage and other Twilio endpoints, resulting in 403 responses reported by Twilio as timeouts.

Fix: set BaseUrlOverride to SystemBehaviorConfig.ResgridApiBaseUrl so the validation URL always matches the base URL Twilio uses when signing — the same URL registered as the webhook in the Twilio console.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Twilio request validation middleware configuration to support improved URL handling in various deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->