### PR TITLE
Fix Twilio IncomingMessage timeouts

### DIFF
--- a/Core/Resgrid.Services/SubscriptionsService.cs
+++ b/Core/Resgrid.Services/SubscriptionsService.cs
@@ -56,26 +56,34 @@ namespace Resgrid.Services
 
 			if (!String.IsNullOrWhiteSpace(Config.SystemBehaviorConfig.BillingApiBaseUrl) && !String.IsNullOrWhiteSpace(Config.ApiConfig.BackendInternalApikey))
 			{
-				var options = new RestClientOptions(Config.SystemBehaviorConfig.BillingApiBaseUrl)
+				try
 				{
-					MaxTimeout = 200000 // ms
-				};
+					var options = new RestClientOptions(Config.SystemBehaviorConfig.BillingApiBaseUrl)
+					{
+						MaxTimeout = 5000 // ms — fail fast so callers (e.g. Twilio webhooks) don't exceed their own timeouts
+					};
 
-				var client = new RestClient(options, configureSerialization: s => s.UseNewtonsoftJson());
-				var request = new RestRequest($"/api/Billing/GetCurrentPlanForDepartment", Method.Get);
-				request.AddHeader("X-API-Key", Config.ApiConfig.BackendInternalApikey);
-				request.AddHeader("Content-Type", "application/json");
-				request.AddParameter("departmentId", departmentId, ParameterType.QueryString);
+					var client = new RestClient(options, configureSerialization: s => s.UseNewtonsoftJson());
+					var request = new RestRequest($"/api/Billing/GetCurrentPlanForDepartment", Method.Get);
+					request.AddHeader("X-API-Key", Config.ApiConfig.BackendInternalApikey);
+					request.AddHeader("Content-Type", "application/json");
+					request.AddParameter("departmentId", departmentId, ParameterType.QueryString);
 
-				var response = await client.ExecuteAsync<GetCurrentPlanForDepartmentResult>(request);
+					var response = await client.ExecuteAsync<GetCurrentPlanForDepartmentResult>(request);
 
-				if (response.StatusCode == HttpStatusCode.NotFound)
+					if (response.StatusCode == HttpStatusCode.NotFound)
+						return freePlan;
+
+					if (response.Data == null)
+						return freePlan;
+
+					return response.Data.Data;
+				}
+				catch (Exception ex)
+				{
+					Framework.Logging.LogException(ex);
 					return freePlan;
-
-				if (response.Data == null)
-					return freePlan;
-
-				return response.Data.Data;
+				}
 			}
 
 			return freePlan;

--- a/Web/Resgrid.Web.Services/Controllers/TwilioController.cs
+++ b/Web/Resgrid.Web.Services/Controllers/TwilioController.cs
@@ -143,12 +143,18 @@ namespace Resgrid.Web.Services.Controllers
 
 				if (departmentId.HasValue)
 				{
-					var department = await _departmentsService.GetDepartmentByIdAsync(departmentId.Value);
-					//var textToCallEnabled = await _departmentSettingsService.GetDepartmentIsTextCallImportEnabledAsync(departmentId.Value);
-					//var textCommandEnabled = await _departmentSettingsService.GetDepartmentIsTextCommandEnabledAsync(departmentId.Value);
-					var dispatchNumbers = await _departmentSettingsService.GetTextToCallSourceNumbersForDepartmentAsync(departmentId.Value);
-					var authroized = await _limitsService.CanDepartmentProvisionNumberAsync(departmentId.Value);
-					var customStates = await _customStateService.GetAllActiveCustomStatesForDepartmentAsync(departmentId.Value);
+					// Run all department-level lookups in parallel — they are independent of each other.
+					var departmentTask = _departmentsService.GetDepartmentByIdAsync(departmentId.Value);
+					var dispatchNumbersTask = _departmentSettingsService.GetTextToCallSourceNumbersForDepartmentAsync(departmentId.Value);
+					var authorizedTask = _limitsService.CanDepartmentProvisionNumberAsync(departmentId.Value);
+					var customStatesTask = _customStateService.GetAllActiveCustomStatesForDepartmentAsync(departmentId.Value);
+
+					await System.Threading.Tasks.Task.WhenAll(departmentTask, dispatchNumbersTask, authorizedTask, customStatesTask);
+
+					var department = departmentTask.Result;
+					var dispatchNumbers = dispatchNumbersTask.Result;
+					var authroized = authorizedTask.Result;
+					var customStates = customStatesTask.Result;
 
 					messageEvent.CustomerId = departmentId.Value.ToString();
 
@@ -196,7 +202,9 @@ namespace Resgrid.Web.Services.Controllers
 
 						if (!isDispatchSource)
 						{
-							var profile = await _userProfileService.GetProfileByMobileNumberAsync(textMessage.Msisdn);
+							// Reuse the profile fetched above when the department was resolved via mobile number;
+							// only hit the DB again if the department came from the phone-number lookup path.
+							var profile = userProfile ?? await _userProfileService.GetProfileByMobileNumberAsync(textMessage.Msisdn);
 
 							if (profile != null)
 							{


### PR DESCRIPTION
- SubscriptionsService: reduce billing API MaxTimeout from 200s to 5s and wrap call in try-catch so network/timeout errors fall back to freePlan instead of hanging the request past Twilio's 15s webhook deadline
- TwilioController.IncomingMessage: run the four independent department lookups (GetDepartmentById, GetTextToCallSourceNumbers, CanDepartmentProvisionNumber, GetAllActiveCustomStates) concurrently with Task.WhenAll instead of sequentially
- TwilioController.IncomingMessage: reuse the UserProfile already fetched in the department-resolution block instead of issuing a second DB call inside the !isDispatchSource branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for billing plan lookups to ensure graceful fallback when API issues occur.

* **Performance**
  * Reduced response time for billing plan checks through optimized API timeout settings.
  * Accelerated incoming message processing through concurrent data operations and reduced redundant queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->