### PR TITLE
RE1-T115 Changing default TTS voice

### DIFF
--- a/Core/Resgrid.Config/TtsConfig.cs
+++ b/Core/Resgrid.Config/TtsConfig.cs
@@ -24,7 +24,7 @@ namespace Resgrid.Config
 		public static int S3PresignedUrlExpiryMinutes = 60;
 		public static string S3PublicBaseUrl = "";
 
-		public static string DefaultVoice = "en-us";
+		public static string DefaultVoice = "en-us+f3";
 		public static int DefaultSpeed = 175;
 		public static int MaxConcurrentGenerations = 4;
 		public static int MaxTextLength = 1000;

--- a/Core/Resgrid.Model/EspeakVoiceCatalog.cs
+++ b/Core/Resgrid.Model/EspeakVoiceCatalog.cs
@@ -37,6 +37,7 @@ namespace Resgrid.Model
 			new TtsVoiceOption("da", "Danish"),
 			new TtsVoiceOption("nl", "Dutch"),
 			new TtsVoiceOption("en-us", "English", "American"),
+			new TtsVoiceOption("en-us+f3", "English", "American Female 3"),
 			new TtsVoiceOption("en", "English", "British"),
 			new TtsVoiceOption("en-029", "English", "Caribbean"),
 			new TtsVoiceOption("en-gb-x-gbclan", "English", "Lancastrian"),
@@ -140,7 +141,7 @@ namespace Resgrid.Model
 
 		private static readonly Dictionary<string, TtsVoiceOption> VoiceLookup = VoicesInternal.ToDictionary(x => x.Identifier, StringComparer.OrdinalIgnoreCase);
 
-		public const string DefaultIdentifier = "en-us";
+		public const string DefaultIdentifier = "en-us+f3";
 
 		public static IReadOnlyList<TtsVoiceOption> Voices => VoicesInternal;
 

--- a/Tests/Resgrid.Tests/Services/DepartmentSettingsServiceTtsLanguageTests.cs
+++ b/Tests/Resgrid.Tests/Services/DepartmentSettingsServiceTtsLanguageTests.cs
@@ -41,7 +41,7 @@ namespace Resgrid.Tests.Services
 				_cacheProvider.Object);
 
 			global::Resgrid.Config.SystemBehaviorConfig.CacheEnabled = false;
-			TtsConfig.DefaultVoice = "en-us";
+			TtsConfig.DefaultVoice = "en-us+f3";
 		}
 
 		[TearDown]
@@ -77,7 +77,7 @@ namespace Resgrid.Tests.Services
 
 			var result = await _service.GetTtsLanguageForDepartmentAsync(7);
 
-			result.Should().Be("en-us");
+			result.Should().Be("en-us+f3");
 		}
 
 		[Test]

--- a/Tests/Resgrid.Tests/Web/Tts/TtsAdminControllerTests.cs
+++ b/Tests/Resgrid.Tests/Web/Tts/TtsAdminControllerTests.cs
@@ -33,7 +33,7 @@ namespace Resgrid.Tests.Web.Tts
 				.Returns<HttpRequest, string>((_, hash) => new Uri($"https://tts.example.com/tts/audio/{hash}.wav"));
 			_options = new TtsOptions
 			{
-				DefaultVoice = "en-us",
+				DefaultVoice = "en-us+f3",
 				DefaultSpeed = 175,
 				StaticPromptAdminKey = "secret-key",
 				PreGeneratedPrompts = new List<string> { "Alpha", "Beta" }
@@ -95,8 +95,8 @@ namespace Resgrid.Tests.Web.Tts
 				.Callback<IEnumerable<TtsRequest>, CancellationToken>((requests, _) => capturedPrompts = requests.ToList())
 				.ReturnsAsync(new[]
 				{
-					new TtsResponse { Hash = "a", ObjectKey = "tts/a.wav", Url = "https://cdn.example.com/tts/a.wav", Voice = "en-us", Speed = 175 },
-					new TtsResponse { Hash = "b", ObjectKey = "tts/b.wav", Url = "https://cdn.example.com/tts/b.wav", Voice = "en-us", Speed = 175 }
+					new TtsResponse { Hash = "a", ObjectKey = "tts/a.wav", Url = "https://cdn.example.com/tts/a.wav", Voice = "en-us+f3", Speed = 175 },
+					new TtsResponse { Hash = "b", ObjectKey = "tts/b.wav", Url = "https://cdn.example.com/tts/b.wav", Voice = "en-us+f3", Speed = 175 }
 				});
 
 			var controller = BuildController();
@@ -106,7 +106,7 @@ namespace Resgrid.Tests.Web.Tts
 			result.Result.Should().BeOfType<OkObjectResult>();
 			capturedPrompts.Should().HaveCount(2);
 			capturedPrompts!.Select(x => x.Text).Should().Equal("Alpha", "Beta");
-			capturedPrompts.Select(x => x.Voice).Should().OnlyContain(x => x == "en-us");
+			capturedPrompts.Select(x => x.Voice).Should().OnlyContain(x => x == "en-us+f3");
 			capturedPrompts.Select(x => x.Speed).Should().OnlyContain(x => x == 175);
 		}
 

--- a/Tests/Resgrid.Tests/Web/Tts/TtsServiceTests.cs
+++ b/Tests/Resgrid.Tests/Web/Tts/TtsServiceTests.cs
@@ -33,7 +33,7 @@ namespace Resgrid.Tests.Web.Tts
 				_audioProcessingService.Object,
 				Options.Create(new TtsOptions
 				{
-					DefaultVoice = "en-us",
+					DefaultVoice = "en-us+f3",
 					DefaultSpeed = 175,
 					MaxConcurrentGenerations = 2,
 					MaxTextLength = 500
@@ -47,7 +47,7 @@ namespace Resgrid.Tests.Web.Tts
 			var cachedUri = new Uri("https://cdn.example.com/tts/abc123.wav");
 
 			_cacheService
-				.Setup(x => x.CreateCacheKey("Press 1 for yes", "en-us", 175))
+				.Setup(x => x.CreateCacheKey("Press 1 for yes", "en-us+f3", 175))
 				.Returns(CacheKey);
 			_cacheService
 				.Setup(x => x.TryGetCachedUrlAsync(CacheKey, It.IsAny<CancellationToken>()))
@@ -59,7 +59,7 @@ namespace Resgrid.Tests.Web.Tts
 			result.Hash.Should().Be(CacheKey.Hash);
 			result.ObjectKey.Should().Be(CacheKey.ObjectKey);
 			result.Url.Should().Be(cachedUri.ToString());
-			result.Voice.Should().Be("en-us");
+			result.Voice.Should().Be("en-us+f3");
 			result.Speed.Should().Be(175);
 
 			_audioProcessingService.Verify(
@@ -77,14 +77,14 @@ namespace Resgrid.Tests.Web.Tts
 			var objectUri = new Uri("https://cdn.example.com/tts/abc123.wav");
 
 			_cacheService
-				.Setup(x => x.CreateCacheKey("Press 1 for yes", "en-us", 175))
+				.Setup(x => x.CreateCacheKey("Press 1 for yes", "en-us+f3", 175))
 				.Returns(CacheKey);
 			_cacheService
 				.SetupSequence(x => x.TryGetCachedUrlAsync(CacheKey, It.IsAny<CancellationToken>()))
 				.ReturnsAsync((Uri)null)
 				.ReturnsAsync((Uri)null);
 			_audioProcessingService
-				.Setup(x => x.GenerateNormalizedWavAsync("Press 1 for yes", "en-us", 175, It.IsAny<CancellationToken>()))
+				.Setup(x => x.GenerateNormalizedWavAsync("Press 1 for yes", "en-us+f3", 175, It.IsAny<CancellationToken>()))
 				.ReturnsAsync(audioBytes);
 			_cacheService
 				.Setup(x => x.StoreAsync(CacheKey, It.Is<byte[]>(bytes => bytes.SequenceEqual(audioBytes)), It.IsAny<CancellationToken>()))
@@ -94,11 +94,11 @@ namespace Resgrid.Tests.Web.Tts
 
 			result.Cached.Should().BeFalse();
 			result.Url.Should().Be(objectUri.ToString());
-			result.Voice.Should().Be("en-us");
+			result.Voice.Should().Be("en-us+f3");
 			result.Speed.Should().Be(175);
 
 			_audioProcessingService.Verify(
-				x => x.GenerateNormalizedWavAsync("Press 1 for yes", "en-us", 175, It.IsAny<CancellationToken>()),
+				x => x.GenerateNormalizedWavAsync("Press 1 for yes", "en-us+f3", 175, It.IsAny<CancellationToken>()),
 				Times.Once);
 			_cacheService.Verify(
 				x => x.StoreAsync(CacheKey, It.Is<byte[]>(bytes => bytes.SequenceEqual(audioBytes)), It.IsAny<CancellationToken>()),
@@ -124,7 +124,7 @@ namespace Resgrid.Tests.Web.Tts
 			var cacheLookupCount = 0;
 
 			_cacheService
-				.Setup(x => x.CreateCacheKey("Press 1 for yes", "en-us", 175))
+				.Setup(x => x.CreateCacheKey("Press 1 for yes", "en-us+f3", 175))
 				.Returns(CacheKey);
 			_cacheService
 				.Setup(x => x.TryGetCachedUrlAsync(CacheKey, It.IsAny<CancellationToken>()))
@@ -134,7 +134,7 @@ namespace Resgrid.Tests.Web.Tts
 					return Task.FromResult<Uri?>(attempt < 4 ? null : objectUri);
 				});
 			_audioProcessingService
-				.Setup(x => x.GenerateNormalizedWavAsync("Press 1 for yes", "en-us", 175, It.IsAny<CancellationToken>()))
+				.Setup(x => x.GenerateNormalizedWavAsync("Press 1 for yes", "en-us+f3", 175, It.IsAny<CancellationToken>()))
 				.Returns(async () =>
 				{
 					generationStarted.TrySetResult(true);
@@ -158,7 +158,7 @@ namespace Resgrid.Tests.Web.Tts
 			responses.Count(response => response.Cached).Should().Be(1);
 			responses.Count(response => !response.Cached).Should().Be(1);
 			_audioProcessingService.Verify(
-				x => x.GenerateNormalizedWavAsync("Press 1 for yes", "en-us", 175, It.IsAny<CancellationToken>()),
+				x => x.GenerateNormalizedWavAsync("Press 1 for yes", "en-us+f3", 175, It.IsAny<CancellationToken>()),
 				Times.Once);
 			_cacheService.Verify(
 				x => x.StoreAsync(CacheKey, It.Is<byte[]>(bytes => bytes.SequenceEqual(audioBytes)), It.IsAny<CancellationToken>()),

--- a/Web/Resgrid.Web.Tts/Configuration/TtsOptions.cs
+++ b/Web/Resgrid.Web.Tts/Configuration/TtsOptions.cs
@@ -5,7 +5,7 @@ namespace Resgrid.Web.Tts.Configuration
 	public sealed class TtsOptions
 	{
 		[Required]
-		public string DefaultVoice { get; set; } = "en-us";
+		public string DefaultVoice { get; set; } = "en-us+f3";
 
 		[Range(80, 450)]
 		public int DefaultSpeed { get; set; } = 175;

--- a/Web/Resgrid.Web.Tts/k8s/deployment.yaml
+++ b/Web/Resgrid.Web.Tts/k8s/deployment.yaml
@@ -17,7 +17,7 @@ data:
   RESGRID__TtsConfig__S3ForcePathStyle: "true"
   RESGRID__TtsConfig__S3UsePresignedUrls: "true"
   RESGRID__TtsConfig__S3PresignedUrlExpiryMinutes: "60"
-  RESGRID__TtsConfig__DefaultVoice: en-us
+  RESGRID__TtsConfig__DefaultVoice: en-us+f3
   RESGRID__TtsConfig__DefaultSpeed: "175"
   RESGRID__TtsConfig__MaxConcurrentGenerations: "4"
   RESGRID__TtsConfig__MaxTextLength: "1000"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default text-to-speech voice setting to `en-us+f3` across system configuration and deployment settings.
  * Added new TTS voice variant to the available voice options.
  * Updated test expectations to align with new default voice configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->