### PR TITLE
RIC-T39 Backend IC work

### DIFF
--- a/Core/Resgrid.Config/SystemBehaviorConfig.cs
+++ b/Core/Resgrid.Config/SystemBehaviorConfig.cs
@@ -31,6 +31,21 @@ namespace Resgrid.Config
 		public static string ResgridEventingBaseUrl = "https://resgridevents.local";
 
 		/// <summary>
+		/// Maximum length (characters) of an outbound SMS body before it is truncated. Default 459 = three concatenated
+		/// GSM-7 SMS segments (153 chars each) - enough to convey a useful summary while keeping per-message cost low;
+		/// the full content is always available in the Resgrid app. (Hard carrier limit is 1600 - Twilio error 21617.)
+		/// </summary>
+		public static int SmsMaxLength = 459;
+
+		/// <summary>
+		/// Comma-separated host allow-list for URLs in outbound SMS. Carriers (A2P 10DLC) filter messages containing
+		/// public/unbranded links, so any URL whose host is not on this list is removed before the SMS is sent.
+		/// Includes Resgrid's own domains, the common mapping/location services departments share, and bit.ly (Resgrid's
+		/// default link shortener). Deployments using a self-hosted shortener (Polr/Kutt) should add their short domain.
+		/// </summary>
+		public static string SmsAllowedUrlDomains = "resgrid.com,resgrid.net,resgrid.io,google.com,maps.app.goo.gl,goo.gl,apple.com,bing.com,openstreetmap.org,osm.org,what3words.com,w3w.co,bit.ly";
+
+		/// <summary>
 		/// Resgrid internal Billing API Url. Do not set for Open-Source install.
 		/// </summary>
 		public static string BillingApiBaseUrl = "";

--- a/Core/Resgrid.Framework/PhoneRegionHelper.cs
+++ b/Core/Resgrid.Framework/PhoneRegionHelper.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+
+namespace Resgrid.Framework
+{
+	/// <summary>
+	/// Maps a country display name (as used in <c>Resgrid.Model.Countries.CountryNames</c>) to its ISO-3166 alpha-2
+	/// region code, which the phone-number validator uses as the default region when parsing a national-format number
+	/// (e.g. a South-African "082446..." -> region "za" -> "+2782446..."). Unmapped countries return null, in which
+	/// case the validator falls back to its own default — callers should treat null as "no region hint".
+	/// Extend the map as new markets are onboarded.
+	/// </summary>
+	public static class PhoneRegionHelper
+	{
+		private static readonly Dictionary<string, string> NameToIso = new Dictionary<string, string>(System.StringComparer.OrdinalIgnoreCase)
+		{
+			{ "United States", "us" },
+			{ "Canada", "ca" },
+			{ "United Kingdom", "gb" },
+			{ "Australia", "au" },
+			{ "New Zealand", "nz" },
+			{ "Ireland", "ie" },
+			{ "South Africa", "za" },
+			{ "Namibia", "na" },
+			{ "Botswana", "bw" },
+			{ "Zimbabwe", "zw" },
+			{ "Kenya", "ke" },
+			{ "Nigeria", "ng" },
+			{ "Ghana", "gh" },
+			{ "India", "in" },
+			{ "Germany", "de" },
+			{ "France", "fr" },
+			{ "Spain", "es" },
+			{ "Italy", "it" },
+			{ "Netherlands", "nl" },
+			{ "Belgium", "be" },
+			{ "Switzerland", "ch" },
+			{ "Austria", "at" },
+			{ "Sweden", "se" },
+			{ "Norway", "no" },
+			{ "Denmark", "dk" },
+			{ "Finland", "fi" },
+			{ "Portugal", "pt" },
+			{ "Poland", "pl" },
+			{ "Mexico", "mx" },
+			{ "Brazil", "br" },
+			{ "Argentina", "ar" },
+			{ "Chile", "cl" },
+			{ "Japan", "jp" },
+			{ "China", "cn" },
+			{ "Singapore", "sg" },
+			{ "Philippines", "ph" },
+			{ "Malaysia", "my" },
+			{ "Indonesia", "id" },
+			{ "United Arab Emirates", "ae" },
+			{ "Saudi Arabia", "sa" },
+			{ "Israel", "il" },
+		};
+
+		/// <summary>Returns the ISO-3166 alpha-2 region code for a country name, or null when not mapped/blank.</summary>
+		public static string ToIso(string countryName)
+		{
+			if (string.IsNullOrWhiteSpace(countryName))
+				return null;
+
+			return NameToIso.TryGetValue(countryName.Trim(), out var iso) ? iso : null;
+		}
+	}
+}

--- a/Core/Resgrid.Framework/SmsContentHelper.cs
+++ b/Core/Resgrid.Framework/SmsContentHelper.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Resgrid.Framework
+{
+	/// <summary>
+	/// Prepares outbound SMS content for deliverability and cost. US carriers (A2P 10DLC) filter messages that
+	/// contain public/unbranded links (bit.ly, tinyurl, unknown domains), so links whose host is not on the supplied
+	/// allow-list are removed. Common non-GSM-7 characters are normalized so a stray smart-quote/em-dash doesn't flip
+	/// the whole message into costlier UCS-2 encoding (67 vs 153 chars per segment), and the body is capped so we
+	/// never pay for an excessively long message (or get rejected for length - Twilio error 21617 at 1600 chars).
+	/// Pure (no config dependency): callers pass the allow-list + max length.
+	/// </summary>
+	public static class SmsContentHelper
+	{
+		private const string TruncationSuffix = "... (open Resgrid for the full message)";
+
+		// Only scheme-qualified (http/https) or www-prefixed links are treated as URLs. Matching bare "domain.tld"
+		// would mangle ordinary text like "U.S.", "9-1-1", or "400 Olive St." that appears in real messages.
+		private static readonly Regex UrlRegex = new Regex(
+			@"(?:https?://|www\.)\S+",
+			RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+		private static readonly Regex MultiSpaceRegex = new Regex(@"[ \t]{2,}", RegexOptions.Compiled);
+
+		/// <summary>Strip-disallowed-URLs, normalize, then truncate. Returns a carrier-safe, cost-bounded body.</summary>
+		public static string PrepareForSms(string message, int maxLength, IEnumerable<string> allowedUrlDomains)
+		{
+			if (string.IsNullOrEmpty(message))
+				return message;
+
+			message = StripDisallowedUrls(message, allowedUrlDomains);
+			message = NormalizeForGsm(message);
+			message = Truncate(message, maxLength);
+			return message;
+		}
+
+		/// <summary>Removes any URL whose host is not on the allow-list (host or a subdomain of an allowed domain).</summary>
+		public static string StripDisallowedUrls(string message, IEnumerable<string> allowedUrlDomains)
+		{
+			if (string.IsNullOrEmpty(message))
+				return message;
+
+			var allowed = (allowedUrlDomains ?? Enumerable.Empty<string>())
+				.Where(d => !string.IsNullOrWhiteSpace(d))
+				.Select(d => d.Trim().TrimStart('.').ToLowerInvariant())
+				.ToList();
+
+			var stripped = false;
+			var result = UrlRegex.Replace(message, match =>
+			{
+				if (IsAllowedUrl(match.Value, allowed))
+					return match.Value;
+
+				stripped = true;
+				return string.Empty;
+			});
+
+			if (!stripped)
+				return message;
+
+			// Collapse whitespace / dangling separators left where a link was removed.
+			result = MultiSpaceRegex.Replace(result, " ");
+			result = result.Replace(" .", ".").Replace(" ,", ",").Replace("( )", "").Replace("()", "");
+			return result.Trim();
+		}
+
+		private static bool IsAllowedUrl(string token, List<string> allowedDomains)
+		{
+			var host = ExtractHost(token);
+			if (string.IsNullOrEmpty(host))
+				return false;
+
+			return allowedDomains.Any(d =>
+				host.Equals(d, StringComparison.OrdinalIgnoreCase) ||
+				host.EndsWith("." + d, StringComparison.OrdinalIgnoreCase));
+		}
+
+		private static string ExtractHost(string token)
+		{
+			var s = token.Trim();
+
+			var scheme = s.IndexOf("://", StringComparison.Ordinal);
+			if (scheme >= 0)
+				s = s.Substring(scheme + 3);
+
+			// Drop anything from the first path/query/fragment separator onward.
+			var sep = s.IndexOfAny(new[] { '/', '?', '#', '\\' });
+			if (sep >= 0)
+				s = s.Substring(0, sep);
+
+			var at = s.IndexOf('@');         // strip userinfo
+			if (at >= 0) s = s.Substring(at + 1);
+
+			var colon = s.IndexOf(':');      // strip port
+			if (colon >= 0) s = s.Substring(0, colon);
+
+			return s.Trim().Trim('.').ToLowerInvariant();
+		}
+
+		/// <summary>Replaces the most common copy-paste non-GSM-7 characters so the body stays single-byte (cheaper).</summary>
+		public static string NormalizeForGsm(string message)
+		{
+			if (string.IsNullOrEmpty(message))
+				return message;
+
+			return message
+				.Replace('‘', '\'').Replace('’', '\'')   // curly single quotes / smart apostrophe
+				.Replace('“', '"').Replace('”', '"')     // curly double quotes
+				.Replace('–', '-').Replace('—', '-')     // en dash / em dash
+				.Replace("…", "...")                          // horizontal ellipsis
+				.Replace(' ', ' ');                           // non-breaking space
+		}
+
+		/// <summary>Truncates to <paramref name="maxLength"/> with a clear suffix when over the limit.</summary>
+		public static string Truncate(string message, int maxLength)
+		{
+			if (maxLength <= 0 || string.IsNullOrEmpty(message) || message.Length <= maxLength)
+				return message;
+
+			if (maxLength <= TruncationSuffix.Length)
+				return message.Substring(0, maxLength);
+
+			return message.Substring(0, maxLength - TruncationSuffix.Length) + TruncationSuffix;
+		}
+	}
+}

--- a/Core/Resgrid.Model/Address.cs
+++ b/Core/Resgrid.Model/Address.cs
@@ -17,27 +17,27 @@ namespace Resgrid.Model
 		public int AddressId { get; set; }
 
 		[Required]
-		[MaxLength(200)]
+		[StringLength(500, ErrorMessage = "Street address cannot exceed 500 characters.")]
 		[Display(Name = "Street Address")]
 		[ProtoMember(2)]
 		public string Address1 { get; set; }
 
 		[Required]
-		[MaxLength(100)]
+		[StringLength(150, ErrorMessage = "City cannot exceed 150 characters.")]
 		[ProtoMember(3)]
 		public string City { get; set; }
 
 		[Required]
-		[MaxLength(50)]
+		[StringLength(100, ErrorMessage = "State/Province cannot exceed 100 characters.")]
 		[ProtoMember(4)]
 		public string State { get; set; }
 
-		[MaxLength(50)]
+		[StringLength(32, ErrorMessage = "Postal code cannot exceed 32 characters.")]
 		[ProtoMember(5)]
 		public string PostalCode { get; set; }
 
 		[Required]
-		[MaxLength(100)]
+		[StringLength(100, ErrorMessage = "Country cannot exceed 100 characters.")]
 		[ProtoMember(6)]
 		public string Country { get; set; }
 

--- a/Core/Resgrid.Model/CheckInRecord.cs
+++ b/Core/Resgrid.Model/CheckInRecord.cs
@@ -27,6 +27,12 @@ namespace Resgrid.Model
 
 		public string Note { get; set; }
 
+		/// <summary>
+		/// Client-supplied idempotency key (the offline outbox event id). When set, a replayed check-in carrying the
+		/// same key returns the original record instead of inserting a duplicate. See offline-first-architecture.md.
+		/// </summary>
+		public string IdempotencyKey { get; set; }
+
 		[NotMapped]
 		public string TableName => "CheckInRecords";
 

--- a/Core/Resgrid.Model/IChangeTracked.cs
+++ b/Core/Resgrid.Model/IChangeTracked.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Resgrid.Model
+{
+	/// <summary>
+	/// Entities that carry a <see cref="ModifiedOn"/> change cursor. It is stamped on every insert and update
+	/// and drives two offline-first concerns: the delta-sync "changed since" query (pull) and last-write-wins
+	/// conflict resolution on reconnect. See <c>docs/architecture/offline-first-architecture.md</c>.
+	/// </summary>
+	public interface IChangeTracked
+	{
+		DateTime? ModifiedOn { get; set; }
+	}
+}

--- a/Core/Resgrid.Model/IncidentCommand/CommandStructureNode.cs
+++ b/Core/Resgrid.Model/IncidentCommand/CommandStructureNode.cs
@@ -9,7 +9,7 @@ namespace Resgrid.Model
 	/// A live lane / span-of-control node on the command board (Division, Group, Branch, Staging, ...).
 	/// Initially seeded from a <c>CommandDefinitionRole</c> then per-incident editable.
 	/// </summary>
-	public class CommandStructureNode : IEntity
+	public class CommandStructureNode : IEntity, IChangeTracked
 	{
 		public string CommandStructureNodeId { get; set; }
 
@@ -36,6 +36,12 @@ namespace Resgrid.Model
 		/// <summary>The CommandDefinitionRole this node was seeded from, if any.</summary>
 		public int? SourceRoleId { get; set; }
 
+		/// <summary>Soft-delete tombstone so a lane removed offline propagates on delta sync (null = live).</summary>
+		public DateTime? DeletedOn { get; set; }
+
+		/// <summary>Change cursor for offline delta sync + last-write-wins; stamped on every write.</summary>
+		public DateTime? ModifiedOn { get; set; }
+
 		[NotMapped]
 		public string TableName => "CommandStructureNodes";
 
@@ -61,7 +67,7 @@ namespace Resgrid.Model
 	/// Assigns a resource to a command structure node. Polymorphic: the resource may be an own-department
 	/// unit/person, a linked (mutual-aid) department unit/person, or an incident ad-hoc unit/person.
 	/// </summary>
-	public class ResourceAssignment : IEntity
+	public class ResourceAssignment : IEntity, IChangeTracked
 	{
 		public string ResourceAssignmentId { get; set; }
 
@@ -84,6 +90,9 @@ namespace Resgrid.Model
 		public DateTime AssignedOn { get; set; }
 
 		public DateTime? ReleasedOn { get; set; }
+
+		/// <summary>Change cursor for offline delta sync + last-write-wins; stamped on every write.</summary>
+		public DateTime? ModifiedOn { get; set; }
 
 		[NotMapped]
 		public string TableName => "ResourceAssignments";

--- a/Core/Resgrid.Model/IncidentCommand/IncidentAdHocResources.cs
+++ b/Core/Resgrid.Model/IncidentCommand/IncidentAdHocResources.cs
@@ -9,7 +9,7 @@ namespace Resgrid.Model
 	/// An incident-scoped, ad-hoc unit created on the fly for resources not in Resgrid (e.g. a mutual-aid
 	/// crew from a non-Resgrid agency, or a unit formed from on-scene personnel). Not a real department Unit.
 	/// </summary>
-	public class IncidentAdHocUnit : IEntity
+	public class IncidentAdHocUnit : IEntity, IChangeTracked
 	{
 		public string IncidentAdHocUnitId { get; set; }
 
@@ -33,6 +33,9 @@ namespace Resgrid.Model
 		public DateTime CreatedOn { get; set; }
 
 		public DateTime? ReleasedOn { get; set; }
+
+		/// <summary>Change cursor for offline delta sync + last-write-wins; stamped on every write.</summary>
+		public DateTime? ModifiedOn { get; set; }
 
 		[NotMapped]
 		public string TableName => "IncidentAdHocUnits";
@@ -59,7 +62,7 @@ namespace Resgrid.Model
 	/// An incident-scoped, ad-hoc person created on the fly for resources not in Resgrid. May ride an ad-hoc
 	/// (or real) unit for accountability via <see cref="RidingResourceKind"/> + <see cref="RidingResourceId"/>.
 	/// </summary>
-	public class IncidentAdHocPersonnel : IEntity
+	public class IncidentAdHocPersonnel : IEntity, IChangeTracked
 	{
 		public string IncidentAdHocPersonnelId { get; set; }
 
@@ -87,6 +90,9 @@ namespace Resgrid.Model
 		public DateTime CreatedOn { get; set; }
 
 		public DateTime? ReleasedOn { get; set; }
+
+		/// <summary>Change cursor for offline delta sync + last-write-wins; stamped on every write.</summary>
+		public DateTime? ModifiedOn { get; set; }
 
 		[NotMapped]
 		public string TableName => "IncidentAdHocPersonnel";

--- a/Core/Resgrid.Model/IncidentCommand/IncidentCommand.cs
+++ b/Core/Resgrid.Model/IncidentCommand/IncidentCommand.cs
@@ -9,7 +9,7 @@ namespace Resgrid.Model
 	/// A live incident-command instance established on a specific <c>Call</c>. Seeded (optionally) from a
 	/// <c>CommandDefinition</c> template and then freely editable by the Commander for the life of the incident.
 	/// </summary>
-	public class IncidentCommand : IEntity
+	public class IncidentCommand : IEntity, IChangeTracked
 	{
 		public string IncidentCommandId { get; set; }
 
@@ -39,6 +39,9 @@ namespace Resgrid.Model
 		public int Status { get; set; }
 
 		public DateTime? ClosedOn { get; set; }
+
+		/// <summary>Change cursor for offline delta sync + last-write-wins; stamped on every write.</summary>
+		public DateTime? ModifiedOn { get; set; }
 
 		[NotMapped]
 		public string TableName => "IncidentCommands";

--- a/Core/Resgrid.Model/IncidentCommand/IncidentCommandChanges.cs
+++ b/Core/Resgrid.Model/IncidentCommand/IncidentCommandChanges.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+
+namespace Resgrid.Model
+{
+	/// <summary>
+	/// Delta payload for offline sync: every change-tracked incident-command row whose <see cref="IChangeTracked.ModifiedOn"/>
+	/// (or, for the append-only timeline, OccurredOn) is newer than the client's last sync cursor, scoped to a department.
+	/// Soft-deleted / closed / released rows ARE included (with their state columns set) so the client can remove or
+	/// update them locally. The client stores <see cref="ServerTimestampMs"/> and passes it back as the next `since`.
+	/// Ad-hoc resources are not change-tracked and are pulled separately (full refetch). See
+	/// docs/architecture/offline-first-architecture.md.
+	/// </summary>
+	public class IncidentCommandChanges
+	{
+		/// <summary>Server clock (Unix epoch ms) captured at the start of the read; the client's next-sync cursor.</summary>
+		public long ServerTimestampMs { get; set; }
+
+		public List<IncidentCommand> Commands { get; set; } = new List<IncidentCommand>();
+
+		public List<CommandStructureNode> Nodes { get; set; } = new List<CommandStructureNode>();
+
+		public List<ResourceAssignment> Assignments { get; set; } = new List<ResourceAssignment>();
+
+		public List<TacticalObjective> Objectives { get; set; } = new List<TacticalObjective>();
+
+		public List<IncidentTimer> Timers { get; set; } = new List<IncidentTimer>();
+
+		public List<IncidentMapAnnotation> Annotations { get; set; } = new List<IncidentMapAnnotation>();
+
+		public List<IncidentRoleAssignment> Roles { get; set; } = new List<IncidentRoleAssignment>();
+
+		public List<IncidentAdHocUnit> AdHocUnits { get; set; } = new List<IncidentAdHocUnit>();
+
+		public List<IncidentAdHocPersonnel> AdHocPersonnel { get; set; } = new List<IncidentAdHocPersonnel>();
+
+		public List<CommandLogEntry> TimelineEntries { get; set; } = new List<CommandLogEntry>();
+	}
+}

--- a/Core/Resgrid.Model/IncidentCommand/IncidentRole.cs
+++ b/Core/Resgrid.Model/IncidentCommand/IncidentRole.cs
@@ -149,7 +149,7 @@ namespace Resgrid.Model
 	/// Assigns a Resgrid user to a functional incident-command role for a specific incident (Call). Incident-scoped,
 	/// not a department-wide claim. Optionally scoped to a structure node for supervisors.
 	/// </summary>
-	public class IncidentRoleAssignment : IEntity
+	public class IncidentRoleAssignment : IEntity, IChangeTracked
 	{
 		public string IncidentRoleAssignmentId { get; set; }
 
@@ -173,6 +173,9 @@ namespace Resgrid.Model
 		public DateTime AssignedOn { get; set; }
 
 		public DateTime? RemovedOn { get; set; }
+
+		/// <summary>Change cursor for offline delta sync + last-write-wins; stamped on every write.</summary>
+		public DateTime? ModifiedOn { get; set; }
 
 		[NotMapped]
 		public string TableName => "IncidentRoleAssignments";

--- a/Core/Resgrid.Model/IncidentCommand/IncidentTacticals.cs
+++ b/Core/Resgrid.Model/IncidentCommand/IncidentTacticals.cs
@@ -6,7 +6,7 @@ using Newtonsoft.Json;
 namespace Resgrid.Model
 {
 	/// <summary>A tactical objective / benchmark for an incident (e.g. "Primary search complete").</summary>
-	public class TacticalObjective : IEntity
+	public class TacticalObjective : IEntity, IChangeTracked
 	{
 		public string TacticalObjectiveId { get; set; }
 
@@ -31,6 +31,9 @@ namespace Resgrid.Model
 		public DateTime? CompletedOn { get; set; }
 
 		public int SortOrder { get; set; }
+
+		/// <summary>Change cursor for offline delta sync + last-write-wins; stamped on every write.</summary>
+		public DateTime? ModifiedOn { get; set; }
 
 		[NotMapped]
 		public string TableName => "TacticalObjectives";
@@ -57,7 +60,7 @@ namespace Resgrid.Model
 	/// A scene / benchmark / role timer for an incident. Personnel accountability (PAR) is handled by the
 	/// Checkin feature, not by these timers.
 	/// </summary>
-	public class IncidentTimer : IEntity
+	public class IncidentTimer : IEntity, IChangeTracked
 	{
 		public string IncidentTimerId { get; set; }
 
@@ -89,6 +92,9 @@ namespace Resgrid.Model
 
 		public DateTime? AcknowledgedOn { get; set; }
 
+		/// <summary>Change cursor for offline delta sync + last-write-wins; stamped on every write.</summary>
+		public DateTime? ModifiedOn { get; set; }
+
 		[NotMapped]
 		public string TableName => "IncidentTimers";
 
@@ -111,7 +117,7 @@ namespace Resgrid.Model
 	}
 
 	/// <summary>A real-time map annotation (markup) on the tactical map, synced across devices.</summary>
-	public class IncidentMapAnnotation : IEntity
+	public class IncidentMapAnnotation : IEntity, IChangeTracked
 	{
 		public string IncidentMapAnnotationId { get; set; }
 
@@ -137,6 +143,9 @@ namespace Resgrid.Model
 		public DateTime CreatedOn { get; set; }
 
 		public DateTime? DeletedOn { get; set; }
+
+		/// <summary>Change cursor for offline delta sync + last-write-wins; stamped on every write.</summary>
+		public DateTime? ModifiedOn { get; set; }
 
 		[NotMapped]
 		public string TableName => "IncidentMapAnnotations";

--- a/Core/Resgrid.Model/Services/IIncidentCommandService.cs
+++ b/Core/Resgrid.Model/Services/IIncidentCommandService.cs
@@ -20,6 +20,13 @@ namespace Resgrid.Model.Services
 		Task<List<PersonnelCallCheckInStatus>> GetAccountabilityForCallAsync(int departmentId, int callId);
 
 		/// <summary>
+		/// Offline-first delta pull: returns every change-tracked incident-command row (and append-only timeline entry)
+		/// for the department whose ModifiedOn/OccurredOn is newer than <paramref name="sinceUtc"/>. Includes
+		/// soft-deleted/closed/released rows so a reconnecting client can reconcile removals. See the offline-first doc.
+		/// </summary>
+		Task<IncidentCommandChanges> GetChangesSinceAsync(int departmentId, System.DateTime sinceUtc);
+
+		/// <summary>
 		/// Sweeps personnel accountability (PAR) for the call and raises <c>CriticalParDetectedEvent</c> once per
 		/// member each time they transition into the Critical (overdue) state. Idempotent via a timeline marker —
 		/// re-alerts only after a member checks in and lapses again. Returns the user ids flagged this pass (empty

--- a/Core/Resgrid.Model/Services/IIncidentResourcesService.cs
+++ b/Core/Resgrid.Model/Services/IIncidentResourcesService.cs
@@ -26,5 +26,12 @@ namespace Resgrid.Model.Services
 
 		/// <summary>Forms a new ad-hoc unit and attaches the given ad-hoc personnel to it as its roster.</summary>
 		Task<IncidentAdHocUnit> FormUnitFromPersonnelAsync(IncidentAdHocUnit unit, List<string> adHocPersonnelIds, string userId, CancellationToken cancellationToken = default(CancellationToken));
+
+		/// <summary>
+		/// Offline-first delta pull for ad-hoc resources: returns the department's ad-hoc units and personnel whose
+		/// ModifiedOn is newer than <paramref name="sinceUtc"/> (released rows included so the client reconciles them).
+		/// Aggregated into the unified /Sync/Changes payload by SyncController. See offline-first-architecture.md.
+		/// </summary>
+		Task<(List<IncidentAdHocUnit> Units, List<IncidentAdHocPersonnel> Personnel)> GetAdHocChangesSinceAsync(int departmentId, System.DateTime sinceUtc);
 	}
 }

--- a/Core/Resgrid.Services/CheckInTimerService.cs
+++ b/Core/Resgrid.Services/CheckInTimerService.cs
@@ -332,7 +332,24 @@ namespace Resgrid.Services
 			}
 
 			record.Timestamp = DateTime.UtcNow;
-			var saved = await _recordRepository.SaveOrUpdateAsync(record, cancellationToken);
+
+			CheckInRecord saved;
+			try
+			{
+				saved = await _recordRepository.SaveOrUpdateAsync(record, cancellationToken);
+			}
+			catch (Exception) when (!string.IsNullOrWhiteSpace(record.IdempotencyKey))
+			{
+				// The in-memory pre-check above is check-then-insert and races under concurrent replays; the filtered
+				// unique index UX_CheckInRecords_Department_IdempotencyKey is the real guard. If we lost the race,
+				// adopt the winner — same idempotent result as the pre-check — rather than surfacing a 500 (which would
+				// just trigger another retry).
+				var existing = await _recordRepository.GetByCallIdAsync(record.CallId);
+				var winner = existing?.FirstOrDefault(r => r.IdempotencyKey == record.IdempotencyKey);
+				if (winner != null)
+					return winner;
+				throw;
+			}
 
 			// Real-time board refresh is best-effort: the check-in is already persisted, so a CQRS/Redis
 			// publish failure must not fail the check-in — that would 500 the caller and a retry would

--- a/Core/Resgrid.Services/CheckInTimerService.cs
+++ b/Core/Resgrid.Services/CheckInTimerService.cs
@@ -320,6 +320,17 @@ namespace Resgrid.Services
 
 		public async Task<CheckInRecord> PerformCheckInAsync(CheckInRecord record, CancellationToken cancellationToken = default)
 		{
+			// Offline idempotency: when the client supplies its outbox event id, a replayed check-in returns the
+			// original record instead of inserting a duplicate. Dedup is in-memory over the call's (small) check-in
+			// set, so only replayed events — which carry a key — pay the extra read; live UI check-ins skip it.
+			if (!string.IsNullOrWhiteSpace(record.IdempotencyKey))
+			{
+				var existing = await _recordRepository.GetByCallIdAsync(record.CallId);
+				var duplicate = existing?.FirstOrDefault(r => r.IdempotencyKey == record.IdempotencyKey);
+				if (duplicate != null)
+					return duplicate;
+			}
+
 			record.Timestamp = DateTime.UtcNow;
 			var saved = await _recordRepository.SaveOrUpdateAsync(record, cancellationToken);
 

--- a/Core/Resgrid.Services/CheckInTimerService.cs
+++ b/Core/Resgrid.Services/CheckInTimerService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Data.Common;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -338,12 +339,14 @@ namespace Resgrid.Services
 			{
 				saved = await _recordRepository.SaveOrUpdateAsync(record, cancellationToken);
 			}
-			catch (Exception) when (!string.IsNullOrWhiteSpace(record.IdempotencyKey))
+			catch (DbException) when (!string.IsNullOrWhiteSpace(record.IdempotencyKey))
 			{
 				// The in-memory pre-check above is check-then-insert and races under concurrent replays; the filtered
-				// unique index UX_CheckInRecords_Department_IdempotencyKey is the real guard. If we lost the race,
-				// adopt the winner — same idempotent result as the pre-check — rather than surfacing a 500 (which would
-				// just trigger another retry).
+				// unique index (UX_CheckInRecords_Department_IdempotencyKey on SQL Server / ux_..._idempotencykey on
+				// PostgreSQL) is the real guard. On that race, adopt the winner — same idempotent result as the
+				// pre-check — rather than 500ing (which would just trigger another retry). Scope is DbException only
+				// (covers PG 23505 + SQL Server 2601/2627, both derive from it); any non-DB failure, or a DbException
+				// with no matching winner, propagates below instead of being masked as a replay.
 				var existing = await _recordRepository.GetByCallIdAsync(record.CallId);
 				var winner = existing?.FirstOrDefault(r => r.IdempotencyKey == record.IdempotencyKey);
 				if (winner != null)

--- a/Core/Resgrid.Services/ContactVerificationService.cs
+++ b/Core/Resgrid.Services/ContactVerificationService.cs
@@ -22,6 +22,7 @@ namespace Resgrid.Services
 		private readonly ISystemAuditsService _systemAuditsService;
 		private readonly IEncryptionService _encryptionService;
 		private readonly IOutboundVoiceProvider _outboundVoiceProvider;
+		private readonly IPhoneNumberProcesserProvider _phoneNumberProcesser;
 
 		public ContactVerificationService(
 			IUserProfileService userProfileService,
@@ -30,7 +31,8 @@ namespace Resgrid.Services
 			ISmsService smsService,
 			ISystemAuditsService systemAuditsService,
 			IEncryptionService encryptionService,
-			IOutboundVoiceProvider outboundVoiceProvider)
+			IOutboundVoiceProvider outboundVoiceProvider,
+			IPhoneNumberProcesserProvider phoneNumberProcesser)
 		{
 			_userProfileService = userProfileService;
 			_usersService = usersService;
@@ -39,6 +41,7 @@ namespace Resgrid.Services
 			_systemAuditsService = systemAuditsService;
 			_encryptionService = encryptionService;
 			_outboundVoiceProvider = outboundVoiceProvider;
+			_phoneNumberProcesser = phoneNumberProcesser;
 		}
 
 		public async Task<bool> SendEmailVerificationCodeAsync(string userId, int departmentId, CancellationToken cancellationToken = default)
@@ -80,6 +83,16 @@ namespace Resgrid.Services
 			if (profile == null || string.IsNullOrWhiteSpace(profile.MobileNumber))
 				return false;
 
+			// Normalize to E.164 and validate before sending so an invalid/local-format number (e.g. a bare
+			// "082446..." with no country code) is rejected here instead of throwing a Twilio "Invalid 'To'" error.
+			var mobileResult = _phoneNumberProcesser.Process(profile.GetPhoneNumber());
+			if (mobileResult == null || !mobileResult.IsValid || string.IsNullOrWhiteSpace(mobileResult.InternationalNumber))
+			{
+				Logging.LogInfo($"Mobile verification SMS skipped for user {userId}: phone number is not a valid sendable number (needs international format, e.g. +<country code><number>).");
+				await WriteAuditAsync(userId, departmentId, ContactVerificationType.MobileNumber, false, "Send-InvalidNumber", null, cancellationToken);
+				return false;
+			}
+
 			if (!IsWithinHourlySendLimit(profile.MobileVerificationCodeExpiry, profile.MobileVerificationAttempts))
 				return false;
 
@@ -90,7 +103,7 @@ namespace Resgrid.Services
 
 			await _userProfileService.SaveProfileAsync(departmentId, profile, cancellationToken);
 
-			bool sent = await _smsService.SendSmsVerificationCodeAsync(profile.GetPhoneNumber(), code, departmentNumber);
+			bool sent = await _smsService.SendSmsVerificationCodeAsync(mobileResult.InternationalNumber, code, departmentNumber);
 
 			await WriteAuditAsync(userId, departmentId, ContactVerificationType.MobileNumber, sent, "Send", null, cancellationToken);
 
@@ -102,6 +115,15 @@ namespace Resgrid.Services
 			var profile = await _userProfileService.GetProfileByUserIdAsync(userId, bypassCache: true);
 			if (profile == null || string.IsNullOrWhiteSpace(profile.HomeNumber))
 				return false;
+
+			// Validate/normalize before placing the Twilio voice call so an invalid number doesn't throw "Invalid 'To'".
+			var homeResult = _phoneNumberProcesser.Process(profile.GetHomePhoneNumber());
+			if (homeResult == null || !homeResult.IsValid || string.IsNullOrWhiteSpace(homeResult.InternationalNumber))
+			{
+				Logging.LogInfo($"Home verification call skipped for user {userId}: phone number is not a valid sendable number.");
+				await WriteAuditAsync(userId, departmentId, ContactVerificationType.HomeNumber, false, "SendVoice-InvalidNumber", null, cancellationToken);
+				return false;
+			}
 
 			if (!IsWithinHourlySendLimit(profile.HomeVerificationCodeExpiry, profile.HomeVerificationAttempts))
 				return false;
@@ -117,7 +139,7 @@ namespace Resgrid.Services
 			// landlines that cannot receive text messages. The call speaks the digits
 			// of the verification code, repeating multiple times so the user can note them.
 			bool sent = await _outboundVoiceProvider.SendVoiceVerificationCallAsync(
-				profile.GetHomePhoneNumber(), userId, (int)ContactVerificationType.HomeNumber);
+				homeResult.InternationalNumber, userId, (int)ContactVerificationType.HomeNumber);
 
 			await WriteAuditAsync(userId, departmentId, ContactVerificationType.HomeNumber, sent, "SendVoice", null, cancellationToken);
 

--- a/Core/Resgrid.Services/IncidentCommandService.cs
+++ b/Core/Resgrid.Services/IncidentCommandService.cs
@@ -357,10 +357,13 @@ namespace Resgrid.Services
 			// returned again on the next sync — harmless, the client upserts idempotently).
 			var changes = new IncidentCommandChanges { ServerTimestampMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() };
 
-			// Method-group conversion is contravariance-aware, so this Func<IChangeTracked,bool> binds to each
-			// entity-typed Where(). Soft-deleted/closed/released rows are intentionally NOT filtered out here — the
-			// delta must surface them (with their state columns) so the client removes/updates them locally.
-			bool Changed(IChangeTracked e) => e.ModifiedOn.HasValue && e.ModifiedOn.Value > sinceUtc;
+			// On an initial full sync (since=0 → DateTime.MinValue) return EVERY row — including any with a null
+			// ModifiedOn (e.g. rows created before the change-tracking column existed) — so the first pull is complete;
+			// incremental syncs keep the strict "changed since the cursor" filter. Method-group conversion is
+			// contravariance-aware, so this Func<IChangeTracked,bool> binds to each entity-typed Where(). Soft-deleted/
+			// closed/released rows are intentionally surfaced (with their state columns) so the client reconciles them.
+			var fullSync = sinceUtc == DateTime.MinValue;
+			bool Changed(IChangeTracked e) => fullSync || (e.ModifiedOn.HasValue && e.ModifiedOn.Value > sinceUtc);
 
 			var commands = await _incidentCommandRepository.GetAllByDepartmentIdAsync(departmentId);
 			if (commands != null)

--- a/Core/Resgrid.Services/IncidentCommandService.cs
+++ b/Core/Resgrid.Services/IncidentCommandService.cs
@@ -98,7 +98,9 @@ namespace Resgrid.Services
 
 			try
 			{
-				command = await _incidentCommandRepository.SaveOrUpdateAsync(command, cancellationToken);
+				// Explicit insert: the GUID is pre-set, and SaveOrUpdateAsync would treat a non-empty IdType-1 id
+				// as an UPDATE (zero rows) instead of an insert.
+				command = await _incidentCommandRepository.InsertAsync(Touch(command), cancellationToken);
 			}
 			catch (Exception)
 			{
@@ -141,7 +143,7 @@ namespace Resgrid.Services
 							SourceRoleId = role.CommandDefinitionRoleId
 						};
 
-						await _commandStructureNodeRepository.SaveOrUpdateAsync(node, cancellationToken);
+						await _commandStructureNodeRepository.InsertAsync(Touch(node), cancellationToken);
 					}
 				}
 			}
@@ -259,23 +261,20 @@ namespace Resgrid.Services
 				return null;
 			assignment.CallId = command.CallId;
 
-			if (string.IsNullOrWhiteSpace(assignment.IncidentRoleAssignmentId))
-			{
-				assignment.IncidentRoleAssignmentId = Guid.NewGuid().ToString();
-			}
-			else
-			{
-				// On update, the existing row must belong to the caller's department.
-				var existing = await _incidentRoleAssignmentRepository.GetByIdAsync(assignment.IncidentRoleAssignmentId);
-				if (existing == null || existing.DepartmentId != assignment.DepartmentId)
-					return null;
-			}
-
 			assignment.AssignedByUserId = userId;
 			if (assignment.AssignedOn == default(DateTime))
 				assignment.AssignedOn = DateTime.UtcNow;
 
-			assignment = await _incidentRoleAssignmentRepository.SaveOrUpdateAsync(assignment, cancellationToken);
+			var (saved, _, rejected) = await UpsertOwnedAsync(_incidentRoleAssignmentRepository, assignment, assignment.DepartmentId,
+				e => e.DepartmentId, (stored, incoming) =>
+				{
+					incoming.AssignedOn = stored.AssignedOn;
+					incoming.AssignedByUserId = stored.AssignedByUserId;
+					incoming.RemovedOn = stored.RemovedOn;
+				}, cancellationToken);
+			if (rejected)
+				return null;
+			assignment = saved;
 
 			await WriteLogAsync(assignment.IncidentCommandId, assignment.DepartmentId, assignment.CallId, CommandLogEntryType.RoleAssigned, $"Role {(IncidentRoleType)assignment.RoleType} assigned", userId, cancellationToken);
 
@@ -290,7 +289,7 @@ namespace Resgrid.Services
 				return false;
 
 			assignment.RemovedOn = DateTime.UtcNow;
-			await _incidentRoleAssignmentRepository.SaveOrUpdateAsync(assignment, cancellationToken);
+			await _incidentRoleAssignmentRepository.SaveOrUpdateAsync(Touch(assignment), cancellationToken);
 
 			await WriteLogAsync(assignment.IncidentCommandId, assignment.DepartmentId, assignment.CallId, CommandLogEntryType.RoleRemoved, $"Role {(IncidentRoleType)assignment.RoleType} removed", userId, cancellationToken);
 			return true;
@@ -352,6 +351,53 @@ namespace Resgrid.Services
 			return board;
 		}
 
+		public async Task<IncidentCommandChanges> GetChangesSinceAsync(int departmentId, DateTime sinceUtc)
+		{
+			// Capture the cursor before reading so a row committed during the read is not missed next time (it may be
+			// returned again on the next sync — harmless, the client upserts idempotently).
+			var changes = new IncidentCommandChanges { ServerTimestampMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() };
+
+			// Method-group conversion is contravariance-aware, so this Func<IChangeTracked,bool> binds to each
+			// entity-typed Where(). Soft-deleted/closed/released rows are intentionally NOT filtered out here — the
+			// delta must surface them (with their state columns) so the client removes/updates them locally.
+			bool Changed(IChangeTracked e) => e.ModifiedOn.HasValue && e.ModifiedOn.Value > sinceUtc;
+
+			var commands = await _incidentCommandRepository.GetAllByDepartmentIdAsync(departmentId);
+			if (commands != null)
+				changes.Commands = commands.Where(Changed).ToList();
+
+			var nodes = await _commandStructureNodeRepository.GetAllByDepartmentIdAsync(departmentId);
+			if (nodes != null)
+				changes.Nodes = nodes.Where(Changed).ToList();
+
+			var assignments = await _resourceAssignmentRepository.GetAllByDepartmentIdAsync(departmentId);
+			if (assignments != null)
+				changes.Assignments = assignments.Where(Changed).ToList();
+
+			var objectives = await _tacticalObjectiveRepository.GetAllByDepartmentIdAsync(departmentId);
+			if (objectives != null)
+				changes.Objectives = objectives.Where(Changed).ToList();
+
+			var timers = await _incidentTimerRepository.GetAllByDepartmentIdAsync(departmentId);
+			if (timers != null)
+				changes.Timers = timers.Where(Changed).ToList();
+
+			var annotations = await _incidentMapAnnotationRepository.GetAllByDepartmentIdAsync(departmentId);
+			if (annotations != null)
+				changes.Annotations = annotations.Where(Changed).ToList();
+
+			var roles = await _incidentRoleAssignmentRepository.GetAllByDepartmentIdAsync(departmentId);
+			if (roles != null)
+				changes.Roles = roles.Where(Changed).ToList();
+
+			// The timeline is append-only (no ModifiedOn); its natural cursor is OccurredOn.
+			var timeline = await _commandLogEntryRepository.GetAllByDepartmentIdAsync(departmentId);
+			if (timeline != null)
+				changes.TimelineEntries = timeline.Where(x => x.OccurredOn > sinceUtc).ToList();
+
+			return changes;
+		}
+
 		public async Task<IncidentCommand> CloseCommandAsync(int departmentId, string incidentCommandId, string userId, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			var command = await _incidentCommandRepository.GetByIdAsync(incidentCommandId);
@@ -360,7 +406,7 @@ namespace Resgrid.Services
 
 			command.Status = (int)IncidentCommandStatus.Closed;
 			command.ClosedOn = DateTime.UtcNow;
-			command = await _incidentCommandRepository.SaveOrUpdateAsync(command, cancellationToken);
+			command = await _incidentCommandRepository.SaveOrUpdateAsync(Touch(command), cancellationToken);
 
 			await WriteLogAsync(command.IncidentCommandId, command.DepartmentId, command.CallId, CommandLogEntryType.CommandClosed, "Command closed", userId, cancellationToken);
 
@@ -378,7 +424,7 @@ namespace Resgrid.Services
 				return null;
 
 			command.CurrentCommanderUserId = toUserId;
-			await _incidentCommandRepository.SaveOrUpdateAsync(command, cancellationToken);
+			await _incidentCommandRepository.SaveOrUpdateAsync(Touch(command), cancellationToken);
 
 			var transfer = new CommandTransfer
 			{
@@ -391,7 +437,7 @@ namespace Resgrid.Services
 				TransferredOn = DateTime.UtcNow,
 				Notes = notes
 			};
-			transfer = await _commandTransferRepository.SaveOrUpdateAsync(transfer, cancellationToken);
+			transfer = await _commandTransferRepository.InsertAsync(transfer, cancellationToken);
 
 			await WriteLogAsync(command.IncidentCommandId, command.DepartmentId, command.CallId, CommandLogEntryType.CommandTransferred, "Command transferred", fromUserId, cancellationToken);
 
@@ -406,7 +452,7 @@ namespace Resgrid.Services
 				return null;
 
 			command.IncidentActionPlan = actionPlan;
-			command = await _incidentCommandRepository.SaveOrUpdateAsync(command, cancellationToken);
+			command = await _incidentCommandRepository.SaveOrUpdateAsync(Touch(command), cancellationToken);
 
 			await WriteLogAsync(command.IncidentCommandId, command.DepartmentId, command.CallId, CommandLogEntryType.Note, "Incident action plan updated", userId, cancellationToken);
 			return command;
@@ -426,20 +472,11 @@ namespace Resgrid.Services
 				return null;
 			node.CallId = command.CallId;
 
-			var isNew = string.IsNullOrWhiteSpace(node.CommandStructureNodeId);
-			if (isNew)
-			{
-				node.CommandStructureNodeId = Guid.NewGuid().ToString();
-			}
-			else
-			{
-				// On update, the existing row must belong to the caller's department (no foreign-row takeover).
-				var existing = await _commandStructureNodeRepository.GetByIdAsync(node.CommandStructureNodeId);
-				if (existing == null || existing.DepartmentId != node.DepartmentId)
-					return null;
-			}
-
-			node = await _commandStructureNodeRepository.SaveOrUpdateAsync(node, cancellationToken);
+			var (saved, isNew, rejected) = await UpsertOwnedAsync(_commandStructureNodeRepository, node, node.DepartmentId,
+				e => e.DepartmentId, (stored, incoming) => incoming.DeletedOn = stored.DeletedOn, cancellationToken);
+			if (rejected)
+				return null;
+			node = saved;
 
 			await WriteLogAsync(node.IncidentCommandId, node.DepartmentId, node.CallId,
 				isNew ? CommandLogEntryType.NodeAdded : CommandLogEntryType.NodeUpdated,
@@ -453,10 +490,13 @@ namespace Resgrid.Services
 			if (node == null || node.DepartmentId != departmentId)
 				return false;
 
-			var result = await _commandStructureNodeRepository.DeleteAsync(node, cancellationToken);
+			// Soft-delete (tombstone) rather than hard-delete so the removal propagates to offline clients on the
+			// next delta sync; ModifiedOn is stamped so the change is picked up by the "changed since" query.
+			node.DeletedOn = DateTime.UtcNow;
+			await _commandStructureNodeRepository.SaveOrUpdateAsync(Touch(node), cancellationToken);
 
 			await WriteLogAsync(node.IncidentCommandId, node.DepartmentId, node.CallId, CommandLogEntryType.NodeRemoved, $"Lane '{node.Name}' removed", userId, cancellationToken);
-			return result;
+			return true;
 		}
 
 		public async Task<List<CommandStructureNode>> GetNodesForCallAsync(int departmentId, int callId)
@@ -465,7 +505,7 @@ namespace Resgrid.Services
 			if (items == null)
 				return new List<CommandStructureNode>();
 
-			return items.Where(x => x.CallId == callId).OrderBy(x => x.SortOrder).ToList();
+			return items.Where(x => x.CallId == callId && x.DeletedOn == null).OrderBy(x => x.SortOrder).ToList();
 		}
 
 		#endregion Structure (lanes)
@@ -481,23 +521,20 @@ namespace Resgrid.Services
 				return null;
 			assignment.CallId = command.CallId;
 
-			if (string.IsNullOrWhiteSpace(assignment.ResourceAssignmentId))
-			{
-				assignment.ResourceAssignmentId = Guid.NewGuid().ToString();
-			}
-			else
-			{
-				// On update, the existing row must belong to the caller's department.
-				var existing = await _resourceAssignmentRepository.GetByIdAsync(assignment.ResourceAssignmentId);
-				if (existing == null || existing.DepartmentId != assignment.DepartmentId)
-					return null;
-			}
-
 			if (assignment.AssignedOn == default(DateTime))
 				assignment.AssignedOn = DateTime.UtcNow;
-
 			assignment.AssignedByUserId = userId;
-			assignment = await _resourceAssignmentRepository.SaveOrUpdateAsync(assignment, cancellationToken);
+
+			var (saved, _, rejected) = await UpsertOwnedAsync(_resourceAssignmentRepository, assignment, assignment.DepartmentId,
+				e => e.DepartmentId, (stored, incoming) =>
+				{
+					incoming.AssignedOn = stored.AssignedOn;
+					incoming.AssignedByUserId = stored.AssignedByUserId;
+					incoming.ReleasedOn = stored.ReleasedOn;
+				}, cancellationToken);
+			if (rejected)
+				return null;
+			assignment = saved;
 
 			await WriteLogAsync(assignment.IncidentCommandId, assignment.DepartmentId, assignment.CallId, CommandLogEntryType.ResourceAssigned, "Resource assigned", userId, cancellationToken);
 
@@ -518,7 +555,7 @@ namespace Resgrid.Services
 				return null;
 
 			assignment.CommandStructureNodeId = targetNodeId;
-			assignment = await _resourceAssignmentRepository.SaveOrUpdateAsync(assignment, cancellationToken);
+			assignment = await _resourceAssignmentRepository.SaveOrUpdateAsync(Touch(assignment), cancellationToken);
 
 			await WriteLogAsync(assignment.IncidentCommandId, assignment.DepartmentId, assignment.CallId, CommandLogEntryType.ResourceMoved, "Resource moved", userId, cancellationToken);
 			return assignment;
@@ -531,7 +568,7 @@ namespace Resgrid.Services
 				return false;
 
 			assignment.ReleasedOn = DateTime.UtcNow;
-			await _resourceAssignmentRepository.SaveOrUpdateAsync(assignment, cancellationToken);
+			await _resourceAssignmentRepository.SaveOrUpdateAsync(Touch(assignment), cancellationToken);
 
 			await WriteLogAsync(assignment.IncidentCommandId, assignment.DepartmentId, assignment.CallId, CommandLogEntryType.ResourceReleased, "Resource released", userId, cancellationToken);
 
@@ -561,20 +598,17 @@ namespace Resgrid.Services
 				return null;
 			objective.CallId = command.CallId;
 
-			var isNew = string.IsNullOrWhiteSpace(objective.TacticalObjectiveId);
-			if (isNew)
-			{
-				objective.TacticalObjectiveId = Guid.NewGuid().ToString();
-			}
-			else
-			{
-				// On update, the existing row must belong to the caller's department.
-				var existing = await _tacticalObjectiveRepository.GetByIdAsync(objective.TacticalObjectiveId);
-				if (existing == null || existing.DepartmentId != objective.DepartmentId)
-					return null;
-			}
-
-			objective = await _tacticalObjectiveRepository.SaveOrUpdateAsync(objective, cancellationToken);
+			var (saved, isNew, rejected) = await UpsertOwnedAsync(_tacticalObjectiveRepository, objective, objective.DepartmentId,
+				e => e.DepartmentId, (stored, incoming) =>
+				{
+					// Completion is owned by CompleteObjectiveAsync; a Save (edit/replay) must not reset it.
+					incoming.Status = stored.Status;
+					incoming.CompletedByUserId = stored.CompletedByUserId;
+					incoming.CompletedOn = stored.CompletedOn;
+				}, cancellationToken);
+			if (rejected)
+				return null;
+			objective = saved;
 
 			if (isNew)
 				await WriteLogAsync(objective.IncidentCommandId, objective.DepartmentId, objective.CallId, CommandLogEntryType.ObjectiveAdded, $"Objective '{objective.Name}' added", userId, cancellationToken);
@@ -591,7 +625,7 @@ namespace Resgrid.Services
 			objective.Status = (int)TacticalObjectiveStatus.Complete;
 			objective.CompletedByUserId = userId;
 			objective.CompletedOn = DateTime.UtcNow;
-			objective = await _tacticalObjectiveRepository.SaveOrUpdateAsync(objective, cancellationToken);
+			objective = await _tacticalObjectiveRepository.SaveOrUpdateAsync(Touch(objective), cancellationToken);
 
 			await WriteLogAsync(objective.IncidentCommandId, objective.DepartmentId, objective.CallId, CommandLogEntryType.ObjectiveCompleted, $"Objective '{objective.Name}' completed", userId, cancellationToken);
 
@@ -621,24 +655,23 @@ namespace Resgrid.Services
 				return null;
 			timer.CallId = command.CallId;
 
-			if (string.IsNullOrWhiteSpace(timer.IncidentTimerId))
-			{
-				timer.IncidentTimerId = Guid.NewGuid().ToString();
-			}
-			else
-			{
-				// On update, the existing row must belong to the caller's department.
-				var existing = await _incidentTimerRepository.GetByIdAsync(timer.IncidentTimerId);
-				if (existing == null || existing.DepartmentId != timer.DepartmentId)
-					return null;
-			}
-
 			timer.StartedOn = DateTime.UtcNow;
 			timer.Status = (int)IncidentTimerStatus.Running;
 			if (timer.IntervalSeconds > 0)
 				timer.NextDueOn = timer.StartedOn.AddSeconds(timer.IntervalSeconds);
 
-			timer = await _incidentTimerRepository.SaveOrUpdateAsync(timer, cancellationToken);
+			var (saved, _, rejected) = await UpsertOwnedAsync(_incidentTimerRepository, timer, timer.DepartmentId,
+				e => e.DepartmentId, (stored, incoming) =>
+				{
+					// Existing id => a replayed start; keep the original run state rather than restarting the timer.
+					incoming.StartedOn = stored.StartedOn;
+					incoming.Status = stored.Status;
+					incoming.NextDueOn = stored.NextDueOn;
+					incoming.AcknowledgedOn = stored.AcknowledgedOn;
+				}, cancellationToken);
+			if (rejected)
+				return null;
+			timer = saved;
 
 			await WriteLogAsync(timer.IncidentCommandId, timer.DepartmentId, timer.CallId, CommandLogEntryType.TimerStarted, $"Timer '{timer.Name}' started", userId, cancellationToken);
 			return timer;
@@ -655,7 +688,7 @@ namespace Resgrid.Services
 			if (timer.IntervalSeconds > 0)
 				timer.NextDueOn = timer.AcknowledgedOn.Value.AddSeconds(timer.IntervalSeconds);
 
-			timer = await _incidentTimerRepository.SaveOrUpdateAsync(timer, cancellationToken);
+			timer = await _incidentTimerRepository.SaveOrUpdateAsync(Touch(timer), cancellationToken);
 
 			await WriteLogAsync(timer.IncidentCommandId, timer.DepartmentId, timer.CallId, CommandLogEntryType.TimerAcknowledged, $"Timer '{timer.Name}' acknowledged", userId, cancellationToken);
 			return timer;
@@ -683,22 +716,21 @@ namespace Resgrid.Services
 				return null;
 			annotation.CallId = command.CallId;
 
-			var isNew = string.IsNullOrWhiteSpace(annotation.IncidentMapAnnotationId);
-			if (isNew)
-			{
-				annotation.IncidentMapAnnotationId = Guid.NewGuid().ToString();
+			if (annotation.CreatedOn == default(DateTime))
 				annotation.CreatedOn = DateTime.UtcNow;
+			if (string.IsNullOrWhiteSpace(annotation.CreatedByUserId))
 				annotation.CreatedByUserId = userId;
-			}
-			else
-			{
-				// On update, the existing row must belong to the caller's department.
-				var existing = await _incidentMapAnnotationRepository.GetByIdAsync(annotation.IncidentMapAnnotationId);
-				if (existing == null || existing.DepartmentId != annotation.DepartmentId)
-					return null;
-			}
 
-			annotation = await _incidentMapAnnotationRepository.SaveOrUpdateAsync(annotation, cancellationToken);
+			var (saved, isNew, rejected) = await UpsertOwnedAsync(_incidentMapAnnotationRepository, annotation, annotation.DepartmentId,
+				e => e.DepartmentId, (stored, incoming) =>
+				{
+					incoming.CreatedOn = stored.CreatedOn;
+					incoming.CreatedByUserId = stored.CreatedByUserId;
+					incoming.DeletedOn = stored.DeletedOn;
+				}, cancellationToken);
+			if (rejected)
+				return null;
+			annotation = saved;
 
 			if (isNew)
 				await WriteLogAsync(annotation.IncidentCommandId, annotation.DepartmentId, annotation.CallId, CommandLogEntryType.AnnotationAdded, "Map annotation added", userId, cancellationToken);
@@ -713,7 +745,7 @@ namespace Resgrid.Services
 				return false;
 
 			annotation.DeletedOn = DateTime.UtcNow;
-			await _incidentMapAnnotationRepository.SaveOrUpdateAsync(annotation, cancellationToken);
+			await _incidentMapAnnotationRepository.SaveOrUpdateAsync(Touch(annotation), cancellationToken);
 
 			await WriteLogAsync(annotation.IncidentCommandId, annotation.DepartmentId, annotation.CallId, CommandLogEntryType.AnnotationRemoved, "Map annotation removed", userId, cancellationToken);
 			return true;
@@ -751,6 +783,55 @@ namespace Resgrid.Services
 		#region Private helpers
 
 		/// <summary>
+		/// Stamps the offline-sync change cursor on an entity. Called on every insert and update so the delta
+		/// endpoint can surface the row as "changed since" and reconnect conflict resolution can compare write
+		/// times (last-write-wins). See docs/architecture/offline-first-architecture.md.
+		/// </summary>
+		private static T Touch<T>(T entity) where T : IChangeTracked
+		{
+			entity.ModifiedOn = DateTime.UtcNow;
+			return entity;
+		}
+
+		/// <summary>
+		/// Idempotent upsert for an owned child entity. Create-vs-update is resolved by the entity id's EXISTENCE
+		/// (not merely whether an id was supplied), which is what makes offline replay safe:
+		///   • no id, or a client-supplied id that does not exist yet -> INSERT with that (or a generated) GUID, so
+		///     an offline-created row replays without duplicating;
+		///   • id already present -> it must belong to <paramref name="departmentId"/> (else rejected) and is
+		///     UPDATED, with <paramref name="preserve"/> copying server-owned fields off the stored row so a
+		///     replayed create payload cannot clobber them.
+		/// Returns rejected=true only for a foreign-department row. A plain SaveOrUpdateAsync cannot do the create
+		/// here: for string-GUID (IdType 1) entities it only inserts when the id is blank and otherwise issues a
+		/// blind UPDATE, so a client-supplied PK would silently update zero rows. See offline-first-architecture.md.
+		/// </summary>
+		private static async Task<(T entity, bool isNew, bool rejected)> UpsertOwnedAsync<T>(
+			IRepository<T> repository, T entity, int departmentId, Func<T, int> departmentOf,
+			Action<T, T> preserve, CancellationToken cancellationToken) where T : class, IEntity, IChangeTracked
+		{
+			var id = entity.IdValue?.ToString();
+
+			T stored = null;
+			if (!string.IsNullOrWhiteSpace(id))
+			{
+				stored = await repository.GetByIdAsync(id);
+				if (stored != null && departmentOf(stored) != departmentId)
+					return (null, false, true);
+			}
+
+			if (stored == null)
+			{
+				if (string.IsNullOrWhiteSpace(id))
+					entity.IdValue = Guid.NewGuid().ToString();
+
+				return (await repository.InsertAsync(Touch(entity), cancellationToken), true, false);
+			}
+
+			preserve?.Invoke(stored, entity);
+			return (await repository.SaveOrUpdateAsync(Touch(entity), cancellationToken), false, false);
+		}
+
+		/// <summary>
 		/// Loads the parent incident command and returns it only if it belongs to the given department (else null).
 		/// Gates create/update of child entities AND supplies the authoritative CallId to stamp onto them — a caller
 		/// must not be trusted to supply a CallId that matches the parent command.
@@ -778,7 +859,7 @@ namespace Resgrid.Services
 				OccurredOn = DateTime.UtcNow
 			};
 
-			var saved = await _commandLogEntryRepository.SaveOrUpdateAsync(entry, cancellationToken);
+			var saved = await _commandLogEntryRepository.InsertAsync(entry, cancellationToken);
 
 			// Real-time: every command mutation flows through here, so push one board-changed signal.
 			await _coreEventService.IncidentCommandUpdatedAsync(departmentId, callId);

--- a/Core/Resgrid.Services/IncidentResourcesService.cs
+++ b/Core/Resgrid.Services/IncidentResourcesService.cs
@@ -44,14 +44,25 @@ namespace Resgrid.Services
 			if (command == null)
 				return null;
 
-			if (string.IsNullOrWhiteSpace(unit.IncidentAdHocUnitId))
+			// Idempotent create: the client may generate the GUID PK offline. If a row with that id already exists
+			// for this department the create was already applied (replay) — return it without duplicating. Otherwise
+			// INSERT explicitly; SaveOrUpdateAsync would treat the pre-set GUID as a 0-row UPDATE, not an insert.
+			if (!string.IsNullOrWhiteSpace(unit.IncidentAdHocUnitId))
+			{
+				var stored = await _adHocUnitRepository.GetByIdAsync(unit.IncidentAdHocUnitId);
+				if (stored != null)
+					return stored.DepartmentId == unit.DepartmentId ? stored : null;
+			}
+			else
+			{
 				unit.IncidentAdHocUnitId = Guid.NewGuid().ToString();
+			}
 
 			unit.CreatedByUserId = userId;
 			if (unit.CreatedOn == default(DateTime))
 				unit.CreatedOn = DateTime.UtcNow;
 
-			unit = await _adHocUnitRepository.SaveOrUpdateAsync(unit, cancellationToken);
+			unit = await _adHocUnitRepository.InsertAsync(Touch(unit), cancellationToken);
 
 			await LogAsync(unit.DepartmentId, unit.CallId, $"Ad-hoc unit '{unit.Name}' created", userId, cancellationToken);
 
@@ -80,7 +91,7 @@ namespace Resgrid.Services
 				return false;
 
 			unit.ReleasedOn = DateTime.UtcNow;
-			await _adHocUnitRepository.SaveOrUpdateAsync(unit, cancellationToken);
+			await _adHocUnitRepository.SaveOrUpdateAsync(Touch(unit), cancellationToken);
 
 			await LogAsync(unit.DepartmentId, unit.CallId, $"Ad-hoc unit '{unit.Name}' released", userId, cancellationToken);
 			return true;
@@ -97,14 +108,24 @@ namespace Resgrid.Services
 			if (command == null)
 				return null;
 
-			if (string.IsNullOrWhiteSpace(personnel.IncidentAdHocPersonnelId))
+			// Idempotent create (see CreateAdHocUnitAsync): replay of an existing id returns the stored row; a new id
+			// is inserted explicitly (a pre-set GUID + SaveOrUpdateAsync would be a 0-row UPDATE, not an insert).
+			if (!string.IsNullOrWhiteSpace(personnel.IncidentAdHocPersonnelId))
+			{
+				var stored = await _adHocPersonnelRepository.GetByIdAsync(personnel.IncidentAdHocPersonnelId);
+				if (stored != null)
+					return stored.DepartmentId == personnel.DepartmentId ? stored : null;
+			}
+			else
+			{
 				personnel.IncidentAdHocPersonnelId = Guid.NewGuid().ToString();
+			}
 
 			personnel.CreatedByUserId = userId;
 			if (personnel.CreatedOn == default(DateTime))
 				personnel.CreatedOn = DateTime.UtcNow;
 
-			personnel = await _adHocPersonnelRepository.SaveOrUpdateAsync(personnel, cancellationToken);
+			personnel = await _adHocPersonnelRepository.InsertAsync(Touch(personnel), cancellationToken);
 
 			await LogAsync(personnel.DepartmentId, personnel.CallId, $"Ad-hoc personnel '{personnel.Name}' created", userId, cancellationToken);
 
@@ -128,7 +149,7 @@ namespace Resgrid.Services
 				return false;
 
 			personnel.ReleasedOn = DateTime.UtcNow;
-			await _adHocPersonnelRepository.SaveOrUpdateAsync(personnel, cancellationToken);
+			await _adHocPersonnelRepository.SaveOrUpdateAsync(Touch(personnel), cancellationToken);
 
 			await LogAsync(personnel.DepartmentId, personnel.CallId, $"Ad-hoc personnel '{personnel.Name}' released", userId, cancellationToken);
 			return true;
@@ -146,7 +167,7 @@ namespace Resgrid.Services
 
 			personnel.RidingResourceKind = ridingResourceKind;
 			personnel.RidingResourceId = ridingResourceId;
-			personnel = await _adHocPersonnelRepository.SaveOrUpdateAsync(personnel, cancellationToken);
+			personnel = await _adHocPersonnelRepository.SaveOrUpdateAsync(Touch(personnel), cancellationToken);
 
 			await LogAsync(personnel.DepartmentId, personnel.CallId, $"'{personnel.Name}' added to unit roster", userId, cancellationToken);
 			return personnel;
@@ -170,7 +191,7 @@ namespace Resgrid.Services
 
 					personnel.RidingResourceKind = (int)ResourceAssignmentKind.AdHocUnit;
 					personnel.RidingResourceId = createdUnit.IncidentAdHocUnitId;
-					await _adHocPersonnelRepository.SaveOrUpdateAsync(personnel, cancellationToken);
+					await _adHocPersonnelRepository.SaveOrUpdateAsync(Touch(personnel), cancellationToken);
 				}
 			}
 
@@ -180,7 +201,30 @@ namespace Resgrid.Services
 
 		#endregion Roster building
 
+		#region Offline sync
+
+		public async Task<(List<IncidentAdHocUnit> Units, List<IncidentAdHocPersonnel> Personnel)> GetAdHocChangesSinceAsync(int departmentId, DateTime sinceUtc)
+		{
+			bool Changed(IChangeTracked e) => e.ModifiedOn.HasValue && e.ModifiedOn.Value > sinceUtc;
+
+			var units = await _adHocUnitRepository.GetAllByDepartmentIdAsync(departmentId);
+			var personnel = await _adHocPersonnelRepository.GetAllByDepartmentIdAsync(departmentId);
+
+			return (
+				units?.Where(Changed).ToList() ?? new List<IncidentAdHocUnit>(),
+				personnel?.Where(Changed).ToList() ?? new List<IncidentAdHocPersonnel>());
+		}
+
+		#endregion Offline sync
+
 		#region Private helpers
+
+		/// <summary>Stamps the offline-sync change cursor (ModifiedOn) on every insert/update. See offline-first-architecture.md.</summary>
+		private static T Touch<T>(T entity) where T : IChangeTracked
+		{
+			entity.ModifiedOn = DateTime.UtcNow;
+			return entity;
+		}
 
 		private async Task LogAsync(int departmentId, int callId, string description, string userId, CancellationToken cancellationToken)
 		{

--- a/Core/Resgrid.Services/IncidentResourcesService.cs
+++ b/Core/Resgrid.Services/IncidentResourcesService.cs
@@ -205,7 +205,9 @@ namespace Resgrid.Services
 
 		public async Task<(List<IncidentAdHocUnit> Units, List<IncidentAdHocPersonnel> Personnel)> GetAdHocChangesSinceAsync(int departmentId, DateTime sinceUtc)
 		{
-			bool Changed(IChangeTracked e) => e.ModifiedOn.HasValue && e.ModifiedOn.Value > sinceUtc;
+			// Full sync (since=0 → DateTime.MinValue) returns every row incl. null-ModifiedOn; incremental filters strictly.
+			var fullSync = sinceUtc == DateTime.MinValue;
+			bool Changed(IChangeTracked e) => fullSync || (e.ModifiedOn.HasValue && e.ModifiedOn.Value > sinceUtc);
 
 			var units = await _adHocUnitRepository.GetAllByDepartmentIdAsync(departmentId);
 			var personnel = await _adHocPersonnelRepository.GetAllByDepartmentIdAsync(departmentId);

--- a/Core/Resgrid.Services/IncidentVoiceService.cs
+++ b/Core/Resgrid.Services/IncidentVoiceService.cs
@@ -126,7 +126,8 @@ namespace Resgrid.Services
 				OccurredOn = DateTime.UtcNow
 			};
 
-			await _commandLogEntryRepository.SaveOrUpdateAsync(entry, cancellationToken);
+			// Append-only insert: a pre-set GUID would make SaveOrUpdateAsync issue a 0-row UPDATE instead of inserting.
+			await _commandLogEntryRepository.InsertAsync(entry, cancellationToken);
 
 			// Real-time: channel open/close is a board change.
 			await _coreEventService.IncidentCommandUpdatedAsync(departmentId, callId);

--- a/Providers/Resgrid.Providers.Migrations/Migrations/M0081_AddIncidentCommandChangeTracking.cs
+++ b/Providers/Resgrid.Providers.Migrations/Migrations/M0081_AddIncidentCommandChangeTracking.cs
@@ -1,0 +1,58 @@
+using FluentMigrator;
+
+namespace Resgrid.Providers.Migrations.Migrations
+{
+	/// <summary>
+	/// Offline-first sync foundation: adds a ModifiedOn change cursor to the mutable incident-command tables
+	/// (delta "changed since" + last-write-wins) and a DeletedOn soft-delete tombstone to CommandStructureNodes
+	/// so a lane removed offline propagates on delta sync. Append-only tables (CommandLogEntries / CommandTransfers)
+	/// already carry a natural creation timestamp and are intentionally excluded.
+	/// See docs/architecture/offline-first-architecture.md.
+	/// </summary>
+	[Migration(81)]
+	public class M0081_AddIncidentCommandChangeTracking : Migration
+	{
+		private static readonly string[] ChangeTrackedTables =
+		{
+			"IncidentCommands",
+			"CommandStructureNodes",
+			"ResourceAssignments",
+			"TacticalObjectives",
+			"IncidentTimers",
+			"IncidentMapAnnotations",
+			"IncidentRoleAssignments"
+		};
+
+		public override void Up()
+		{
+			foreach (var table in ChangeTrackedTables)
+			{
+				if (Schema.Table(table).Exists() && !Schema.Table(table).Column("ModifiedOn").Exists())
+				{
+					Alter.Table(table).AddColumn("ModifiedOn").AsDateTime2().Nullable();
+				}
+			}
+
+			if (Schema.Table("CommandStructureNodes").Exists() && !Schema.Table("CommandStructureNodes").Column("DeletedOn").Exists())
+			{
+				Alter.Table("CommandStructureNodes").AddColumn("DeletedOn").AsDateTime2().Nullable();
+			}
+		}
+
+		public override void Down()
+		{
+			foreach (var table in ChangeTrackedTables)
+			{
+				if (Schema.Table(table).Exists() && Schema.Table(table).Column("ModifiedOn").Exists())
+				{
+					Delete.Column("ModifiedOn").FromTable(table);
+				}
+			}
+
+			if (Schema.Table("CommandStructureNodes").Exists() && Schema.Table("CommandStructureNodes").Column("DeletedOn").Exists())
+			{
+				Delete.Column("DeletedOn").FromTable("CommandStructureNodes");
+			}
+		}
+	}
+}

--- a/Providers/Resgrid.Providers.Migrations/Migrations/M0082_AddCheckInRecordIdempotencyKey.cs
+++ b/Providers/Resgrid.Providers.Migrations/Migrations/M0082_AddCheckInRecordIdempotencyKey.cs
@@ -1,0 +1,28 @@
+using FluentMigrator;
+
+namespace Resgrid.Providers.Migrations.Migrations
+{
+	/// <summary>
+	/// Offline-first action idempotency: a client-supplied key on check-in records so a replayed offline check-in
+	/// dedups instead of creating a duplicate row. See docs/architecture/offline-first-architecture.md.
+	/// </summary>
+	[Migration(82)]
+	public class M0082_AddCheckInRecordIdempotencyKey : Migration
+	{
+		public override void Up()
+		{
+			if (Schema.Table("CheckInRecords").Exists() && !Schema.Table("CheckInRecords").Column("IdempotencyKey").Exists())
+			{
+				Alter.Table("CheckInRecords").AddColumn("IdempotencyKey").AsString(128).Nullable();
+			}
+		}
+
+		public override void Down()
+		{
+			if (Schema.Table("CheckInRecords").Exists() && Schema.Table("CheckInRecords").Column("IdempotencyKey").Exists())
+			{
+				Delete.Column("IdempotencyKey").FromTable("CheckInRecords");
+			}
+		}
+	}
+}

--- a/Providers/Resgrid.Providers.Migrations/Migrations/M0082_AddCheckInRecordIdempotencyKey.cs
+++ b/Providers/Resgrid.Providers.Migrations/Migrations/M0082_AddCheckInRecordIdempotencyKey.cs
@@ -14,6 +14,11 @@ namespace Resgrid.Providers.Migrations.Migrations
 			if (Schema.Table("CheckInRecords").Exists() && !Schema.Table("CheckInRecords").Column("IdempotencyKey").Exists())
 			{
 				Alter.Table("CheckInRecords").AddColumn("IdempotencyKey").AsString(128).Nullable();
+
+				// At most one check-in per (department, idempotency key). Filtered so the many NULL-key (live UI)
+				// check-ins don't collide. Backstops the check-then-insert race in
+				// CheckInTimerService.PerformCheckInAsync (which adopts the winner on violation).
+				Execute.Sql("CREATE UNIQUE NONCLUSTERED INDEX UX_CheckInRecords_Department_IdempotencyKey ON CheckInRecords (DepartmentId, IdempotencyKey) WHERE IdempotencyKey IS NOT NULL;");
 			}
 		}
 
@@ -21,6 +26,7 @@ namespace Resgrid.Providers.Migrations.Migrations
 		{
 			if (Schema.Table("CheckInRecords").Exists() && Schema.Table("CheckInRecords").Column("IdempotencyKey").Exists())
 			{
+				Execute.Sql("DROP INDEX IF EXISTS UX_CheckInRecords_Department_IdempotencyKey ON CheckInRecords;");
 				Delete.Column("IdempotencyKey").FromTable("CheckInRecords");
 			}
 		}

--- a/Providers/Resgrid.Providers.Migrations/Migrations/M0083_AddAdHocResourceChangeTracking.cs
+++ b/Providers/Resgrid.Providers.Migrations/Migrations/M0083_AddAdHocResourceChangeTracking.cs
@@ -1,0 +1,36 @@
+using FluentMigrator;
+
+namespace Resgrid.Providers.Migrations.Migrations
+{
+	/// <summary>
+	/// Offline-first: adds a ModifiedOn change cursor to the ad-hoc incident resource tables so they participate in
+	/// the /Sync/Changes delta pull (previously they were full-refetched). See docs/architecture/offline-first-architecture.md.
+	/// </summary>
+	[Migration(83)]
+	public class M0083_AddAdHocResourceChangeTracking : Migration
+	{
+		private static readonly string[] Tables = { "IncidentAdHocUnits", "IncidentAdHocPersonnel" };
+
+		public override void Up()
+		{
+			foreach (var table in Tables)
+			{
+				if (Schema.Table(table).Exists() && !Schema.Table(table).Column("ModifiedOn").Exists())
+				{
+					Alter.Table(table).AddColumn("ModifiedOn").AsDateTime2().Nullable();
+				}
+			}
+		}
+
+		public override void Down()
+		{
+			foreach (var table in Tables)
+			{
+				if (Schema.Table(table).Exists() && Schema.Table(table).Column("ModifiedOn").Exists())
+				{
+					Delete.Column("ModifiedOn").FromTable(table);
+				}
+			}
+		}
+	}
+}

--- a/Providers/Resgrid.Providers.Migrations/Migrations/M0084_WidenAutofillDataColumn.cs
+++ b/Providers/Resgrid.Providers.Migrations/Migrations/M0084_WidenAutofillDataColumn.cs
@@ -1,0 +1,27 @@
+using System;
+using FluentMigrator;
+
+namespace Resgrid.Providers.Migrations.Migrations
+{
+	/// <summary>
+	/// Widens Autofills.Data (the call-note / autofill template body) from the M0011 default nvarchar(255) to
+	/// nvarchar(max). Users saving a call-note template longer than 255 chars via POST /User/Templates/EditCallNote
+	/// hit SQL error 8152 "String or binary data would be truncated" in RepositoryBase.UpdateAsync.
+	/// </summary>
+	[Migration(84)]
+	public class M0084_WidenAutofillDataColumn : Migration
+	{
+		public override void Up()
+		{
+			if (Schema.Table("Autofills").Exists() && Schema.Table("Autofills").Column("Data").Exists())
+			{
+				Alter.Table("Autofills").AlterColumn("Data").AsString(Int32.MaxValue).Nullable();
+			}
+		}
+
+		public override void Down()
+		{
+			// No-op: narrowing back to nvarchar(255) could truncate existing data.
+		}
+	}
+}

--- a/Providers/Resgrid.Providers.Migrations/Migrations/M0085_WidenAddressColumns.cs
+++ b/Providers/Resgrid.Providers.Migrations/Migrations/M0085_WidenAddressColumns.cs
@@ -1,0 +1,32 @@
+using System;
+using FluentMigrator;
+
+namespace Resgrid.Providers.Migrations.Migrations
+{
+	/// <summary>
+	/// Widens the Addresses columns. Address1 (street address) was nvarchar(200); long addresses saved via Contacts
+	/// edit (and Stations/Groups/Home) hit SQL error 8152 "String or binary data would be truncated" in
+	/// RepositoryBase.UpdateAsync (AddressService.SaveAddressAsync). Street address is free-text and goes to max; the
+	/// shorter fields are padded generously.
+	/// </summary>
+	[Migration(85)]
+	public class M0085_WidenAddressColumns : Migration
+	{
+		public override void Up()
+		{
+			if (Schema.Table("Addresses").Exists())
+			{
+				Alter.Table("Addresses").AlterColumn("Address1").AsString(Int32.MaxValue).NotNullable();
+				Alter.Table("Addresses").AlterColumn("City").AsString(200).NotNullable();
+				Alter.Table("Addresses").AlterColumn("State").AsString(100).NotNullable();
+				Alter.Table("Addresses").AlterColumn("PostalCode").AsString(100).Nullable();
+				Alter.Table("Addresses").AlterColumn("Country").AsString(100).NotNullable();
+			}
+		}
+
+		public override void Down()
+		{
+			// No-op: narrowing back could truncate existing data.
+		}
+	}
+}

--- a/Providers/Resgrid.Providers.Migrations/Migrations/M0085_WidenAddressColumns.cs
+++ b/Providers/Resgrid.Providers.Migrations/Migrations/M0085_WidenAddressColumns.cs
@@ -16,11 +16,15 @@ namespace Resgrid.Providers.Migrations.Migrations
 		{
 			if (Schema.Table("Addresses").Exists())
 			{
-				Alter.Table("Addresses").AlterColumn("Address1").AsString(Int32.MaxValue).NotNullable();
-				Alter.Table("Addresses").AlterColumn("City").AsString(200).NotNullable();
-				Alter.Table("Addresses").AlterColumn("State").AsString(100).NotNullable();
+				// Keep these columns Nullable: the Addresses table predates the migration system and they were never
+				// enforced NOT NULL, so legacy rows may hold NULLs. Enforcing NOT NULL here would fail the migration on
+				// those rows. ([Required] on the Address model already prevents new null saves at the app layer.) This
+				// migration's job is only to widen the columns to stop the 8152 "would be truncated" errors.
+				Alter.Table("Addresses").AlterColumn("Address1").AsString(Int32.MaxValue).Nullable();
+				Alter.Table("Addresses").AlterColumn("City").AsString(200).Nullable();
+				Alter.Table("Addresses").AlterColumn("State").AsString(100).Nullable();
 				Alter.Table("Addresses").AlterColumn("PostalCode").AsString(100).Nullable();
-				Alter.Table("Addresses").AlterColumn("Country").AsString(100).NotNullable();
+				Alter.Table("Addresses").AlterColumn("Country").AsString(100).Nullable();
 			}
 		}
 

--- a/Providers/Resgrid.Providers.MigrationsPg/Migrations/M0081_AddIncidentCommandChangeTrackingPg.cs
+++ b/Providers/Resgrid.Providers.MigrationsPg/Migrations/M0081_AddIncidentCommandChangeTrackingPg.cs
@@ -1,0 +1,59 @@
+using FluentMigrator;
+
+namespace Resgrid.Providers.MigrationsPg.Migrations
+{
+	/// <summary>
+	/// Offline-first sync foundation (PostgreSQL): adds a ModifiedOn change cursor to the mutable incident-command
+	/// tables (delta "changed since" + last-write-wins) and a DeletedOn soft-delete tombstone to commandstructurenodes.
+	/// Append-only tables already carry a natural creation timestamp and are intentionally excluded.
+	/// See docs/architecture/offline-first-architecture.md.
+	/// </summary>
+	[Migration(81)]
+	public class M0081_AddIncidentCommandChangeTrackingPg : Migration
+	{
+		private static readonly string[] ChangeTrackedTables =
+		{
+			"IncidentCommands",
+			"CommandStructureNodes",
+			"ResourceAssignments",
+			"TacticalObjectives",
+			"IncidentTimers",
+			"IncidentMapAnnotations",
+			"IncidentRoleAssignments"
+		};
+
+		public override void Up()
+		{
+			foreach (var table in ChangeTrackedTables)
+			{
+				var t = table.ToLower();
+				if (Schema.Table(t).Exists() && !Schema.Table(t).Column("ModifiedOn".ToLower()).Exists())
+				{
+					Alter.Table(t).AddColumn("ModifiedOn".ToLower()).AsDateTime2().Nullable();
+				}
+			}
+
+			if (Schema.Table("CommandStructureNodes".ToLower()).Exists() && !Schema.Table("CommandStructureNodes".ToLower()).Column("DeletedOn".ToLower()).Exists())
+			{
+				Alter.Table("CommandStructureNodes".ToLower()).AddColumn("DeletedOn".ToLower()).AsDateTime2().Nullable();
+			}
+		}
+
+		public override void Down()
+		{
+			foreach (var table in ChangeTrackedTables)
+			{
+				var t = table.ToLower();
+				if (Schema.Table(t).Exists() && Schema.Table(t).Column("ModifiedOn".ToLower()).Exists())
+				{
+					Delete.Column("ModifiedOn".ToLower()).FromTable(t);
+				}
+			}
+
+			if (Schema.Table("CommandStructureNodes".ToLower()).Exists() && Schema.Table("CommandStructureNodes".ToLower()).Column("DeletedOn".ToLower()).Exists())
+			{
+				Delete.Column("DeletedOn".ToLower()).FromTable("CommandStructureNodes".ToLower());
+			}
+		}
+	}
+}

--- a/Providers/Resgrid.Providers.MigrationsPg/Migrations/M0082_AddCheckInRecordIdempotencyKeyPg.cs
+++ b/Providers/Resgrid.Providers.MigrationsPg/Migrations/M0082_AddCheckInRecordIdempotencyKeyPg.cs
@@ -1,0 +1,28 @@
+using FluentMigrator;
+
+namespace Resgrid.Providers.MigrationsPg.Migrations
+{
+	/// <summary>
+	/// Offline-first action idempotency (PostgreSQL): a client-supplied key on check-in records so a replayed offline
+	/// check-in dedups instead of creating a duplicate row. See docs/architecture/offline-first-architecture.md.
+	/// </summary>
+	[Migration(82)]
+	public class M0082_AddCheckInRecordIdempotencyKeyPg : Migration
+	{
+		public override void Up()
+		{
+			if (Schema.Table("CheckInRecords".ToLower()).Exists() && !Schema.Table("CheckInRecords".ToLower()).Column("IdempotencyKey".ToLower()).Exists())
+			{
+				Alter.Table("CheckInRecords".ToLower()).AddColumn("IdempotencyKey".ToLower()).AsCustom("citext").Nullable();
+			}
+		}
+
+		public override void Down()
+		{
+			if (Schema.Table("CheckInRecords".ToLower()).Exists() && Schema.Table("CheckInRecords".ToLower()).Column("IdempotencyKey".ToLower()).Exists())
+			{
+				Delete.Column("IdempotencyKey".ToLower()).FromTable("CheckInRecords".ToLower());
+			}
+		}
+	}
+}

--- a/Providers/Resgrid.Providers.MigrationsPg/Migrations/M0082_AddCheckInRecordIdempotencyKeyPg.cs
+++ b/Providers/Resgrid.Providers.MigrationsPg/Migrations/M0082_AddCheckInRecordIdempotencyKeyPg.cs
@@ -14,6 +14,10 @@ namespace Resgrid.Providers.MigrationsPg.Migrations
 			if (Schema.Table("CheckInRecords".ToLower()).Exists() && !Schema.Table("CheckInRecords".ToLower()).Column("IdempotencyKey".ToLower()).Exists())
 			{
 				Alter.Table("CheckInRecords".ToLower()).AddColumn("IdempotencyKey".ToLower()).AsCustom("citext").Nullable();
+
+				// At most one check-in per (department, idempotency key). Partial so the many NULL-key (live UI)
+				// check-ins don't collide. Backstops the check-then-insert race in PerformCheckInAsync.
+				Execute.Sql("CREATE UNIQUE INDEX IF NOT EXISTS ux_checkinrecords_department_idempotencykey ON checkinrecords (departmentid, idempotencykey) WHERE idempotencykey IS NOT NULL;");
 			}
 		}
 
@@ -21,6 +25,7 @@ namespace Resgrid.Providers.MigrationsPg.Migrations
 		{
 			if (Schema.Table("CheckInRecords".ToLower()).Exists() && Schema.Table("CheckInRecords".ToLower()).Column("IdempotencyKey".ToLower()).Exists())
 			{
+				Execute.Sql("DROP INDEX IF EXISTS ux_checkinrecords_department_idempotencykey;");
 				Delete.Column("IdempotencyKey".ToLower()).FromTable("CheckInRecords".ToLower());
 			}
 		}

--- a/Providers/Resgrid.Providers.MigrationsPg/Migrations/M0083_AddAdHocResourceChangeTrackingPg.cs
+++ b/Providers/Resgrid.Providers.MigrationsPg/Migrations/M0083_AddAdHocResourceChangeTrackingPg.cs
@@ -1,0 +1,38 @@
+using FluentMigrator;
+
+namespace Resgrid.Providers.MigrationsPg.Migrations
+{
+	/// <summary>
+	/// Offline-first (PostgreSQL): adds a ModifiedOn change cursor to the ad-hoc incident resource tables so they
+	/// participate in the /Sync/Changes delta pull. See docs/architecture/offline-first-architecture.md.
+	/// </summary>
+	[Migration(83)]
+	public class M0083_AddAdHocResourceChangeTrackingPg : Migration
+	{
+		private static readonly string[] Tables = { "IncidentAdHocUnits", "IncidentAdHocPersonnel" };
+
+		public override void Up()
+		{
+			foreach (var table in Tables)
+			{
+				var t = table.ToLower();
+				if (Schema.Table(t).Exists() && !Schema.Table(t).Column("ModifiedOn".ToLower()).Exists())
+				{
+					Alter.Table(t).AddColumn("ModifiedOn".ToLower()).AsDateTime2().Nullable();
+				}
+			}
+		}
+
+		public override void Down()
+		{
+			foreach (var table in Tables)
+			{
+				var t = table.ToLower();
+				if (Schema.Table(t).Exists() && Schema.Table(t).Column("ModifiedOn".ToLower()).Exists())
+				{
+					Delete.Column("ModifiedOn".ToLower()).FromTable(t);
+				}
+			}
+		}
+	}
+}

--- a/Providers/Resgrid.Providers.MigrationsPg/Migrations/M0084_WidenAutofillDataColumnPg.cs
+++ b/Providers/Resgrid.Providers.MigrationsPg/Migrations/M0084_WidenAutofillDataColumnPg.cs
@@ -1,0 +1,25 @@
+using FluentMigrator;
+
+namespace Resgrid.Providers.MigrationsPg.Migrations
+{
+	/// <summary>
+	/// PostgreSQL twin of the Autofills.Data widening: ensure the call-note / autofill template body is unbounded
+	/// (text) so long templates don't truncate. See M0084_WidenAutofillDataColumn (SQL Server).
+	/// </summary>
+	[Migration(84)]
+	public class M0084_WidenAutofillDataColumnPg : Migration
+	{
+		public override void Up()
+		{
+			if (Schema.Table("autofills").Exists() && Schema.Table("autofills").Column("data").Exists())
+			{
+				Alter.Table("autofills").AlterColumn("data").AsCustom("text").Nullable();
+			}
+		}
+
+		public override void Down()
+		{
+			// No-op: narrowing could truncate existing data.
+		}
+	}
+}

--- a/Providers/Resgrid.Providers.MigrationsPg/Migrations/M0085_WidenAddressColumnsPg.cs
+++ b/Providers/Resgrid.Providers.MigrationsPg/Migrations/M0085_WidenAddressColumnsPg.cs
@@ -1,0 +1,26 @@
+using FluentMigrator;
+
+namespace Resgrid.Providers.MigrationsPg.Migrations
+{
+	/// <summary>
+	/// PostgreSQL twin of the Addresses widening. PG string columns are typically citext/unbounded (so the SQL-Server
+	/// 8152 truncation does not occur here), but ensure the free-text street address is unbounded for parity.
+	/// See M0085_WidenAddressColumns (SQL Server).
+	/// </summary>
+	[Migration(85)]
+	public class M0085_WidenAddressColumnsPg : Migration
+	{
+		public override void Up()
+		{
+			if (Schema.Table("addresses").Exists() && Schema.Table("addresses").Column("address1").Exists())
+			{
+				Alter.Table("addresses").AlterColumn("address1").AsCustom("text").NotNullable();
+			}
+		}
+
+		public override void Down()
+		{
+			// No-op: narrowing could truncate existing data.
+		}
+	}
+}

--- a/Providers/Resgrid.Providers.MigrationsPg/Migrations/M0085_WidenAddressColumnsPg.cs
+++ b/Providers/Resgrid.Providers.MigrationsPg/Migrations/M0085_WidenAddressColumnsPg.cs
@@ -14,7 +14,8 @@ namespace Resgrid.Providers.MigrationsPg.Migrations
 		{
 			if (Schema.Table("addresses").Exists() && Schema.Table("addresses").Column("address1").Exists())
 			{
-				Alter.Table("addresses").AlterColumn("address1").AsCustom("text").NotNullable();
+				// Keep Nullable (see M0085_WidenAddressColumns): legacy rows may hold NULLs, so NOT NULL would fail.
+				Alter.Table("addresses").AlterColumn("address1").AsCustom("text").Nullable();
 			}
 		}
 

--- a/Providers/Resgrid.Providers.Number/TextMessageProvider.cs
+++ b/Providers/Resgrid.Providers.Number/TextMessageProvider.cs
@@ -28,6 +28,11 @@ namespace Resgrid.Providers.NumberProvider
 
 		public async Task<bool> SendTextMessage(string number, string message, string departmentNumber, MobileCarriers carrier, int departmentId, bool forceGateway = false, bool isCall = false)
 		{
+			// Single chokepoint for every outbound SMS path below (Twilio + SignalWire fallback): strip non-allow-listed
+			// URLs (carrier deliverability) and cap length (cost + avoid Twilio error 21617 at 1600 chars) before sending.
+			message = SmsContentHelper.PrepareForSms(message, Config.SystemBehaviorConfig.SmsMaxLength,
+				(Config.SystemBehaviorConfig.SmsAllowedUrlDomains ?? string.Empty).Split(',', StringSplitOptions.RemoveEmptyEntries));
+
 			var wasTwillioSuccessful = await SendTextMessageViaTwillio(number, message, departmentNumber);
 
 			if (!wasTwillioSuccessful && isCall)
@@ -153,6 +158,13 @@ namespace Resgrid.Providers.NumberProvider
 					return true;
 				else
 					return false;
+			}
+			catch (Twilio.Exceptions.ApiException ex) when (ex.Code == 21211 || ex.Code == 21214 || ex.Code == 21217 || ex.Code == 21614)
+			{
+				// Invalid / unreachable 'To' number - bad input, not a system fault. Log quietly so these don't flood
+				// Sentry as fatals; the caller still gets false and can surface a validation message to the user.
+				Framework.Logging.LogInfo($"Twilio rejected an invalid 'To' number (code {ex.Code}): {ex.Message}");
+				return false;
 			}
 			catch (Exception ex)
 			{

--- a/Providers/Resgrid.Providers.Workflow/Executors/TwilioSmsExecutor.cs
+++ b/Providers/Resgrid.Providers.Workflow/Executors/TwilioSmsExecutor.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Resgrid.Config;
+using Resgrid.Framework;
 using Resgrid.Model;
 using Resgrid.Model.Providers;
 using Twilio.Clients;
@@ -55,11 +56,15 @@ namespace Resgrid.Providers.Workflow.Executors
 
 				var twilioClient = new TwilioRestClient(cred.AccountSid, cred.AuthToken);
 
+				// Strip non-allow-listed URLs (carrier deliverability) and cap length (cost + avoid Twilio error 21617).
+				var body = SmsContentHelper.PrepareForSms(context.RenderedContent, SystemBehaviorConfig.SmsMaxLength,
+					(SystemBehaviorConfig.SmsAllowedUrlDomains ?? string.Empty).Split(',', StringSplitOptions.RemoveEmptyEntries));
+
 				string lastSid = null;
 				foreach (var recipient in recipients)
 				{
 					var message = await MessageResource.CreateAsync(
-						body: context.RenderedContent,
+						body: body,
 						from: new Twilio.Types.PhoneNumber(cred.FromNumber),
 						to: new Twilio.Types.PhoneNumber(recipient),
 						client: twilioClient);

--- a/Repositories/Resgrid.Repositories.DataRepository/HealthRepository.cs
+++ b/Repositories/Resgrid.Repositories.DataRepository/HealthRepository.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Dapper;
+using Resgrid.Framework;
 using Resgrid.Model.Repositories;
 using Resgrid.Model.Repositories.Connection;
 
@@ -33,8 +34,11 @@ namespace Resgrid.Repositories.DataRepository
 					return timestamp == default(DateTime) ? null : timestamp.ToString("o");
 				}
 			}
-			catch (Exception)
+			catch (Exception ex)
 			{
+				// Log so a failing health check (DatabaseOnline = false) is diagnosable instead of silently swallowed;
+				// keep returning null so the caller still reports the DB as offline rather than throwing.
+				Logging.LogException(ex, "HealthRepository.GetDatabaseCurrentTime database connectivity check failed");
 				return null;
 			}
 		}

--- a/Repositories/Resgrid.Repositories.DataRepository/HealthRepository.cs
+++ b/Repositories/Resgrid.Repositories.DataRepository/HealthRepository.cs
@@ -1,26 +1,36 @@
-﻿using System;
-using System.Data;
-using Microsoft.Data.SqlClient;
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Dapper;
 using Resgrid.Model.Repositories;
+using Resgrid.Model.Repositories.Connection;
 
 namespace Resgrid.Repositories.DataRepository
 {
 	public class HealthRepository : IHealthRepository
 	{
+		private readonly IConnectionProvider _connectionProvider;
+
+		public HealthRepository(IConnectionProvider connectionProvider)
+		{
+			_connectionProvider = connectionProvider;
+		}
+
 		public async Task<string> GetDatabaseCurrentTime()
 		{
-			var query = $@"SELECT GETDATE()";
+			// Use the configured connection provider (SQL Server OR PostgreSQL) and a portable query.
+			// CURRENT_TIMESTAMP is valid on both engines; the old hardcoded SqlConnection + GETDATE() always threw
+			// on PostgreSQL-backed datacenters, so the health check reported DatabaseOnline = false there.
+			const string query = "SELECT CURRENT_TIMESTAMP";
 
 			try
 			{
-				using (IDbConnection db = new SqlConnection(Config.DataConfig.ConnectionString))
+				using (var db = _connectionProvider.Create())
 				{
-					var results = await db.QueryAsync<string>(query);
+					var results = await db.QueryAsync<DateTime>(query);
+					var timestamp = results.FirstOrDefault();
 
-					return results.FirstOrDefault();
+					return timestamp == default(DateTime) ? null : timestamp.ToString("o");
 				}
 			}
 			catch (Exception)

--- a/Tests/Resgrid.Tests/Services/CheckInTimerServiceTests.cs
+++ b/Tests/Resgrid.Tests/Services/CheckInTimerServiceTests.cs
@@ -308,11 +308,30 @@ namespace Resgrid.Tests.Services
 				.ReturnsAsync(new List<CheckInRecord>())
 				.ReturnsAsync(new List<CheckInRecord> { winner });
 			_recordRepo.Setup(x => x.SaveOrUpdateAsync(It.IsAny<CheckInRecord>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()))
-				.ThrowsAsync(new Exception("unique constraint violation"));
+				.ThrowsAsync(new FakeDbException("23505: duplicate key value violates unique constraint"));
 
 			var result = await _service.PerformCheckInAsync(new CheckInRecord { DepartmentId = 10, CallId = 1, UserId = "user1", IdempotencyKey = "evt-1" });
 
 			result.Should().BeSameAs(winner);
+		}
+
+		[Test]
+		public async Task PerformCheckInAsync_NonDatabaseError_Propagates_NotMaskedAsReplay()
+		{
+			// A non-DbException must NOT be swallowed as an idempotent replay even when a key is present.
+			_recordRepo.Setup(x => x.GetByCallIdAsync(1)).ReturnsAsync(new List<CheckInRecord>());
+			_recordRepo.Setup(x => x.SaveOrUpdateAsync(It.IsAny<CheckInRecord>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()))
+				.ThrowsAsync(new InvalidOperationException("boom"));
+
+			Func<Task> act = async () => await _service.PerformCheckInAsync(new CheckInRecord { DepartmentId = 10, CallId = 1, UserId = "user1", IdempotencyKey = "evt-1" });
+
+			await act.Should().ThrowAsync<InvalidOperationException>();
+		}
+
+		// Minimal concrete DbException (the framework type is abstract) to simulate a provider unique-constraint violation.
+		private sealed class FakeDbException : System.Data.Common.DbException
+		{
+			public FakeDbException(string message) : base(message) { }
 		}
 
 		[Test]

--- a/Tests/Resgrid.Tests/Services/CheckInTimerServiceTests.cs
+++ b/Tests/Resgrid.Tests/Services/CheckInTimerServiceTests.cs
@@ -271,6 +271,34 @@ namespace Resgrid.Tests.Services
 		}
 
 		[Test]
+		public async Task PerformCheckInAsync_WithIdempotencyKey_ReturnsExistingRecord_WithoutDuplicateInsert()
+		{
+			// A check-in with this key was already recorded for the call (the client's outbox is replaying it).
+			var existing = new CheckInRecord { CheckInRecordId = "existing-1", DepartmentId = 10, CallId = 1, UserId = "user1", IdempotencyKey = "evt-1", Timestamp = DateTime.UtcNow.AddMinutes(-1) };
+			_recordRepo.Setup(x => x.GetByCallIdAsync(1)).ReturnsAsync(new List<CheckInRecord> { existing });
+
+			var replay = new CheckInRecord { DepartmentId = 10, CallId = 1, UserId = "user1", IdempotencyKey = "evt-1" };
+			var result = await _service.PerformCheckInAsync(replay);
+
+			result.Should().BeSameAs(existing);
+			_recordRepo.Verify(x => x.SaveOrUpdateAsync(It.IsAny<CheckInRecord>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()), Times.Never);
+		}
+
+		[Test]
+		public async Task PerformCheckInAsync_WithNewIdempotencyKey_Inserts()
+		{
+			_recordRepo.Setup(x => x.GetByCallIdAsync(1)).ReturnsAsync(new List<CheckInRecord>()); // key not seen yet
+			_recordRepo.Setup(x => x.SaveOrUpdateAsync(It.IsAny<CheckInRecord>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()))
+				.ReturnsAsync((CheckInRecord r, CancellationToken ct, bool b) => { r.CheckInRecordId = "new-id"; return r; });
+
+			var record = new CheckInRecord { DepartmentId = 10, CallId = 1, UserId = "user1", IdempotencyKey = "evt-2" };
+			var result = await _service.PerformCheckInAsync(record);
+
+			result.CheckInRecordId.Should().Be("new-id");
+			_recordRepo.Verify(x => x.SaveOrUpdateAsync(It.IsAny<CheckInRecord>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()), Times.Once);
+		}
+
+		[Test]
 		public async Task GetLastCheckInAsync_ReturnsUserCheckIn_WhenNoUnitId()
 		{
 			var checkIn = new CheckInRecord { CheckInRecordId = "ci1", UserId = "user1", CallId = 1 };

--- a/Tests/Resgrid.Tests/Services/CheckInTimerServiceTests.cs
+++ b/Tests/Resgrid.Tests/Services/CheckInTimerServiceTests.cs
@@ -299,6 +299,23 @@ namespace Resgrid.Tests.Services
 		}
 
 		[Test]
+		public async Task PerformCheckInAsync_OnConcurrentReplayUniqueViolation_AdoptsTheWinningRecord()
+		{
+			var winner = new CheckInRecord { CheckInRecordId = "winner-1", DepartmentId = 10, CallId = 1, UserId = "user1", IdempotencyKey = "evt-1" };
+			// Race: our pre-check sees nothing, a concurrent replay commits first, so our insert hits the unique
+			// index; the post-violation re-query then finds the winner and we adopt it instead of 500ing.
+			_recordRepo.SetupSequence(x => x.GetByCallIdAsync(1))
+				.ReturnsAsync(new List<CheckInRecord>())
+				.ReturnsAsync(new List<CheckInRecord> { winner });
+			_recordRepo.Setup(x => x.SaveOrUpdateAsync(It.IsAny<CheckInRecord>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()))
+				.ThrowsAsync(new Exception("unique constraint violation"));
+
+			var result = await _service.PerformCheckInAsync(new CheckInRecord { DepartmentId = 10, CallId = 1, UserId = "user1", IdempotencyKey = "evt-1" });
+
+			result.Should().BeSameAs(winner);
+		}
+
+		[Test]
 		public async Task GetLastCheckInAsync_ReturnsUserCheckIn_WhenNoUnitId()
 		{
 			var checkIn = new CheckInRecord { CheckInRecordId = "ci1", UserId = "user1", CallId = 1 };

--- a/Tests/Resgrid.Tests/Services/ContactVerificationServiceTests.cs
+++ b/Tests/Resgrid.Tests/Services/ContactVerificationServiceTests.cs
@@ -23,6 +23,7 @@ namespace Resgrid.Tests.Services
 			protected Mock<ISystemAuditsService> _systemAuditsServiceMock;
 			protected Mock<IEncryptionService> _encryptionServiceMock;
 			protected Mock<IOutboundVoiceProvider> _outboundVoiceProviderMock;
+			protected Mock<IPhoneNumberProcesserProvider> _phoneNumberProcesserMock;
 			protected IContactVerificationService _contactVerificationService;
 
 			protected with_the_contact_verification_service()
@@ -52,6 +53,13 @@ namespace Resgrid.Tests.Services
 					.Setup(v => v.SendVoiceVerificationCallAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>()))
 					.ReturnsAsync(true);
 
+				// Phone processor: by default treat numbers as valid and echo them back as the "international" form so
+				// the send paths proceed; individual tests can override to simulate an invalid/unsendable number.
+				_phoneNumberProcesserMock = new Mock<IPhoneNumberProcesserProvider>();
+				_phoneNumberProcesserMock
+					.Setup(p => p.Process(It.IsAny<string>(), It.IsAny<string>()))
+					.Returns<string, string>((num, cc) => new PhoneNumberResult { IsValid = !string.IsNullOrWhiteSpace(num), InternationalNumber = num, LocalNumber = num });
+
 				_contactVerificationService = new ContactVerificationService(
 					_userProfileServiceMock.Object,
 					_usersServiceMock.Object,
@@ -59,7 +67,8 @@ namespace Resgrid.Tests.Services
 					_smsServiceMock.Object,
 					_systemAuditsServiceMock.Object,
 					_encryptionServiceMock.Object,
-					_outboundVoiceProviderMock.Object);
+					_outboundVoiceProviderMock.Object,
+					_phoneNumberProcesserMock.Object);
 			}
 
 			protected static UserProfile BuildProfile(string userId = "user1",

--- a/Tests/Resgrid.Tests/Services/IncidentCommandServiceParTests.cs
+++ b/Tests/Resgrid.Tests/Services/IncidentCommandServiceParTests.cs
@@ -483,5 +483,21 @@ namespace Resgrid.Tests.Services
 			changes.Commands.Should().ContainSingle().Which.IncidentCommandId.Should().Be("c-new");
 			changes.Nodes.Should().ContainSingle().Which.DeletedOn.Should().NotBeNull();
 		}
+
+		[Test]
+		public async Task GetChangesSinceAsync_FullSync_ReturnsAllRowsIncludingNullModifiedOn()
+		{
+			_commandRepo.Setup(x => x.GetAllByDepartmentIdAsync(Dept)).ReturnsAsync(new List<IncidentCommand>
+			{
+				new IncidentCommand { IncidentCommandId = "c-tracked", DepartmentId = Dept, CallId = CallId, ModifiedOn = DateTime.UtcNow },
+				new IncidentCommand { IncidentCommandId = "c-legacy", DepartmentId = Dept, CallId = CallId, ModifiedOn = null } // never stamped
+			});
+
+			// since=0 maps to DateTime.MinValue in the controller — the full pull must include the legacy null row.
+			var changes = await _service.GetChangesSinceAsync(Dept, DateTime.MinValue);
+
+			changes.Commands.Should().HaveCount(2);
+			changes.Commands.Should().Contain(c => c.IncidentCommandId == "c-legacy");
+		}
 	}
 }

--- a/Tests/Resgrid.Tests/Services/IncidentCommandServiceParTests.cs
+++ b/Tests/Resgrid.Tests/Services/IncidentCommandServiceParTests.cs
@@ -61,8 +61,8 @@ namespace Resgrid.Tests.Services
 			_eventAggregator = new Mock<IEventAggregator>();
 			_coreEventService = new Mock<ICoreEventService>();
 
-			// The marker write echoes back the entry so WriteLogAsync resolves a non-null result.
-			_logRepo.Setup(x => x.SaveOrUpdateAsync(It.IsAny<CommandLogEntry>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()))
+			// Timeline entries are append-only inserts; echo back the entry so WriteLogAsync resolves a non-null result.
+			_logRepo.Setup(x => x.InsertAsync(It.IsAny<CommandLogEntry>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()))
 				.ReturnsAsync((CommandLogEntry e, CancellationToken ct, bool b) => e);
 
 			_service = new IncidentCommandService(_commandRepo.Object, _nodeRepo.Object, _assignmentRepo.Object,
@@ -126,7 +126,7 @@ namespace Resgrid.Tests.Services
 			result.Should().ContainSingle().Which.Should().Be("user1");
 			_eventAggregator.Verify(x => x.SendMessage(It.Is<CriticalParDetectedEvent>(
 				e => e.UserId == "user1" && e.CallId == CallId && e.DepartmentId == Dept)), Times.Once);
-			_logRepo.Verify(x => x.SaveOrUpdateAsync(
+			_logRepo.Verify(x => x.InsertAsync(
 				It.Is<CommandLogEntry>(e => e.EntryType == (int)CommandLogEntryType.ParCritical && e.UserId == "user1"),
 				It.IsAny<CancellationToken>(), It.IsAny<bool>()), Times.Once);
 		}
@@ -150,7 +150,7 @@ namespace Resgrid.Tests.Services
 
 			result.Should().BeEmpty();
 			_eventAggregator.Verify(x => x.SendMessage(It.IsAny<CriticalParDetectedEvent>()), Times.Never);
-			_logRepo.Verify(x => x.SaveOrUpdateAsync(It.IsAny<CommandLogEntry>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()), Times.Never);
+			_logRepo.Verify(x => x.InsertAsync(It.IsAny<CommandLogEntry>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()), Times.Never);
 		}
 
 		[Test]
@@ -254,7 +254,7 @@ namespace Resgrid.Tests.Services
 			{
 				IncidentCommandId = "ic1", DepartmentId = Dept, CallId = CallId, Status = (int)IncidentCommandStatus.Active
 			});
-			_nodeRepo.Setup(x => x.SaveOrUpdateAsync(It.IsAny<CommandStructureNode>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()))
+			_nodeRepo.Setup(x => x.InsertAsync(It.IsAny<CommandStructureNode>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()))
 				.ReturnsAsync((CommandStructureNode n, CancellationToken ct, bool b) => n);
 
 			var node = new CommandStructureNode { IncidentCommandId = "ic1", DepartmentId = Dept, CallId = 999, Name = "Staging" };
@@ -329,6 +329,159 @@ namespace Resgrid.Tests.Services
 			var result = await _service.MoveResourceAsync(Dept, "ra1", "ghost", "user1");
 
 			result.Should().BeNull();
+		}
+
+		// Offline-first change tracking: every mutation stamps ModifiedOn (the delta "changed since" cursor) and a
+		// lane removal is a soft-delete tombstone (DeletedOn), so removals propagate to offline clients on delta sync.
+
+		[Test]
+		public async Task SaveNodeAsync_StampsModifiedOn_OnSave()
+		{
+			_commandRepo.Setup(x => x.GetByIdAsync("ic1")).ReturnsAsync(new IncidentCommand
+			{
+				IncidentCommandId = "ic1", DepartmentId = Dept, CallId = CallId, Status = (int)IncidentCommandStatus.Active
+			});
+			_nodeRepo.Setup(x => x.InsertAsync(It.IsAny<CommandStructureNode>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()))
+				.ReturnsAsync((CommandStructureNode n, CancellationToken ct, bool b) => n);
+
+			var node = new CommandStructureNode { IncidentCommandId = "ic1", DepartmentId = Dept, CallId = CallId, Name = "Staging" };
+			var saved = await _service.SaveNodeAsync(node, "user1");
+
+			saved.Should().NotBeNull();
+			saved.ModifiedOn.Should().NotBeNull();
+		}
+
+		// Idempotent creates (offline replay): the client generates the GUID PK offline. A brand-new client id must
+		// INSERT (not be rejected as a missing-row update); a replayed id must UPDATE the same row (no duplicate);
+		// an id owned by another department must be rejected.
+
+		[Test]
+		public async Task SaveNodeAsync_WithClientSuppliedId_NotYetPersisted_InsertsWithThatId()
+		{
+			const string clientId = "client-guid-1";
+			_commandRepo.Setup(x => x.GetByIdAsync("ic1")).ReturnsAsync(new IncidentCommand
+			{
+				IncidentCommandId = "ic1", DepartmentId = Dept, CallId = CallId, Status = (int)IncidentCommandStatus.Active
+			});
+			_nodeRepo.Setup(x => x.GetByIdAsync(clientId)).ReturnsAsync((CommandStructureNode)null); // not persisted yet
+			_nodeRepo.Setup(x => x.InsertAsync(It.IsAny<CommandStructureNode>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()))
+				.ReturnsAsync((CommandStructureNode n, CancellationToken ct, bool b) => n);
+
+			var node = new CommandStructureNode { CommandStructureNodeId = clientId, IncidentCommandId = "ic1", DepartmentId = Dept, Name = "Staging" };
+			var saved = await _service.SaveNodeAsync(node, "user1");
+
+			saved.Should().NotBeNull();
+			saved.CommandStructureNodeId.Should().Be(clientId); // honored the client GUID, did not generate a new one
+			_nodeRepo.Verify(x => x.InsertAsync(It.IsAny<CommandStructureNode>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()), Times.Once);
+			_nodeRepo.Verify(x => x.SaveOrUpdateAsync(It.IsAny<CommandStructureNode>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()), Times.Never);
+		}
+
+		[Test]
+		public async Task SaveNodeAsync_WithClientSuppliedId_AlreadyPersisted_Updates_WithoutDuplicateInsert()
+		{
+			const string clientId = "client-guid-1";
+			_commandRepo.Setup(x => x.GetByIdAsync("ic1")).ReturnsAsync(new IncidentCommand
+			{
+				IncidentCommandId = "ic1", DepartmentId = Dept, CallId = CallId, Status = (int)IncidentCommandStatus.Active
+			});
+			// Replay: the row already exists for this department.
+			_nodeRepo.Setup(x => x.GetByIdAsync(clientId)).ReturnsAsync(new CommandStructureNode
+			{
+				CommandStructureNodeId = clientId, IncidentCommandId = "ic1", DepartmentId = Dept, CallId = CallId, Name = "Staging"
+			});
+			_nodeRepo.Setup(x => x.SaveOrUpdateAsync(It.IsAny<CommandStructureNode>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()))
+				.ReturnsAsync((CommandStructureNode n, CancellationToken ct, bool b) => n);
+
+			var node = new CommandStructureNode { CommandStructureNodeId = clientId, IncidentCommandId = "ic1", DepartmentId = Dept, Name = "Staging (edited)" };
+			var saved = await _service.SaveNodeAsync(node, "user1");
+
+			saved.Should().NotBeNull();
+			_nodeRepo.Verify(x => x.SaveOrUpdateAsync(It.IsAny<CommandStructureNode>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()), Times.Once);
+			_nodeRepo.Verify(x => x.InsertAsync(It.IsAny<CommandStructureNode>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()), Times.Never);
+		}
+
+		[Test]
+		public async Task SaveNodeAsync_WithClientSuppliedId_OwnedByAnotherDepartment_ReturnsNull()
+		{
+			const string clientId = "client-guid-1";
+			_commandRepo.Setup(x => x.GetByIdAsync("ic1")).ReturnsAsync(new IncidentCommand
+			{
+				IncidentCommandId = "ic1", DepartmentId = Dept, CallId = CallId, Status = (int)IncidentCommandStatus.Active
+			});
+			// A row with that id exists but belongs to another department — reject, never take it over.
+			_nodeRepo.Setup(x => x.GetByIdAsync(clientId)).ReturnsAsync(new CommandStructureNode
+			{
+				CommandStructureNodeId = clientId, DepartmentId = 99, CallId = CallId
+			});
+
+			var node = new CommandStructureNode { CommandStructureNodeId = clientId, IncidentCommandId = "ic1", DepartmentId = Dept, Name = "Staging" };
+			var saved = await _service.SaveNodeAsync(node, "user1");
+
+			saved.Should().BeNull();
+			_nodeRepo.Verify(x => x.InsertAsync(It.IsAny<CommandStructureNode>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()), Times.Never);
+			_nodeRepo.Verify(x => x.SaveOrUpdateAsync(It.IsAny<CommandStructureNode>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()), Times.Never);
+		}
+
+		[Test]
+		public async Task DeleteNodeAsync_SoftDeletes_SetsDeletedOnAndModifiedOn_AndPersistsInsteadOfHardDeleting()
+		{
+			CommandStructureNode persisted = null;
+			_nodeRepo.Setup(x => x.GetByIdAsync("node-1")).ReturnsAsync(new CommandStructureNode
+			{
+				CommandStructureNodeId = "node-1", DepartmentId = Dept, CallId = CallId, IncidentCommandId = "ic1", Name = "Staging"
+			});
+			// A hard delete would never call SaveOrUpdate; capturing it here proves the removal is a soft-delete.
+			_nodeRepo.Setup(x => x.SaveOrUpdateAsync(It.IsAny<CommandStructureNode>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()))
+				.Callback((CommandStructureNode n, CancellationToken ct, bool b) => persisted = n)
+				.ReturnsAsync((CommandStructureNode n, CancellationToken ct, bool b) => n);
+
+			var result = await _service.DeleteNodeAsync(Dept, "node-1", "user1");
+
+			result.Should().BeTrue();
+			persisted.Should().NotBeNull();
+			persisted.DeletedOn.Should().NotBeNull();
+			persisted.ModifiedOn.Should().NotBeNull();
+		}
+
+		[Test]
+		public async Task GetNodesForCallAsync_ExcludesSoftDeletedNodes()
+		{
+			_nodeRepo.Setup(x => x.GetAllByDepartmentIdAsync(Dept)).ReturnsAsync(new List<CommandStructureNode>
+			{
+				new CommandStructureNode { CommandStructureNodeId = "n1", DepartmentId = Dept, CallId = CallId, Name = "Live", SortOrder = 1 },
+				new CommandStructureNode { CommandStructureNodeId = "n2", DepartmentId = Dept, CallId = CallId, Name = "Removed", SortOrder = 2, DeletedOn = DateTime.UtcNow }
+			});
+
+			var nodes = await _service.GetNodesForCallAsync(Dept, CallId);
+
+			nodes.Should().ContainSingle().Which.CommandStructureNodeId.Should().Be("n1");
+		}
+
+		// Delta pull (offline reconnect): returns only rows changed after the cursor — INCLUDING soft-deleted rows so
+		// the client can remove them locally; rows with no ModifiedOn or an older ModifiedOn are excluded.
+
+		[Test]
+		public async Task GetChangesSinceAsync_ReturnsOnlyRowsChangedAfterCursor_IncludingSoftDeleted()
+		{
+			var since = DateTime.UtcNow.AddMinutes(-10);
+
+			_commandRepo.Setup(x => x.GetAllByDepartmentIdAsync(Dept)).ReturnsAsync(new List<IncidentCommand>
+			{
+				new IncidentCommand { IncidentCommandId = "c-new", DepartmentId = Dept, CallId = CallId, ModifiedOn = DateTime.UtcNow },
+				new IncidentCommand { IncidentCommandId = "c-old", DepartmentId = Dept, CallId = CallId, ModifiedOn = since.AddMinutes(-5) },
+				new IncidentCommand { IncidentCommandId = "c-null", DepartmentId = Dept, CallId = CallId, ModifiedOn = null }
+			});
+			_nodeRepo.Setup(x => x.GetAllByDepartmentIdAsync(Dept)).ReturnsAsync(new List<CommandStructureNode>
+			{
+				// A lane soft-deleted after the cursor must be INCLUDED (with DeletedOn) so the client removes it.
+				new CommandStructureNode { CommandStructureNodeId = "n-del", DepartmentId = Dept, CallId = CallId, DeletedOn = DateTime.UtcNow, ModifiedOn = DateTime.UtcNow }
+			});
+
+			var changes = await _service.GetChangesSinceAsync(Dept, since);
+
+			changes.ServerTimestampMs.Should().BeGreaterThan(0);
+			changes.Commands.Should().ContainSingle().Which.IncidentCommandId.Should().Be("c-new");
+			changes.Nodes.Should().ContainSingle().Which.DeletedOn.Should().NotBeNull();
 		}
 	}
 }

--- a/Tests/Resgrid.Tests/Services/IncidentResourcesServiceTests.cs
+++ b/Tests/Resgrid.Tests/Services/IncidentResourcesServiceTests.cs
@@ -176,5 +176,19 @@ namespace Resgrid.Tests.Services
 			units.Should().ContainSingle().Which.IncidentAdHocUnitId.Should().Be("u-new");
 			personnel.Should().ContainSingle().Which.IncidentAdHocPersonnelId.Should().Be("p-rel");
 		}
+
+		[Test]
+		public async Task GetAdHocChangesSinceAsync_FullSync_IncludesNullModifiedOnRows()
+		{
+			_unitRepo.Setup(x => x.GetAllByDepartmentIdAsync(Dept)).ReturnsAsync(new List<IncidentAdHocUnit>
+			{
+				new IncidentAdHocUnit { IncidentAdHocUnitId = "u-legacy", DepartmentId = Dept, CallId = CallId, ModifiedOn = null }
+			});
+			_personnelRepo.Setup(x => x.GetAllByDepartmentIdAsync(Dept)).ReturnsAsync(new List<IncidentAdHocPersonnel>());
+
+			var (units, _) = await _service.GetAdHocChangesSinceAsync(Dept, DateTime.MinValue);
+
+			units.Should().ContainSingle().Which.IncidentAdHocUnitId.Should().Be("u-legacy");
+		}
 	}
 }

--- a/Tests/Resgrid.Tests/Services/IncidentResourcesServiceTests.cs
+++ b/Tests/Resgrid.Tests/Services/IncidentResourcesServiceTests.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using Resgrid.Model;
+using Resgrid.Model.Providers;
+using Resgrid.Model.Repositories;
+using Resgrid.Model.Services;
+using Resgrid.Services;
+
+namespace Resgrid.Tests.Services
+{
+	/// <summary>
+	/// Covers idempotent ad-hoc resource creation: the create must actually INSERT (a pre-set GUID + SaveOrUpdateAsync
+	/// would be a silent 0-row UPDATE), honor a client-supplied GUID, treat a replayed id as a no-op (return the stored
+	/// row, no duplicate), and reject an id owned by another department.
+	/// </summary>
+	[TestFixture]
+	public class IncidentResourcesServiceTests
+	{
+		private const int Dept = 10;
+		private const int CallId = 7;
+
+		private Mock<IIncidentAdHocUnitRepository> _unitRepo;
+		private Mock<IIncidentAdHocPersonnelRepository> _personnelRepo;
+		private Mock<IIncidentCommandService> _commandService;
+		private Mock<IEventAggregator> _eventAggregator;
+		private IncidentResourcesService _service;
+
+		[SetUp]
+		public void SetUp()
+		{
+			_unitRepo = new Mock<IIncidentAdHocUnitRepository>();
+			_personnelRepo = new Mock<IIncidentAdHocPersonnelRepository>();
+			_commandService = new Mock<IIncidentCommandService>();
+			_eventAggregator = new Mock<IEventAggregator>();
+
+			_service = new IncidentResourcesService(_unitRepo.Object, _personnelRepo.Object, _commandService.Object, _eventAggregator.Object);
+		}
+
+		private void ArrangeActiveCommand()
+		{
+			_commandService.Setup(x => x.GetActiveCommandForCallAsync(Dept, CallId)).ReturnsAsync(new IncidentCommand
+			{
+				IncidentCommandId = "ic1", DepartmentId = Dept, CallId = CallId, Status = (int)IncidentCommandStatus.Active
+			});
+		}
+
+		[Test]
+		public async Task CreateAdHocUnitAsync_ReturnsNull_WhenNoActiveCommandForCall()
+		{
+			_commandService.Setup(x => x.GetActiveCommandForCallAsync(Dept, CallId)).ReturnsAsync((IncidentCommand)null);
+
+			var result = await _service.CreateAdHocUnitAsync(new IncidentAdHocUnit { DepartmentId = Dept, CallId = CallId, Name = "Engine 1" }, "user1");
+
+			result.Should().BeNull();
+			_unitRepo.Verify(x => x.InsertAsync(It.IsAny<IncidentAdHocUnit>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()), Times.Never);
+		}
+
+		[Test]
+		public async Task CreateAdHocUnitAsync_NoId_GeneratesIdAndInserts()
+		{
+			ArrangeActiveCommand();
+			_unitRepo.Setup(x => x.InsertAsync(It.IsAny<IncidentAdHocUnit>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()))
+				.ReturnsAsync((IncidentAdHocUnit u, CancellationToken ct, bool b) => u);
+
+			var result = await _service.CreateAdHocUnitAsync(new IncidentAdHocUnit { DepartmentId = Dept, CallId = CallId, Name = "Engine 1" }, "user1");
+
+			result.Should().NotBeNull();
+			result.IncidentAdHocUnitId.Should().NotBeNullOrEmpty();
+			result.CreatedOn.Should().NotBe(default(DateTime));
+			_unitRepo.Verify(x => x.InsertAsync(It.IsAny<IncidentAdHocUnit>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()), Times.Once);
+			_unitRepo.Verify(x => x.SaveOrUpdateAsync(It.IsAny<IncidentAdHocUnit>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()), Times.Never);
+		}
+
+		[Test]
+		public async Task CreateAdHocUnitAsync_ClientSuppliedId_NotPersisted_InsertsWithThatId()
+		{
+			ArrangeActiveCommand();
+			_unitRepo.Setup(x => x.GetByIdAsync("client-1")).ReturnsAsync((IncidentAdHocUnit)null);
+			_unitRepo.Setup(x => x.InsertAsync(It.IsAny<IncidentAdHocUnit>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()))
+				.ReturnsAsync((IncidentAdHocUnit u, CancellationToken ct, bool b) => u);
+
+			var result = await _service.CreateAdHocUnitAsync(new IncidentAdHocUnit { IncidentAdHocUnitId = "client-1", DepartmentId = Dept, CallId = CallId, Name = "Engine 1" }, "user1");
+
+			result.Should().NotBeNull();
+			result.IncidentAdHocUnitId.Should().Be("client-1"); // honored the client GUID
+			_unitRepo.Verify(x => x.InsertAsync(It.IsAny<IncidentAdHocUnit>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()), Times.Once);
+		}
+
+		[Test]
+		public async Task CreateAdHocUnitAsync_ReplayOfExistingId_ReturnsStored_WithoutDuplicate()
+		{
+			ArrangeActiveCommand();
+			_unitRepo.Setup(x => x.GetByIdAsync("client-1")).ReturnsAsync(new IncidentAdHocUnit
+			{
+				IncidentAdHocUnitId = "client-1", DepartmentId = Dept, CallId = CallId, Name = "Engine 1"
+			});
+
+			var result = await _service.CreateAdHocUnitAsync(new IncidentAdHocUnit { IncidentAdHocUnitId = "client-1", DepartmentId = Dept, CallId = CallId, Name = "Engine 1" }, "user1");
+
+			result.Should().NotBeNull();
+			result.IncidentAdHocUnitId.Should().Be("client-1");
+			_unitRepo.Verify(x => x.InsertAsync(It.IsAny<IncidentAdHocUnit>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()), Times.Never);
+			_unitRepo.Verify(x => x.SaveOrUpdateAsync(It.IsAny<IncidentAdHocUnit>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()), Times.Never);
+		}
+
+		[Test]
+		public async Task CreateAdHocUnitAsync_ClientSuppliedId_OwnedByAnotherDepartment_ReturnsNull()
+		{
+			ArrangeActiveCommand();
+			_unitRepo.Setup(x => x.GetByIdAsync("client-1")).ReturnsAsync(new IncidentAdHocUnit
+			{
+				IncidentAdHocUnitId = "client-1", DepartmentId = 99, CallId = CallId, Name = "Engine 1"
+			});
+
+			var result = await _service.CreateAdHocUnitAsync(new IncidentAdHocUnit { IncidentAdHocUnitId = "client-1", DepartmentId = Dept, CallId = CallId, Name = "Engine 1" }, "user1");
+
+			result.Should().BeNull();
+			_unitRepo.Verify(x => x.InsertAsync(It.IsAny<IncidentAdHocUnit>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()), Times.Never);
+		}
+
+		[Test]
+		public async Task CreateAdHocPersonnelAsync_NoId_GeneratesIdAndInserts()
+		{
+			ArrangeActiveCommand();
+			_personnelRepo.Setup(x => x.InsertAsync(It.IsAny<IncidentAdHocPersonnel>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()))
+				.ReturnsAsync((IncidentAdHocPersonnel p, CancellationToken ct, bool b) => p);
+
+			var result = await _service.CreateAdHocPersonnelAsync(new IncidentAdHocPersonnel { DepartmentId = Dept, CallId = CallId, Name = "J. Doe" }, "user1");
+
+			result.Should().NotBeNull();
+			result.IncidentAdHocPersonnelId.Should().NotBeNullOrEmpty();
+			_personnelRepo.Verify(x => x.InsertAsync(It.IsAny<IncidentAdHocPersonnel>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()), Times.Once);
+			_personnelRepo.Verify(x => x.SaveOrUpdateAsync(It.IsAny<IncidentAdHocPersonnel>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()), Times.Never);
+		}
+
+		// Change tracking: ad-hoc resources now carry ModifiedOn so they ride the /Sync/Changes delta.
+
+		[Test]
+		public async Task CreateAdHocUnitAsync_StampsModifiedOn()
+		{
+			ArrangeActiveCommand();
+			IncidentAdHocUnit inserted = null;
+			_unitRepo.Setup(x => x.InsertAsync(It.IsAny<IncidentAdHocUnit>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()))
+				.Callback((IncidentAdHocUnit u, CancellationToken ct, bool b) => inserted = u)
+				.ReturnsAsync((IncidentAdHocUnit u, CancellationToken ct, bool b) => u);
+
+			await _service.CreateAdHocUnitAsync(new IncidentAdHocUnit { DepartmentId = Dept, CallId = CallId, Name = "Engine 1" }, "user1");
+
+			inserted.Should().NotBeNull();
+			inserted.ModifiedOn.Should().NotBeNull();
+		}
+
+		[Test]
+		public async Task GetAdHocChangesSinceAsync_ReturnsOnlyRowsChangedAfterCursor()
+		{
+			var since = DateTime.UtcNow.AddMinutes(-10);
+			_unitRepo.Setup(x => x.GetAllByDepartmentIdAsync(Dept)).ReturnsAsync(new List<IncidentAdHocUnit>
+			{
+				new IncidentAdHocUnit { IncidentAdHocUnitId = "u-new", DepartmentId = Dept, CallId = CallId, ModifiedOn = DateTime.UtcNow },
+				new IncidentAdHocUnit { IncidentAdHocUnitId = "u-old", DepartmentId = Dept, CallId = CallId, ModifiedOn = since.AddMinutes(-5) },
+				new IncidentAdHocUnit { IncidentAdHocUnitId = "u-null", DepartmentId = Dept, CallId = CallId, ModifiedOn = null }
+			});
+			_personnelRepo.Setup(x => x.GetAllByDepartmentIdAsync(Dept)).ReturnsAsync(new List<IncidentAdHocPersonnel>
+			{
+				// A released person changed after the cursor must be included so the client reconciles the removal.
+				new IncidentAdHocPersonnel { IncidentAdHocPersonnelId = "p-rel", DepartmentId = Dept, CallId = CallId, ReleasedOn = DateTime.UtcNow, ModifiedOn = DateTime.UtcNow }
+			});
+
+			var (units, personnel) = await _service.GetAdHocChangesSinceAsync(Dept, since);
+
+			units.Should().ContainSingle().Which.IncidentAdHocUnitId.Should().Be("u-new");
+			personnel.Should().ContainSingle().Which.IncidentAdHocPersonnelId.Should().Be("p-rel");
+		}
+	}
+}

--- a/Tests/Resgrid.Tests/Services/IncidentVoiceServiceTests.cs
+++ b/Tests/Resgrid.Tests/Services/IncidentVoiceServiceTests.cs
@@ -46,7 +46,7 @@ namespace Resgrid.Tests.Services
 					Status = (int)IncidentCommandStatus.Closed, EstablishedOn = DateTime.UtcNow.AddHours(-1)
 				}
 			});
-			logRepo.Setup(x => x.SaveOrUpdateAsync(It.IsAny<CommandLogEntry>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()))
+			logRepo.Setup(x => x.InsertAsync(It.IsAny<CommandLogEntry>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()))
 				.ReturnsAsync((CommandLogEntry e, CancellationToken ct, bool b) => e);
 
 			var service = new IncidentVoiceService(voiceService.Object, departmentsService.Object, logRepo.Object,
@@ -55,8 +55,8 @@ namespace Resgrid.Tests.Services
 			var result = await service.CloseIncidentChannelsForCallAsync(10, 7, "user1");
 
 			result.Should().BeTrue();
-			// The channel-closed entry is logged against the (now Closed) command, not silently dropped.
-			logRepo.Verify(x => x.SaveOrUpdateAsync(
+			// The channel-closed entry is logged (inserted) against the (now Closed) command, not silently dropped.
+			logRepo.Verify(x => x.InsertAsync(
 				It.Is<CommandLogEntry>(e => e.EntryType == (int)CommandLogEntryType.ChannelClosed && e.IncidentCommandId == "ic1"),
 				It.IsAny<CancellationToken>(), It.IsAny<bool>()), Times.Once);
 			coreEventService.Verify(x => x.IncidentCommandUpdatedAsync(10, 7), Times.Once);

--- a/Tests/Resgrid.Tests/Services/PhoneRegionHelperTests.cs
+++ b/Tests/Resgrid.Tests/Services/PhoneRegionHelperTests.cs
@@ -1,0 +1,32 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Resgrid.Framework;
+
+namespace Resgrid.Tests.Services
+{
+	[TestFixture]
+	public class PhoneRegionHelperTests
+	{
+		[Test]
+		public void ToIso_MapsKnownCountries()
+		{
+			PhoneRegionHelper.ToIso("South Africa").Should().Be("za");
+			PhoneRegionHelper.ToIso("United States").Should().Be("us");
+			PhoneRegionHelper.ToIso("United Kingdom").Should().Be("gb");
+		}
+
+		[Test]
+		public void ToIso_IsCaseAndWhitespaceInsensitive()
+		{
+			PhoneRegionHelper.ToIso("  south africa  ").Should().Be("za");
+		}
+
+		[Test]
+		public void ToIso_ReturnsNullForUnknownOrBlank()
+		{
+			PhoneRegionHelper.ToIso("Atlantis").Should().BeNull();
+			PhoneRegionHelper.ToIso("").Should().BeNull();
+			PhoneRegionHelper.ToIso(null).Should().BeNull();
+		}
+	}
+}

--- a/Tests/Resgrid.Tests/Services/SmsContentHelperTests.cs
+++ b/Tests/Resgrid.Tests/Services/SmsContentHelperTests.cs
@@ -1,0 +1,86 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Resgrid.Framework;
+
+namespace Resgrid.Tests.Services
+{
+	[TestFixture]
+	public class SmsContentHelperTests
+	{
+		private static readonly string[] Allowed = { "resgrid.com", "google.com", "maps.app.goo.gl", "bit.ly", "what3words.com" };
+
+		[Test]
+		public void StripDisallowedUrls_KeepsAllowListedLinks()
+		{
+			var input = "Map https://maps.app.goo.gl/abc123 also https://www.google.com/maps/place/x audio https://bit.ly/xyz";
+
+			var result = SmsContentHelper.StripDisallowedUrls(input, Allowed);
+
+			result.Should().Contain("https://maps.app.goo.gl/abc123");
+			result.Should().Contain("https://www.google.com/maps/place/x");
+			result.Should().Contain("https://bit.ly/xyz");
+		}
+
+		[Test]
+		public void StripDisallowedUrls_RemovesUnknownAndShortenerLinks()
+		{
+			var input = "See https://tinyurl.com/abc and http://evil.example.com/phish now";
+
+			var result = SmsContentHelper.StripDisallowedUrls(input, Allowed);
+
+			result.Should().NotContain("tinyurl.com");
+			result.Should().NotContain("evil.example.com");
+			result.Should().Contain("See");
+			result.Should().Contain("now");
+		}
+
+		[Test]
+		public void StripDisallowedUrls_DoesNotMangleAbbreviationsOrAddresses()
+		{
+			// No scheme/www tokens -> nothing should be treated as a URL.
+			var input = "Meet at 400 Olive St, Dallas, TX 75201, U.S. Call 9-1-1 for emergencies.";
+
+			SmsContentHelper.StripDisallowedUrls(input, Allowed).Should().Be(input);
+		}
+
+		[Test]
+		public void StripDisallowedUrls_AllowsSubdomainsOfAllowedDomain()
+		{
+			SmsContentHelper.StripDisallowedUrls("Loc https://maps.google.com/q", Allowed).Should().Contain("maps.google.com");
+		}
+
+		[Test]
+		public void Truncate_CapsLongBodyWithSuffix()
+		{
+			var result = SmsContentHelper.Truncate(new string('a', 1000), 459);
+
+			result.Length.Should().Be(459);
+			result.Should().EndWith("the full message)");
+		}
+
+		[Test]
+		public void Truncate_LeavesShortBodyUnchanged()
+		{
+			SmsContentHelper.Truncate("short body", 459).Should().Be("short body");
+		}
+
+		[Test]
+		public void NormalizeForGsm_ReplacesSmartPunctuation()
+		{
+			var input = "It’s a “test” – really…";
+
+			SmsContentHelper.NormalizeForGsm(input).Should().Be("It's a \"test\" - really...");
+		}
+
+		[Test]
+		public void PrepareForSms_StripsDisallowedUrlThenTruncates()
+		{
+			var input = "Go to https://tinyurl.com/spam " + new string('b', 1000);
+
+			var result = SmsContentHelper.PrepareForSms(input, 459, Allowed);
+
+			result.Should().NotContain("tinyurl.com");
+			(result.Length <= 459).Should().BeTrue();
+		}
+	}
+}

--- a/Web/Resgrid.Web.Services/Controllers/v4/CheckInTimersController.cs
+++ b/Web/Resgrid.Web.Services/Controllers/v4/CheckInTimersController.cs
@@ -391,7 +391,8 @@ namespace Resgrid.Web.Services.Controllers.v4
 				UnitId = input.UnitId,
 				Latitude = input.Latitude,
 				Longitude = input.Longitude,
-				Note = input.Note
+				Note = input.Note,
+				IdempotencyKey = input.IdempotencyKey
 			};
 
 			var saved = await _checkInTimerService.PerformCheckInAsync(record, cancellationToken);

--- a/Web/Resgrid.Web.Services/Controllers/v4/SyncController.cs
+++ b/Web/Resgrid.Web.Services/Controllers/v4/SyncController.cs
@@ -1,0 +1,66 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Resgrid.Model;
+using Resgrid.Model.Services;
+using Resgrid.Providers.Claims;
+using Resgrid.Web.Services.Helpers;
+using Resgrid.Web.Services.Models.v4.Sync;
+using System;
+using System.Threading.Tasks;
+
+namespace Resgrid.Web.Services.Controllers.v4
+{
+	/// <summary>
+	/// Offline-first delta sync. A reconnecting client calls Changes with its last cursor to pull everything that
+	/// changed while it was offline (created / updated / removed incident-command rows), reconciles its local store,
+	/// then replays its outbox. See docs/architecture/offline-first-architecture.md.
+	/// </summary>
+	[Route("api/v{VersionId:apiVersion}/[controller]")]
+	[ApiVersion("4.0")]
+	[ApiExplorerSettings(GroupName = "v4")]
+	public class SyncController : V4AuthenticatedApiControllerbase
+	{
+		#region Members and Constructors
+		private readonly IIncidentCommandService _incidentCommandService;
+		private readonly IIncidentResourcesService _incidentResourcesService;
+
+		public SyncController(IIncidentCommandService incidentCommandService, IIncidentResourcesService incidentResourcesService)
+		{
+			_incidentCommandService = incidentCommandService;
+			_incidentResourcesService = incidentResourcesService;
+		}
+		#endregion Members and Constructors
+
+		/// <summary>
+		/// Returns incident-command rows changed since <paramref name="since"/> (Unix epoch milliseconds; 0 or omitted
+		/// = full pull), scoped to the caller's department. Soft-deleted / closed / released rows are included so the
+		/// client can remove them locally. Persist the returned <c>Data.ServerTimestampMs</c> and pass it as the next
+		/// <paramref name="since"/>.
+		/// </summary>
+		[HttpGet("Changes")]
+		[ProducesResponseType(StatusCodes.Status200OK)]
+		[Authorize(Policy = ResgridResources.Command_View)]
+		public async Task<ActionResult<SyncChangesResult>> Changes(long since = 0)
+		{
+			var sinceUtc = since <= 0
+				? DateTime.MinValue
+				: DateTimeOffset.FromUnixTimeMilliseconds(since).UtcDateTime;
+
+			var changes = await _incidentCommandService.GetChangesSinceAsync(DepartmentId, sinceUtc);
+
+			// Ad-hoc resources live in IncidentResourcesService; aggregate them into the unified delta payload.
+			var adHoc = await _incidentResourcesService.GetAdHocChangesSinceAsync(DepartmentId, sinceUtc);
+			changes.AdHocUnits = adHoc.Units;
+			changes.AdHocPersonnel = adHoc.Personnel;
+
+			var result = new SyncChangesResult { Data = changes };
+			result.PageSize = changes.Commands.Count + changes.Nodes.Count + changes.Assignments.Count
+				+ changes.Objectives.Count + changes.Timers.Count + changes.Annotations.Count
+				+ changes.Roles.Count + changes.AdHocUnits.Count + changes.AdHocPersonnel.Count + changes.TimelineEntries.Count;
+			result.Status = ResponseHelper.Success;
+			ResponseHelper.PopulateV4ResponseData(result);
+			return result;
+		}
+	}
+}

--- a/Web/Resgrid.Web.Services/Models/v4/CheckInTimers/CheckInTimerModels.cs
+++ b/Web/Resgrid.Web.Services/Models/v4/CheckInTimers/CheckInTimerModels.cs
@@ -145,6 +145,9 @@ namespace Resgrid.Web.Services.Models.v4.CheckInTimers
 		public string Longitude { get; set; }
 		public int? UnitId { get; set; }
 		public string Note { get; set; }
+
+		/// <summary>Optional offline idempotency key (the client's outbox event id); a replayed check-in dedups on it.</summary>
+		public string IdempotencyKey { get; set; }
 	}
 
 	public class PerformCheckInResult : StandardApiResponseV4Base

--- a/Web/Resgrid.Web.Services/Models/v4/Sync/SyncModels.cs
+++ b/Web/Resgrid.Web.Services/Models/v4/Sync/SyncModels.cs
@@ -1,0 +1,13 @@
+using Resgrid.Web.Services.Models.v4;
+
+namespace Resgrid.Web.Services.Models.v4.Sync
+{
+	/// <summary>
+	/// Delta sync payload for offline clients: incident-command rows changed since the client's cursor. The client
+	/// stores <c>Data.ServerTimestampMs</c> and passes it back as the next `since`.
+	/// </summary>
+	public class SyncChangesResult : StandardApiResponseV4Base
+	{
+		public Resgrid.Model.IncidentCommandChanges Data { get; set; }
+	}
+}

--- a/Web/Resgrid.Web.Services/Resgrid.Web.Services.xml
+++ b/Web/Resgrid.Web.Services/Resgrid.Web.Services.xml
@@ -1922,6 +1922,21 @@
             </summary>
             <returns></returns>
         </member>
+        <member name="T:Resgrid.Web.Services.Controllers.v4.SyncController">
+            <summary>
+            Offline-first delta sync. A reconnecting client calls Changes with its last cursor to pull everything that
+            changed while it was offline (created / updated / removed incident-command rows), reconciles its local store,
+            then replays its outbox. See docs/architecture/offline-first-architecture.md.
+            </summary>
+        </member>
+        <member name="M:Resgrid.Web.Services.Controllers.v4.SyncController.Changes(System.Int64)">
+            <summary>
+            Returns incident-command rows changed since <paramref name="since"/> (Unix epoch milliseconds; 0 or omitted
+            = full pull), scoped to the caller's department. Soft-deleted / closed / released rows are included so the
+            client can remove them locally. Persist the returned <c>Data.ServerTimestampMs</c> and pass it as the next
+            <paramref name="since"/>.
+            </summary>
+        </member>
         <member name="T:Resgrid.Web.Services.Controllers.v4.TemplatesController">
             <summary>
             Templates in the system. Templates can be call Templates, Autofills (i.e. Call Notes)
@@ -6303,6 +6318,9 @@
             User Defined Field values for this contact
             </summary>
         </member>
+        <member name="P:Resgrid.Web.Services.Models.v4.CheckInTimers.PerformCheckInInput.IdempotencyKey">
+            <summary>Optional offline idempotency key (the client's outbox event id); a replayed check-in dedups on it.</summary>
+        </member>
         <member name="T:Resgrid.Web.Services.Models.v4.CheckInTimers.UserCallCheckInStatusResult">
             <summary>
             Response wrapper for <see cref="!:GetUserCallCheckInStatuses"/>.
@@ -9612,6 +9630,12 @@
         <member name="M:Resgrid.Web.Services.Models.v4.Statuses.UnitTypeStatusResultData.#ctor">
             <summary>
             Default constructor
+            </summary>
+        </member>
+        <member name="T:Resgrid.Web.Services.Models.v4.Sync.SyncChangesResult">
+            <summary>
+            Delta sync payload for offline clients: incident-command rows changed since the client's cursor. The client
+            stores <c>Data.ServerTimestampMs</c> and passes it back as the next `since`.
             </summary>
         </member>
         <member name="T:Resgrid.Web.Services.Models.v4.Templates.CallNoteTemplatesResult">

--- a/Web/Resgrid.Web/Areas/User/Controllers/ContactsController.cs
+++ b/Web/Resgrid.Web/Areas/User/Controllers/ContactsController.cs
@@ -38,11 +38,12 @@ namespace Resgrid.Web.Areas.User.Controllers
 		private readonly IUdfRenderingService _udfRenderingService;
 		private readonly IDepartmentGroupsService _departmentGroupsService;
 		private readonly IRouteService _routeService;
+		private readonly IPhoneNumberProcesserProvider _phoneNumberProcesser;
 
 		public ContactsController(IContactsService contactsService, IDepartmentsService departmentsService, IUserProfileService userProfileService,
 			IAddressService addressService, IEventAggregator eventAggregator, ICallsService callsService, IAuthorizationService authorizationService,
 			IUserDefinedFieldsService userDefinedFieldsService, IUdfRenderingService udfRenderingService,
-			IDepartmentGroupsService departmentGroupsService, IRouteService routeService)
+			IDepartmentGroupsService departmentGroupsService, IRouteService routeService, IPhoneNumberProcesserProvider phoneNumberProcesser)
 		{
 			_contactsService = contactsService;
 			_departmentsService = departmentsService;
@@ -55,6 +56,7 @@ namespace Resgrid.Web.Areas.User.Controllers
 			_udfRenderingService = udfRenderingService;
 			_departmentGroupsService = departmentGroupsService;
 			_routeService = routeService;
+			_phoneNumberProcesser = phoneNumberProcesser;
 		}
 
 		#endregion Private Members and Constructors
@@ -262,6 +264,13 @@ namespace Resgrid.Web.Areas.User.Controllers
 			{
 				ModelState.AddModelError("ExitGpsLongitude", "Exit Longitude value seems invalid, MUST be decimal format.");
 			}
+
+			// Server-side phone backstop: validate + normalize each number to E.164 so saved values are
+			// Twilio-sendable (mirrors EditUserProfile). Region comes from the contact's physical country.
+			model.Contact.CellPhoneNumber = PhoneValidationHelper.ValidateAndNormalize(_phoneNumberProcesser, ModelState, "Contact.CellPhoneNumber", "cell phone number", model.Contact.CellPhoneNumber, model.PhysicalCountry);
+			model.Contact.HomePhoneNumber = PhoneValidationHelper.ValidateAndNormalize(_phoneNumberProcesser, ModelState, "Contact.HomePhoneNumber", "home phone number", model.Contact.HomePhoneNumber, model.PhysicalCountry);
+			model.Contact.FaxPhoneNumber = PhoneValidationHelper.ValidateAndNormalize(_phoneNumberProcesser, ModelState, "Contact.FaxPhoneNumber", "fax number", model.Contact.FaxPhoneNumber, model.PhysicalCountry);
+			model.Contact.OfficePhoneNumber = PhoneValidationHelper.ValidateAndNormalize(_phoneNumberProcesser, ModelState, "Contact.OfficePhoneNumber", "office phone number", model.Contact.OfficePhoneNumber, model.PhysicalCountry);
 
 			Address physicalAddress = new Address();
 			Address mailingAddress = new Address();
@@ -523,6 +532,13 @@ namespace Resgrid.Web.Areas.User.Controllers
 				ModelState.AddModelError("ExitGpsLongitude", "Exit Longitude value seems invalid, MUST be decimal format.");
 			}
 
+			// Server-side phone backstop: validate + normalize each number to E.164 so saved values are
+			// Twilio-sendable (mirrors EditUserProfile). Region comes from the contact's physical country.
+			model.Contact.CellPhoneNumber = PhoneValidationHelper.ValidateAndNormalize(_phoneNumberProcesser, ModelState, "Contact.CellPhoneNumber", "cell phone number", model.Contact.CellPhoneNumber, model.PhysicalCountry);
+			model.Contact.HomePhoneNumber = PhoneValidationHelper.ValidateAndNormalize(_phoneNumberProcesser, ModelState, "Contact.HomePhoneNumber", "home phone number", model.Contact.HomePhoneNumber, model.PhysicalCountry);
+			model.Contact.FaxPhoneNumber = PhoneValidationHelper.ValidateAndNormalize(_phoneNumberProcesser, ModelState, "Contact.FaxPhoneNumber", "fax number", model.Contact.FaxPhoneNumber, model.PhysicalCountry);
+			model.Contact.OfficePhoneNumber = PhoneValidationHelper.ValidateAndNormalize(_phoneNumberProcesser, ModelState, "Contact.OfficePhoneNumber", "office phone number", model.Contact.OfficePhoneNumber, model.PhysicalCountry);
+
 			if (ModelState.IsValid)
 			{
 				var contact = await _contactsService.GetContactByIdAsync(model.Contact.ContactId);
@@ -591,11 +607,11 @@ namespace Resgrid.Web.Areas.User.Controllers
 					if (contact.MailingAddressId.HasValue)
 						mailingAddress = await _addressService.GetAddressByIdAsync(contact.MailingAddressId.Value);
 
-					mailingAddress.Address1 = model.PhysicalAddress1;
-					mailingAddress.City = model.PhysicalCity;
-					mailingAddress.Country = model.PhysicalCountry;
-					mailingAddress.PostalCode = model.PhysicalPostalCode;
-					mailingAddress.State = model.PhysicalState;
+					mailingAddress.Address1 = model.MailingAddress1;
+					mailingAddress.City = model.MailingCity;
+					mailingAddress.Country = model.MailingCountry;
+					mailingAddress.PostalCode = model.MailingPostalCode;
+					mailingAddress.State = model.MailingState;
 
 					mailingAddress = await _addressService.SaveAddressAsync(mailingAddress, cancellationToken);
 					contact.MailingAddressId = mailingAddress.AddressId;

--- a/Web/Resgrid.Web/Areas/User/Controllers/HomeController.cs
+++ b/Web/Resgrid.Web/Areas/User/Controllers/HomeController.cs
@@ -70,6 +70,7 @@ namespace Resgrid.Web.Areas.User.Controllers
 		private readonly IStringLocalizer<Resgrid.Localization.Areas.User.Security.Security> _secLocalizer;
 		private readonly IGdprDataExportService _gdprDataExportService;
 		private readonly ISystemAuditsService _systemAuditsService;
+		private readonly IPhoneNumberProcesserProvider _phoneNumberProcesser;
 
 		public HomeController(IDepartmentsService departmentsService, IUsersService usersService, IActionLogsService actionLogsService,
 			IUserStateService userStateService, IDepartmentGroupsService departmentGroupsService, Resgrid.Model.Services.IAuthorizationService authorizationService,
@@ -79,7 +80,7 @@ namespace Resgrid.Web.Areas.User.Controllers
 			IStringLocalizerFactory factory, ISubscriptionsService subscriptionsService, IContactVerificationService contactVerificationService,
 			IUserDefinedFieldsService userDefinedFieldsService, IUdfRenderingService udfRenderingService, IDepartmentSsoService departmentSsoService,
 			IStringLocalizer<Resgrid.Localization.Areas.User.Security.Security> secLocalizer, IGdprDataExportService gdprDataExportService,
-			ISystemAuditsService systemAuditsService)
+			ISystemAuditsService systemAuditsService, IPhoneNumberProcesserProvider phoneNumberProcesser)
 		{
 			_departmentsService = departmentsService;
 			_usersService = usersService;
@@ -108,6 +109,7 @@ namespace Resgrid.Web.Areas.User.Controllers
 			_secLocalizer = secLocalizer;
 			_gdprDataExportService = gdprDataExportService;
 			_systemAuditsService = systemAuditsService;
+			_phoneNumberProcesser = phoneNumberProcesser;
 
 			_localizer = factory.Create("Home.Dashboard", new AssemblyName(typeof(SupportedLocales).GetTypeInfo().Assembly.FullName).Name);
 		}
@@ -563,6 +565,26 @@ namespace Resgrid.Web.Areas.User.Controllers
 				ModelState.AddModelError("Profile.MobileNumber", "You have selected you want SMS/Text notifications but have not supplied a mobile number.");
 			}
 
+			// Validate phone numbers to a sendable E.164 form (Twilio rejects non-E.164 'To' numbers). Use the user's
+			// country as the region hint so a national-format number (e.g. "082446...") can be recognized & normalized.
+			var phoneRegion = PhoneRegionHelper.ToIso(model.PhysicalCountry) ?? PhoneRegionHelper.ToIso(model.MailingCountry);
+			PhoneNumberResult mobileResult = null;
+			PhoneNumberResult homeResult = null;
+
+			if (!String.IsNullOrWhiteSpace(model.Profile.MobileNumber))
+			{
+				mobileResult = _phoneNumberProcesser.Process(model.Profile.MobileNumber, phoneRegion);
+				if (mobileResult == null || !mobileResult.IsValid)
+					ModelState.AddModelError("Profile.MobileNumber", "This mobile number doesn't look valid for sending texts. Enter it in full international format, starting with your country code (for example +27 82 446 1783).");
+			}
+
+			if (!String.IsNullOrWhiteSpace(model.Profile.HomeNumber))
+			{
+				homeResult = _phoneNumberProcesser.Process(model.Profile.HomeNumber, phoneRegion);
+				if (homeResult == null || !homeResult.IsValid)
+					ModelState.AddModelError("Profile.HomeNumber", "This home/phone number doesn't look valid for calls. Enter it in full international format, starting with your country code.");
+			}
+
 			// They specified a street address for physical
 			if (!String.IsNullOrWhiteSpace(model.PhysicalAddress1))
 			{
@@ -685,7 +707,9 @@ namespace Resgrid.Web.Areas.User.Controllers
 				savedProfile.MobileCarrier = (int)model.Carrier;
 				savedProfile.FirstName = model.FirstName;
 				savedProfile.LastName = model.LastName;
-				savedProfile.MobileNumber = model.Profile.MobileNumber;
+				savedProfile.MobileNumber = (mobileResult != null && mobileResult.IsValid && !string.IsNullOrWhiteSpace(mobileResult.InternationalNumber))
+					? mobileResult.InternationalNumber
+					: model.Profile.MobileNumber;
 				savedProfile.SendEmail = model.Profile.SendEmail;
 				savedProfile.SendPush = model.Profile.SendPush;
 				savedProfile.SendSms = model.Profile.SendSms;
@@ -696,7 +720,9 @@ namespace Resgrid.Web.Areas.User.Controllers
 				savedProfile.SendNotificationPush = model.Profile.SendNotificationPush;
 				savedProfile.SendNotificationSms = model.Profile.SendNotificationSms;
 				savedProfile.DoNotRecieveNewsletters = model.Profile.DoNotRecieveNewsletters;
-				savedProfile.HomeNumber = model.Profile.HomeNumber;
+				savedProfile.HomeNumber = (homeResult != null && homeResult.IsValid && !string.IsNullOrWhiteSpace(homeResult.InternationalNumber))
+					? homeResult.InternationalNumber
+					: model.Profile.HomeNumber;
 				savedProfile.IdentificationNumber = model.Profile.IdentificationNumber;
 				savedProfile.TimeZone = model.Profile.TimeZone;
 				savedProfile.Language = model.Profile.Language;
@@ -1082,6 +1108,38 @@ namespace Resgrid.Web.Areas.User.Controllers
 			bool confirmed = await _contactVerificationService.ConfirmVerificationCodeAsync(UserId, DepartmentId, request.Type, request.Code, ipAddress, cancellationToken);
 
 			return Json(new { success = confirmed });
+		}
+
+		/// <summary>
+		/// AJAX: validates a phone number the user is entering on the profile page and returns its canonical E.164
+		/// form. Read-only (no state change), so it intentionally skips antiforgery. The profile form calls this on
+		/// blur to warn about — and offer a one-click fix for — numbers Twilio would reject.
+		/// </summary>
+		[HttpPost]
+		[Authorize(Policy = ResgridResources.Department_View)]
+		public IActionResult ValidatePhoneNumber([FromBody] ValidatePhoneNumberRequest request)
+		{
+			if (request == null || string.IsNullOrWhiteSpace(request.Number))
+				return Json(new { isValid = false, formatted = (string)null, message = "Please enter a phone number." });
+
+			var iso = PhoneRegionHelper.ToIso(request.Country);
+			var result = _phoneNumberProcesser.Process(request.Number, iso);
+
+			if (result != null && result.IsValid && !string.IsNullOrWhiteSpace(result.InternationalNumber))
+				return Json(new { isValid = true, formatted = result.InternationalNumber, message = (string)null });
+
+			return Json(new
+			{
+				isValid = false,
+				formatted = (result != null && !string.IsNullOrWhiteSpace(result.InternationalNumber)) ? result.InternationalNumber : null,
+				message = "This number doesn't look valid for sending. Enter it in full international format, starting with your country code (for example +27 82 446 1783)."
+			});
+		}
+
+		public sealed class ValidatePhoneNumberRequest
+		{
+			public string Number { get; set; }
+			public string Country { get; set; }
 		}
 		#endregion Contact Verification (AJAX)
 

--- a/Web/Resgrid.Web/Areas/User/Controllers/PersonnelController.cs
+++ b/Web/Resgrid.Web/Areas/User/Controllers/PersonnelController.cs
@@ -60,6 +60,7 @@ namespace Resgrid.Web.Areas.User.Controllers
 		private readonly IUserDefinedFieldsService _userDefinedFieldsService;
 		private readonly IUdfRenderingService _udfRenderingService;
 		private readonly IStringLocalizer<Resgrid.Localization.Common> _localizer;
+		private readonly IPhoneNumberProcesserProvider _phoneNumberProcesser;
 
 		public PersonnelController(IDepartmentsService departmentsService, IUsersService usersService, IActionLogsService actionLogsService,
 			IEmailService emailService, IUserProfileService userProfileService, IDeleteService deleteService, Model.Services.IAuthorizationService authorizationService,
@@ -67,7 +68,7 @@ namespace Resgrid.Web.Areas.User.Controllers
 			IEventAggregator eventAggregator, IEmailMarketingProvider emailMarketingProvider, ICertificationService certificationService, ICustomStateService customStateService,
 			IGeoService geoService, UserManager<IdentityUser> userManager, IDepartmentSettingsService departmentSettingsService, ICallsService callsService,
 			IGeoLocationProvider geoLocationProvider, IMappingService mappingService, IUserDefinedFieldsService userDefinedFieldsService, IUdfRenderingService udfRenderingService,
-			IStringLocalizer<Resgrid.Localization.Common> localizer)
+			IStringLocalizer<Resgrid.Localization.Common> localizer, IPhoneNumberProcesserProvider phoneNumberProcesser)
 		{
 			_departmentsService = departmentsService;
 			_usersService = usersService;
@@ -93,6 +94,7 @@ namespace Resgrid.Web.Areas.User.Controllers
 			_userDefinedFieldsService = userDefinedFieldsService;
 			_udfRenderingService = udfRenderingService;
 			_localizer = localizer;
+			_phoneNumberProcesser = phoneNumberProcesser;
 		}
 		#endregion Private Members and Constructors
 
@@ -512,6 +514,10 @@ namespace Resgrid.Web.Areas.User.Controllers
 			{
 				ModelState.AddModelError("Profile.MobileNumber", "You have selected you want SMS/Text notifications but have not supplied a mobile number.");
 			}
+
+			// Server-side phone backstop: validate + normalize to E.164 so the saved number is Twilio-sendable
+			// (mirrors EditUserProfile). AddPerson has no country field, so the validator uses its default region.
+			model.Profile.MobileNumber = PhoneValidationHelper.ValidateAndNormalize(_phoneNumberProcesser, ModelState, "Profile.MobileNumber", "mobile number", model.Profile.MobileNumber, null);
 
 			var deletedUserId = await _departmentsService.GetUserIdForDeletedUserInDepartmentAsync(DepartmentId, model.Email);
 			if (deletedUserId != null)

--- a/Web/Resgrid.Web/Areas/User/Models/Connect/ProfileView.cs
+++ b/Web/Resgrid.Web/Areas/User/Models/Connect/ProfileView.cs
@@ -15,18 +15,19 @@ namespace Resgrid.Web.Areas.User.Models.Connect
 
 		public string ApiUrl { get; set; }
 
+		[StringLength(500, ErrorMessage = "Street address cannot exceed 500 characters.")]
 		public string Address1 { get; set; }
 
-		[MaxLength(100)]
+		[StringLength(150, ErrorMessage = "City cannot exceed 150 characters.")]
 		public string City { get; set; }
 
-		[MaxLength(50)]
+		[StringLength(100, ErrorMessage = "State/Province cannot exceed 100 characters.")]
 		public string State { get; set; }
 
-		[MaxLength(50)]
+		[StringLength(32, ErrorMessage = "Postal code cannot exceed 32 characters.")]
 		public string PostalCode { get; set; }
 
-		[MaxLength(100)]
+		[StringLength(100, ErrorMessage = "Country cannot exceed 100 characters.")]
 		public string Country { get; set; }
 	}
 }

--- a/Web/Resgrid.Web/Areas/User/Models/Contacts/AddContactView.cs
+++ b/Web/Resgrid.Web/Areas/User/Models/Contacts/AddContactView.cs
@@ -1,4 +1,4 @@
-﻿using Resgrid.Model;
+using Resgrid.Model;
 using System.ComponentModel.DataAnnotations;
 
 namespace Resgrid.Web.Areas.User.Models.Contacts
@@ -18,42 +18,44 @@ namespace Resgrid.Web.Areas.User.Models.Contacts
 		public string ExitGpsLatitude { get; set; }
 		public string ExitGpsLongitude { get; set; }
 
-		[MaxLength(100)]
+		// Limits mirror the (widened) Addresses columns so client + server validation give feedback before save;
+		// every cap is <= its DB column width, so a validated value can never truncate. See M0085.
+		[StringLength(500, ErrorMessage = "Street address cannot exceed 500 characters.")]
 		public string PhysicalAddress1 { get; set; }
 
-		[MaxLength(100)]
+		[StringLength(500, ErrorMessage = "Street address line 2 cannot exceed 500 characters.")]
 		public string PhysicalAddress2 { get; set; }
 
-		[MaxLength(100)]
+		[StringLength(150, ErrorMessage = "City cannot exceed 150 characters.")]
 		public string PhysicalCity { get; set; }
 
-		[MaxLength(50)]
+		[StringLength(100, ErrorMessage = "State/Province cannot exceed 100 characters.")]
 		public string PhysicalState { get; set; }
 
-		[MaxLength(50)]
+		[StringLength(32, ErrorMessage = "Postal code cannot exceed 32 characters.")]
 		public string PhysicalPostalCode { get; set; }
 
-		[MaxLength(100)]
+		[StringLength(100, ErrorMessage = "Country cannot exceed 100 characters.")]
 		public string PhysicalCountry { get; set; }
 
 		public bool MailingAddressSameAsPhysical { get; set; }
 
-		[MaxLength(100)]
+		[StringLength(500, ErrorMessage = "Street address cannot exceed 500 characters.")]
 		public string MailingAddress1 { get; set; }
 
-		[MaxLength(100)]
+		[StringLength(500, ErrorMessage = "Street address line 2 cannot exceed 500 characters.")]
 		public string MailingAddress2 { get; set; }
 
-		[MaxLength(100)]
+		[StringLength(150, ErrorMessage = "City cannot exceed 150 characters.")]
 		public string MailingCity { get; set; }
 
-		[MaxLength(50)]
+		[StringLength(100, ErrorMessage = "State/Province cannot exceed 100 characters.")]
 		public string MailingState { get; set; }
 
-		[MaxLength(50)]
+		[StringLength(32, ErrorMessage = "Postal code cannot exceed 32 characters.")]
 		public string MailingPostalCode { get; set; }
 
-		[MaxLength(100)]
+		[StringLength(100, ErrorMessage = "Country cannot exceed 100 characters.")]
 		public string MailingCountry { get; set; }
 	}
 }

--- a/Web/Resgrid.Web/Areas/User/Models/Contacts/EditContactView.cs
+++ b/Web/Resgrid.Web/Areas/User/Models/Contacts/EditContactView.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
 using Resgrid.Model;
 
 namespace Resgrid.Web.Areas.User.Models.Contacts;
@@ -21,41 +21,43 @@ public class EditContactView
 	public string ExitGpsLatitude { get; set; }
 	public string ExitGpsLongitude { get; set; }
 
-	[MaxLength(100)]
+	// Limits mirror the (widened) Addresses columns so client + server validation give feedback before save;
+	// every cap is <= its DB column width, so a validated value can never truncate. See M0085.
+	[StringLength(500, ErrorMessage = "Street address cannot exceed 500 characters.")]
 	public string PhysicalAddress1 { get; set; }
 
-	[MaxLength(100)]
+	[StringLength(500, ErrorMessage = "Street address line 2 cannot exceed 500 characters.")]
 	public string PhysicalAddress2 { get; set; }
 
-	[MaxLength(100)]
+	[StringLength(150, ErrorMessage = "City cannot exceed 150 characters.")]
 	public string PhysicalCity { get; set; }
 
-	[MaxLength(50)]
+	[StringLength(100, ErrorMessage = "State/Province cannot exceed 100 characters.")]
 	public string PhysicalState { get; set; }
 
-	[MaxLength(50)]
+	[StringLength(32, ErrorMessage = "Postal code cannot exceed 32 characters.")]
 	public string PhysicalPostalCode { get; set; }
 
-	[MaxLength(100)]
+	[StringLength(100, ErrorMessage = "Country cannot exceed 100 characters.")]
 	public string PhysicalCountry { get; set; }
 
 	public bool MailingAddressSameAsPhysical { get; set; }
 
-	[MaxLength(100)]
+	[StringLength(500, ErrorMessage = "Street address cannot exceed 500 characters.")]
 	public string MailingAddress1 { get; set; }
 
-	[MaxLength(100)]
+	[StringLength(500, ErrorMessage = "Street address line 2 cannot exceed 500 characters.")]
 	public string MailingAddress2 { get; set; }
 
-	[MaxLength(100)]
+	[StringLength(150, ErrorMessage = "City cannot exceed 150 characters.")]
 	public string MailingCity { get; set; }
 
-	[MaxLength(50)]
+	[StringLength(100, ErrorMessage = "State/Province cannot exceed 100 characters.")]
 	public string MailingState { get; set; }
 
-	[MaxLength(50)]
+	[StringLength(32, ErrorMessage = "Postal code cannot exceed 32 characters.")]
 	public string MailingPostalCode { get; set; }
 
-	[MaxLength(100)]
+	[StringLength(100, ErrorMessage = "Country cannot exceed 100 characters.")]
 	public string MailingCountry { get; set; }
 }

--- a/Web/Resgrid.Web/Areas/User/Models/DepartmentSettingsModel.cs
+++ b/Web/Resgrid.Web/Areas/User/Models/DepartmentSettingsModel.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Resgrid.Model;
 using Resgrid.Model.Identity;
@@ -18,10 +19,19 @@ namespace Resgrid.Web.Areas.User.Models
 		public string MapZoomLevel { get; set; }
 		public string RefreshTime { get; set; }
 
+		[StringLength(500, ErrorMessage = "Street address cannot exceed 500 characters.")]
 		public string MapCenterPointAddressAddress1 { get; set; }
+
+		[StringLength(150, ErrorMessage = "City cannot exceed 150 characters.")]
 		public string MapCenterPointAddressCity { get; set; }
+
+		[StringLength(100, ErrorMessage = "State/Province cannot exceed 100 characters.")]
 		public string MapCenterPointAddressState { get; set; }
+
+		[StringLength(32, ErrorMessage = "Postal code cannot exceed 32 characters.")]
 		public string MapCenterPointAddressPostalCode { get; set; }
+
+		[StringLength(100, ErrorMessage = "Country cannot exceed 100 characters.")]
 		public string MapCenterPointAddressCountry { get; set; }
 		public string MapCenterGpsCoordinatesLatitude { get; set; }
 		public string MapCenterGpsCoordinatesLongitude { get; set; }

--- a/Web/Resgrid.Web/Areas/User/Models/EditProfileModel.cs
+++ b/Web/Resgrid.Web/Areas/User/Models/EditProfileModel.cs
@@ -71,42 +71,42 @@ namespace Resgrid.Web.Areas.User.Models
 		public int MinPasswordLength { get; set; } = 8;
 
 
-		[MaxLength(100)]
+		[StringLength(500, ErrorMessage = "Street address cannot exceed 500 characters.")]
 		public string PhysicalAddress1 { get; set; }
 
-		[MaxLength(100)]
+		[StringLength(500, ErrorMessage = "Street address line 2 cannot exceed 500 characters.")]
 		public string PhysicalAddress2 { get; set; }
 
-		[MaxLength(100)]
+		[StringLength(150, ErrorMessage = "City cannot exceed 150 characters.")]
 		public string PhysicalCity { get; set; }
 
-		[MaxLength(50)]
+		[StringLength(100, ErrorMessage = "State/Province cannot exceed 100 characters.")]
 		public string PhysicalState { get; set; }
 
-		[MaxLength(50)]
+		[StringLength(32, ErrorMessage = "Postal code cannot exceed 32 characters.")]
 		public string PhysicalPostalCode { get; set; }
 
-		[MaxLength(100)]
+		[StringLength(100, ErrorMessage = "Country cannot exceed 100 characters.")]
 		public string PhysicalCountry { get; set; }
 
 		public bool MailingAddressSameAsPhysical { get; set; }
 
-		[MaxLength(100)]
+		[StringLength(500, ErrorMessage = "Street address cannot exceed 500 characters.")]
 		public string MailingAddress1 { get; set; }
 
-		[MaxLength(100)]
+		[StringLength(500, ErrorMessage = "Street address line 2 cannot exceed 500 characters.")]
 		public string MailingAddress2 { get; set; }
 
-		[MaxLength(100)]
+		[StringLength(150, ErrorMessage = "City cannot exceed 150 characters.")]
 		public string MailingCity { get; set; }
 
-		[MaxLength(50)]
+		[StringLength(100, ErrorMessage = "State/Province cannot exceed 100 characters.")]
 		public string MailingState { get; set; }
 
-		[MaxLength(50)]
+		[StringLength(32, ErrorMessage = "Postal code cannot exceed 32 characters.")]
 		public string MailingPostalCode { get; set; }
 
-		[MaxLength(100)]
+		[StringLength(100, ErrorMessage = "Country cannot exceed 100 characters.")]
 		public string MailingCountry { get; set; }
 
 		public bool EnableSms { get; set; }

--- a/Web/Resgrid.Web/Areas/User/Models/Groups/EditGroupView.cs
+++ b/Web/Resgrid.Web/Areas/User/Models/Groups/EditGroupView.cs
@@ -14,18 +14,19 @@ namespace Resgrid.Web.Areas.User.Models.Groups
 		public List<IdentityUser> Users { get; set; }
 		public SelectList StationGroups { get; set; }
 
+		[StringLength(500, ErrorMessage = "Street address cannot exceed 500 characters.")]
 		public string Address1 { get; set; }
 
-		[MaxLength(100)]
+		[StringLength(150, ErrorMessage = "City cannot exceed 150 characters.")]
 		public string City { get; set; }
 
-		[MaxLength(50)]
+		[StringLength(100, ErrorMessage = "State/Province cannot exceed 100 characters.")]
 		public string State { get; set; }
 
-		[MaxLength(50)]
+		[StringLength(32, ErrorMessage = "Postal code cannot exceed 32 characters.")]
 		public string PostalCode { get; set; }
 
-		[MaxLength(100)]
+		[StringLength(100, ErrorMessage = "Country cannot exceed 100 characters.")]
 		public string Country { get; set; }
 
 		public string InternalDispatchEmail { get; set; }

--- a/Web/Resgrid.Web/Areas/User/Models/Groups/NewGroupView.cs
+++ b/Web/Resgrid.Web/Areas/User/Models/Groups/NewGroupView.cs
@@ -21,18 +21,19 @@ namespace Resgrid.Web.Areas.User.Models.Groups
 			NewGroup.Type = 1;
 		}
 
+		[StringLength(500, ErrorMessage = "Street address cannot exceed 500 characters.")]
 		public string Address1 { get; set; }
 
-		[MaxLength(100)]
+		[StringLength(150, ErrorMessage = "City cannot exceed 150 characters.")]
 		public string City { get; set; }
 
-		[MaxLength(50)]
+		[StringLength(100, ErrorMessage = "State/Province cannot exceed 100 characters.")]
 		public string State { get; set; }
 
-		[MaxLength(50)]
+		[StringLength(32, ErrorMessage = "Postal code cannot exceed 32 characters.")]
 		public string PostalCode { get; set; }
 
-		[MaxLength(100)]
+		[StringLength(100, ErrorMessage = "Country cannot exceed 100 characters.")]
 		public string Country { get; set; }
 
 		public string Latitude { get; set; }

--- a/Web/Resgrid.Web/Areas/User/Views/Connect/Profile.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Connect/Profile.cshtml
@@ -163,7 +163,7 @@
                             <div class="col-sm-10">
                                 <div class="row">
                                     <div class="col-sm-6">
-                                        @Html.TextBoxFor(m => m.Address1, new { @class = "form-control" })
+                                        @Html.TextBoxFor(m => m.Address1, new { @class = "form-control" }) @Html.ValidationMessageFor(m => m.Address1, "", new { @class = "text-danger" })
                                     </div>
                                 </div>
                             </div>
@@ -175,7 +175,7 @@
                             <div class="col-sm-10">
                                 <div class="row">
                                     <div class="col-sm-4">
-                                        @Html.TextBoxFor(m => m.City, new { @class = "form-control" })
+                                        @Html.TextBoxFor(m => m.City, new { @class = "form-control" }) @Html.ValidationMessageFor(m => m.City, "", new { @class = "text-danger" })
                                     </div>
                                 </div>
                             </div>
@@ -187,7 +187,7 @@
                             <div class="col-sm-10">
                                 <div class="row">
                                     <div class="col-sm-4">
-                                        @Html.TextBoxFor(m => m.State, new { @class = "form-control" })
+                                        @Html.TextBoxFor(m => m.State, new { @class = "form-control" }) @Html.ValidationMessageFor(m => m.State, "", new { @class = "text-danger" })
                                     </div>
                                 </div>
                             </div>
@@ -199,7 +199,7 @@
                             <div class="col-sm-10">
                                 <div class="row">
                                     <div class="col-sm-2">
-                                        @Html.TextBoxFor(m => m.PostalCode, new { @class = "form-control" })
+                                        @Html.TextBoxFor(m => m.PostalCode, new { @class = "form-control" }) @Html.ValidationMessageFor(m => m.PostalCode, "", new { @class = "text-danger" })
                                     </div>
                                 </div>
                             </div>
@@ -397,6 +397,7 @@
 }
 @section Scripts
 {
+    <partial name="_ValidationScriptsPartial" />
     <script src="~/clib/croppic/js/croppic.js" type="text/javascript"></script>
     <script>
         var croppicContainerModalOptions = {

--- a/Web/Resgrid.Web/Areas/User/Views/Contacts/Add.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Contacts/Add.cshtml
@@ -106,19 +106,19 @@
                         </div>
                         <div class="form-group">
                             <label class="col-sm-2 control-label">@localizer["CellPhoneLabel"]</label>
-                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["CellPhonePlaceholder"]" asp-for="Contact.CellPhoneNumber"></div>
+                            <div class="col-sm-10"><input type="text" class="form-control js-phone-validate" placeholder="@localizer["CellPhonePlaceholder"]" asp-for="Contact.CellPhoneNumber"><span asp-validation-for="Contact.CellPhoneNumber" class="text-danger"></span><div class="js-phone-feedback small"></div></div>
                         </div>
                         <div class="form-group">
                             <label class="col-sm-2 control-label">@localizer["HomePhoneLabel"]</label>
-                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["HomePhonePlaceholder"]" asp-for="Contact.HomePhoneNumber"></div>
+                            <div class="col-sm-10"><input type="text" class="form-control js-phone-validate" placeholder="@localizer["HomePhonePlaceholder"]" asp-for="Contact.HomePhoneNumber"><span asp-validation-for="Contact.HomePhoneNumber" class="text-danger"></span><div class="js-phone-feedback small"></div></div>
                         </div>
                         <div class="form-group">
                             <label class="col-sm-2 control-label">@localizer["FaxPhoneLabel"]</label>
-                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["FaxPhonePlaceholder"]" asp-for="Contact.FaxPhoneNumber"></div>
+                            <div class="col-sm-10"><input type="text" class="form-control js-phone-validate" placeholder="@localizer["FaxPhonePlaceholder"]" asp-for="Contact.FaxPhoneNumber"><span asp-validation-for="Contact.FaxPhoneNumber" class="text-danger"></span><div class="js-phone-feedback small"></div></div>
                         </div>
                         <div class="form-group">
                             <label class="col-sm-2 control-label">@localizer["OfficePhoneLabel"]</label>
-                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["OfficePhonePlaceholder"]" asp-for="Contact.OfficePhoneNumber"></div>
+                            <div class="col-sm-10"><input type="text" class="form-control js-phone-validate" placeholder="@localizer["OfficePhonePlaceholder"]" asp-for="Contact.OfficePhoneNumber"><span asp-validation-for="Contact.OfficePhoneNumber" class="text-danger"></span><div class="js-phone-feedback small"></div></div>
                         </div>
                         <div class="hr-line-dashed"></div>
                         <h3>
@@ -229,19 +229,19 @@
                         </h3>
                         <div class="form-group">
                             <label class="col-sm-2 control-label">@localizer["AddressLabel"]</label>
-                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["AddressPlaceholder"]" asp-for="PhysicalAddress1"></div>
+                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["AddressPlaceholder"]" asp-for="PhysicalAddress1"><span asp-validation-for="PhysicalAddress1" class="text-danger"></span></div>
                         </div>
                         <div class="form-group">
                             <label class="col-sm-2 control-label">@localizer["CityLabel"]</label>
-                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["CityPlaceholder"]" asp-for="PhysicalCity"></div>
+                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["CityPlaceholder"]" asp-for="PhysicalCity"><span asp-validation-for="PhysicalCity" class="text-danger"></span></div>
                         </div>
                         <div class="form-group">
                             <label class="col-sm-2 control-label">@localizer["StateLabel"]</label>
-                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["StatePlaceholder"]" asp-for="PhysicalState"></div>
+                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["StatePlaceholder"]" asp-for="PhysicalState"><span asp-validation-for="PhysicalState" class="text-danger"></span></div>
                         </div>
                         <div class="form-group">
                             <label class="col-sm-2 control-label">@localizer["PostalCodeLabel"]</label>
-                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["PostalCodePlaceholder"]" asp-for="PhysicalPostalCode"></div>
+                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["PostalCodePlaceholder"]" asp-for="PhysicalPostalCode"><span asp-validation-for="PhysicalPostalCode" class="text-danger"></span></div>
                         </div>
                         <div class="form-group">
                             <label class="col-sm-2 control-label">@localizer["CountryLabel"]</label>
@@ -257,19 +257,19 @@
                         </div>
                         <div class="form-group">
                             <label class="col-sm-2 control-label">@localizer["MailingAddressLabel"]</label>
-                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["MailingAddressPlaceholder"]" asp-for="MailingAddress1"></div>
+                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["MailingAddressPlaceholder"]" asp-for="MailingAddress1"><span asp-validation-for="MailingAddress1" class="text-danger"></span></div>
                         </div>
                         <div class="form-group">
                             <label class="col-sm-2 control-label">@localizer["MailingCityLabel"]</label>
-                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["MailingCityPlaceholder"]" asp-for="MailingCity"></div>
+                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["MailingCityPlaceholder"]" asp-for="MailingCity"><span asp-validation-for="MailingCity" class="text-danger"></span></div>
                         </div>
                         <div class="form-group">
                             <label class="col-sm-2 control-label">@localizer["MailingStateLabel"]</label>
-                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["MailingStatePlaceholder"]" asp-for="MailingState"></div>
+                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["MailingStatePlaceholder"]" asp-for="MailingState"><span asp-validation-for="MailingState" class="text-danger"></span></div>
                         </div>
                         <div class="form-group">
                             <label class="col-sm-2 control-label">@localizer["MailingPostalCodeLabel"]</label>
-                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["MailingPostalCodePlaceholder"]" asp-for="MailingPostalCode"></div>
+                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["MailingPostalCodePlaceholder"]" asp-for="MailingPostalCode"><span asp-validation-for="MailingPostalCode" class="text-danger"></span></div>
                         </div>
                         <div class="form-group">
                             <label class="col-sm-2 control-label">@localizer["MailingCountryLabel"]</label>
@@ -307,6 +307,9 @@
 
 @section Scripts
 {
+    <partial name="_ValidationScriptsPartial" />
+    <script src="~/js/app/resgrid.phonevalidate.js"></script>
+
     <script>
         var sameAddress = '@Model.MailingAddressSameAsPhysical';
     </script>

--- a/Web/Resgrid.Web/Areas/User/Views/Contacts/Edit.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Contacts/Edit.cshtml
@@ -106,19 +106,19 @@
                         </div>
                         <div class="form-group">
                             <label class="col-sm-2 control-label">@localizer["CellPhoneLabel"]</label>
-                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["CellPhonePlaceholder"]" asp-for="Contact.CellPhoneNumber"></div>
+                            <div class="col-sm-10"><input type="text" class="form-control js-phone-validate" placeholder="@localizer["CellPhonePlaceholder"]" asp-for="Contact.CellPhoneNumber"><span asp-validation-for="Contact.CellPhoneNumber" class="text-danger"></span><div class="js-phone-feedback small"></div></div>
                         </div>
                         <div class="form-group">
                             <label class="col-sm-2 control-label">@localizer["HomePhoneLabel"]</label>
-                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["HomePhonePlaceholder"]" asp-for="Contact.HomePhoneNumber"></div>
+                            <div class="col-sm-10"><input type="text" class="form-control js-phone-validate" placeholder="@localizer["HomePhonePlaceholder"]" asp-for="Contact.HomePhoneNumber"><span asp-validation-for="Contact.HomePhoneNumber" class="text-danger"></span><div class="js-phone-feedback small"></div></div>
                         </div>
                         <div class="form-group">
                             <label class="col-sm-2 control-label">@localizer["FaxPhoneLabel"]</label>
-                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["FaxPhonePlaceholder"]" asp-for="Contact.FaxPhoneNumber"></div>
+                            <div class="col-sm-10"><input type="text" class="form-control js-phone-validate" placeholder="@localizer["FaxPhonePlaceholder"]" asp-for="Contact.FaxPhoneNumber"><span asp-validation-for="Contact.FaxPhoneNumber" class="text-danger"></span><div class="js-phone-feedback small"></div></div>
                         </div>
                         <div class="form-group">
                             <label class="col-sm-2 control-label">@localizer["OfficePhoneLabel"]</label>
-                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["OfficePhonePlaceholder"]" asp-for="Contact.OfficePhoneNumber"></div>
+                            <div class="col-sm-10"><input type="text" class="form-control js-phone-validate" placeholder="@localizer["OfficePhonePlaceholder"]" asp-for="Contact.OfficePhoneNumber"><span asp-validation-for="Contact.OfficePhoneNumber" class="text-danger"></span><div class="js-phone-feedback small"></div></div>
                         </div>
                         <div class="hr-line-dashed"></div>
                         <h3>
@@ -229,19 +229,19 @@
                         </h3>
                         <div class="form-group">
                             <label class="col-sm-2 control-label">@localizer["AddressLabel"]</label>
-                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["AddressPlaceholder"]" asp-for="PhysicalAddress1"></div>
+                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["AddressPlaceholder"]" asp-for="PhysicalAddress1"><span asp-validation-for="PhysicalAddress1" class="text-danger"></span></div>
                         </div>
                         <div class="form-group">
                             <label class="col-sm-2 control-label">@localizer["CityLabel"]</label>
-                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["CityPlaceholder"]" asp-for="PhysicalCity"></div>
+                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["CityPlaceholder"]" asp-for="PhysicalCity"><span asp-validation-for="PhysicalCity" class="text-danger"></span></div>
                         </div>
                         <div class="form-group">
                             <label class="col-sm-2 control-label">@localizer["StateLabel"]</label>
-                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["StatePlaceholder"]" asp-for="PhysicalState"></div>
+                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["StatePlaceholder"]" asp-for="PhysicalState"><span asp-validation-for="PhysicalState" class="text-danger"></span></div>
                         </div>
                         <div class="form-group">
                             <label class="col-sm-2 control-label">@localizer["PostalCodeLabel"]</label>
-                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["PostalCodePlaceholder"]" asp-for="PhysicalPostalCode"></div>
+                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["PostalCodePlaceholder"]" asp-for="PhysicalPostalCode"><span asp-validation-for="PhysicalPostalCode" class="text-danger"></span></div>
                         </div>
                         <div class="form-group">
                             <label class="col-sm-2 control-label">@localizer["CountryLabel"]</label>
@@ -257,19 +257,19 @@
                         </div>
                         <div class="form-group">
                             <label class="col-sm-2 control-label">@localizer["MailingAddressLabel"]</label>
-                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["MailingAddressPlaceholder"]" asp-for="MailingAddress1"></div>
+                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["MailingAddressPlaceholder"]" asp-for="MailingAddress1"><span asp-validation-for="MailingAddress1" class="text-danger"></span></div>
                         </div>
                         <div class="form-group">
                             <label class="col-sm-2 control-label">@localizer["MailingCityLabel"]</label>
-                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["MailingCityPlaceholder"]" asp-for="MailingCity"></div>
+                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["MailingCityPlaceholder"]" asp-for="MailingCity"><span asp-validation-for="MailingCity" class="text-danger"></span></div>
                         </div>
                         <div class="form-group">
                             <label class="col-sm-2 control-label">@localizer["MailingStateLabel"]</label>
-                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["MailingStatePlaceholder"]" asp-for="MailingState"></div>
+                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["MailingStatePlaceholder"]" asp-for="MailingState"><span asp-validation-for="MailingState" class="text-danger"></span></div>
                         </div>
                         <div class="form-group">
                             <label class="col-sm-2 control-label">@localizer["MailingPostalCodeLabel"]</label>
-                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["MailingPostalCodePlaceholder"]" asp-for="MailingPostalCode"></div>
+                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["MailingPostalCodePlaceholder"]" asp-for="MailingPostalCode"><span asp-validation-for="MailingPostalCode" class="text-danger"></span></div>
                         </div>
                         <div class="form-group">
                             <label class="col-sm-2 control-label">@localizer["MailingCountryLabel"]</label>
@@ -307,6 +307,9 @@
 
 @section Scripts
 {
+    <partial name="_ValidationScriptsPartial" />
+    <script src="~/js/app/resgrid.phonevalidate.js"></script>
+
     <script>
         var sameAddress = '@Model.MailingAddressSameAsPhysical';
     </script>

--- a/Web/Resgrid.Web/Areas/User/Views/Contacts/Index.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Contacts/Index.cshtml
@@ -82,9 +82,9 @@
 
                                 if (categoryContacts != null && categoryContacts.Any())
                                 {
-                                    @Html.Raw("<div id='contactsTab" + Model.Contacts[i].ContactCategoryId + "' class='contactsTabPannel' style='display: none;'>")
+                                    @Html.Raw("<div id='contactsTab" + Model.ContactCategories[i].ContactCategoryId + "' class='contactsTabPannel' style='display: none;'>")
 
-                                    @Html.Raw($"<div class='table-responsive'><table class='table table-striped' data-page-length='100' width='100%'><thead><tr><th class='span1'></th><th>{@commonLocalizer["Name"]}</th><th>{@commonLocalizer["Type"]}</th><th>{@commonLocalizer["Category"]}</th><th>{@localizer["LastUpdated"]}</th><th data-searchable='false' data-orderable='false'></th></tr></thead><tbody id='contactsCategory_{Model.Contacts[i].ContactCategoryId}'>")
+                                    @Html.Raw($"<div class='table-responsive'><table class='table table-striped' data-page-length='100' width='100%'><thead><tr><th class='span1'></th><th>{@commonLocalizer["Name"]}</th><th>{@commonLocalizer["Type"]}</th><th>{@commonLocalizer["Category"]}</th><th>{@localizer["LastUpdated"]}</th><th data-searchable='false' data-orderable='false'></th></tr></thead><tbody id='contactsCategory_{Model.ContactCategories[i].ContactCategoryId}'>")
 
 
                                     foreach (var c in categoryContacts)

--- a/Web/Resgrid.Web/Areas/User/Views/Department/Address.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Department/Address.cshtml
@@ -49,7 +49,7 @@
                             @localizer["StreetLabel"]
                         </label>
                         <div class="controls">
-                            @Html.TextBoxFor(m => m.Department.Address.Address1, new { @class = "form-control" })
+                            @Html.TextBoxFor(m => m.Department.Address.Address1, new { @class = "form-control" }) @Html.ValidationMessageFor(m => m.Department.Address.Address1, "", new { @class = "text-danger" })
                         </div>
                     </div>
                     <div class="form-group">
@@ -57,7 +57,7 @@
                             @localizer["CityLabel"]
                         </label>
                         <div class="controls">
-                            @Html.TextBoxFor(m => m.Department.Address.City, new { @class = "form-control" })
+                            @Html.TextBoxFor(m => m.Department.Address.City, new { @class = "form-control" }) @Html.ValidationMessageFor(m => m.Department.Address.City, "", new { @class = "text-danger" })
                         </div>
                     </div>
                     <div class="form-group">
@@ -65,7 +65,7 @@
                             @localizer["StateLabel"]
                         </label>
                         <div class="controls">
-                            @Html.TextBoxFor(m => m.Department.Address.State, new { @class = "form-control" })
+                            @Html.TextBoxFor(m => m.Department.Address.State, new { @class = "form-control" }) @Html.ValidationMessageFor(m => m.Department.Address.State, "", new { @class = "text-danger" })
                         </div>
                     </div>
                     <div class="form-group">
@@ -73,7 +73,7 @@
                             @localizer["PostalCodeLabel"]
                         </label>
                         <div class="controls">
-                            @Html.TextBoxFor(m => m.Department.Address.PostalCode, new { @class = "form-control" })
+                            @Html.TextBoxFor(m => m.Department.Address.PostalCode, new { @class = "form-control" }) @Html.ValidationMessageFor(m => m.Department.Address.PostalCode, "", new { @class = "text-danger" })
                         </div>
                     </div>
                     <div class="form-group">
@@ -81,7 +81,7 @@
                             @localizer["CountryLabel"]
                         </label>
                         <div class="controls">
-                            @Html.TextBoxFor(m => m.Department.Address.Country, new { @class = "form-control" })
+                            @Html.TextBoxFor(m => m.Department.Address.Country, new { @class = "form-control" }) @Html.ValidationMessageFor(m => m.Department.Address.Country, "", new { @class = "text-danger" })
                         </div>
                     </div>
                     <div class="form-actions">
@@ -94,5 +94,5 @@
 </div>
 @section Scripts
     {
-
+    <partial name="_ValidationScriptsPartial" />
 }

--- a/Web/Resgrid.Web/Areas/User/Views/Department/Settings.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Department/Settings.cshtml
@@ -139,7 +139,7 @@
                                 @localizer["Street"]
                             </label>
                             <div class="col-sm-10">
-                                @Html.TextBoxFor(m => m.Department.Address.Address1, new { @class = "form-control" })
+                                @Html.TextBoxFor(m => m.Department.Address.Address1, new { @class = "form-control" }) @Html.ValidationMessageFor(m => m.Department.Address.Address1, "", new { @class = "text-danger" })
                             </div>
                         </div>
                         <div class="form-group">
@@ -147,7 +147,7 @@
                                 @localizer["City"]
                             </label>
                             <div class="col-sm-10">
-                                @Html.TextBoxFor(m => m.Department.Address.City, new { @class = "form-control" })
+                                @Html.TextBoxFor(m => m.Department.Address.City, new { @class = "form-control" }) @Html.ValidationMessageFor(m => m.Department.Address.City, "", new { @class = "text-danger" })
                             </div>
                         </div>
                         <div class="form-group">
@@ -155,7 +155,7 @@
                                 @localizer["State"]
                             </label>
                             <div class="col-sm-10">
-                                @Html.TextBoxFor(m => m.Department.Address.State, new { @class = "form-control" })
+                                @Html.TextBoxFor(m => m.Department.Address.State, new { @class = "form-control" }) @Html.ValidationMessageFor(m => m.Department.Address.State, "", new { @class = "text-danger" })
                             </div>
                         </div>
                         <div class="form-group">
@@ -163,7 +163,7 @@
                                 @localizer["Zip"]
                             </label>
                             <div class="col-sm-10">
-                                @Html.TextBoxFor(m => m.Department.Address.PostalCode, new { @class = "form-control" })
+                                @Html.TextBoxFor(m => m.Department.Address.PostalCode, new { @class = "form-control" }) @Html.ValidationMessageFor(m => m.Department.Address.PostalCode, "", new { @class = "text-danger" })
                             </div>
                         </div>
                         <div class="form-group">
@@ -366,5 +366,6 @@
 
 @section Scripts
     {
+    <partial name="_ValidationScriptsPartial" />
     <script src="~/js/app/internal/department/resgrid.department.settings.js" type="text/javascript"></script>
 }

--- a/Web/Resgrid.Web/Areas/User/Views/Groups/EditGroup.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Groups/EditGroup.cshtml
@@ -94,7 +94,7 @@
                                             @localizer["Street"]
                                         </label>
                                         <div class="col-sm-10">
-                                            @Html.TextBoxFor(m => m.Address1, new { @class = "form-control" })
+                                            @Html.TextBoxFor(m => m.Address1, new { @class = "form-control" }) @Html.ValidationMessageFor(m => m.Address1, "", new { @class = "text-danger" })
                                         </div>
                                     </div>
                                     <div class="form-group">
@@ -102,7 +102,7 @@
                                             @localizer["City"]
                                         </label>
                                         <div class="col-sm-10">
-                                            @Html.TextBoxFor(m => m.City, new { @class = "form-control" })
+                                            @Html.TextBoxFor(m => m.City, new { @class = "form-control" }) @Html.ValidationMessageFor(m => m.City, "", new { @class = "text-danger" })
                                         </div>
                                     </div>
                                     <div class="form-group">
@@ -110,7 +110,7 @@
                                             @localizer["StateProvince"]
                                         </label>
                                         <div class="col-sm-10">
-                                            @Html.TextBoxFor(m => m.State, new { @class = "form-control" })
+                                            @Html.TextBoxFor(m => m.State, new { @class = "form-control" }) @Html.ValidationMessageFor(m => m.State, "", new { @class = "text-danger" })
                                         </div>
                                     </div>
                                     <div class="form-group">
@@ -118,7 +118,7 @@
                                             @localizer["ZipPostalCode"]
                                         </label>
                                         <div class="col-sm-10">
-                                            @Html.TextBoxFor(m => m.PostalCode, new { @class = "form-control" })
+                                            @Html.TextBoxFor(m => m.PostalCode, new { @class = "form-control" }) @Html.ValidationMessageFor(m => m.PostalCode, "", new { @class = "text-danger" })
                                         </div>
                                     </div>
                                     <div class="form-group">
@@ -268,6 +268,7 @@
 
 @section Scripts
     {
+    <partial name="_ValidationScriptsPartial" />
     @if (Model.EditGroup.Type.HasValue && Model.EditGroup.Type.Value == (int)DepartmentGroupTypes.Station)
     {
         <script>

--- a/Web/Resgrid.Web/Areas/User/Views/Groups/NewGroup.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Groups/NewGroup.cshtml
@@ -79,7 +79,7 @@
                       @localizer["Street"]
                     </label>
                     <div class="col-sm-10">
-                      @Html.TextBoxFor(m => m.Address1, new { @class = "form-control" })
+                      @Html.TextBoxFor(m => m.Address1, new { @class = "form-control" }) @Html.ValidationMessageFor(m => m.Address1, "", new { @class = "text-danger" })
                     </div>
                   </div>
                   <div class="form-group">
@@ -87,7 +87,7 @@
                       @localizer["City"]
                     </label>
                     <div class="col-sm-10">
-                      @Html.TextBoxFor(m => m.City, new { @class = "form-control" })
+                      @Html.TextBoxFor(m => m.City, new { @class = "form-control" }) @Html.ValidationMessageFor(m => m.City, "", new { @class = "text-danger" })
                     </div>
                   </div>
                   <div class="form-group">
@@ -95,7 +95,7 @@
                       @localizer["StateProvince"]
                     </label>
                     <div class="col-sm-10">
-                      @Html.TextBoxFor(m => m.State, new { @class = "form-control" })
+                      @Html.TextBoxFor(m => m.State, new { @class = "form-control" }) @Html.ValidationMessageFor(m => m.State, "", new { @class = "text-danger" })
                     </div>
                   </div>
                   <div class="form-group">
@@ -103,7 +103,7 @@
                       @localizer["ZipPostalCode"]
                     </label>
                     <div class="col-sm-10">
-                      @Html.TextBoxFor(m => m.PostalCode, new { @class = "form-control" })
+                      @Html.TextBoxFor(m => m.PostalCode, new { @class = "form-control" }) @Html.ValidationMessageFor(m => m.PostalCode, "", new { @class = "text-danger" })
                     </div>
                   </div>
                   <div class="form-group">
@@ -242,5 +242,6 @@
 
 @section Scripts
 {
+  <partial name="_ValidationScriptsPartial" />
   <script src="~/js/app/internal/groups/resgrid.groups.newgroup.js"></script>
 }

--- a/Web/Resgrid.Web/Areas/User/Views/Home/EditUserProfile.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Home/EditUserProfile.cshtml
@@ -170,7 +170,7 @@
                             <label class="col-sm-2 control-label">@localizer["HomeNumberLabel"]</label>
                             <div class="col-sm-10">
                                 <div class="input-group">
-                                    <input type="text" class="form-control" placeholder="@localizer["HomeNumberPlaceholder"]" asp-for="Profile.HomeNumber">
+                                    <input type="text" class="form-control js-phone-validate" data-region-source="PhysicalCountry" placeholder="@localizer["HomeNumberPlaceholder"]" asp-for="Profile.HomeNumber">
                                     @if (!string.IsNullOrWhiteSpace(Model.Profile?.HomeNumber))
                                     {
                                         @if (Model.HomeNumberVerified == true)
@@ -193,6 +193,8 @@
                                         }
                                     }
                                 </div>
+                                <span asp-validation-for="Profile.HomeNumber" class="text-danger"></span>
+                                <div class="js-phone-feedback small"></div>
                                 @if (!string.IsNullOrWhiteSpace(Model.Profile?.HomeNumber) && Model.CanSelfVerify)
                                 {
                                     @if (Model.HomeNumberVerified == false)
@@ -230,7 +232,7 @@
                             <label class="col-sm-2 control-label">@localizer["MobileNumberLabel"]</label>
                             <div class="col-sm-10">
                                 <div class="input-group">
-                                    <input type="text" class="form-control" placeholder="@localizer["MobileNumberPlaceholder"]" asp-for="Profile.MobileNumber">
+                                    <input type="text" class="form-control js-phone-validate" data-region-source="PhysicalCountry" placeholder="@localizer["MobileNumberPlaceholder"]" asp-for="Profile.MobileNumber">
                                     @if (!string.IsNullOrWhiteSpace(Model.Profile?.MobileNumber))
                                     {
                                         @if (Model.MobileNumberVerified == true)
@@ -253,6 +255,8 @@
                                         }
                                     }
                                 </div>
+                                <span asp-validation-for="Profile.MobileNumber" class="text-danger"></span>
+                                <div class="js-phone-feedback small"></div>
                                 @if (!string.IsNullOrWhiteSpace(Model.Profile?.MobileNumber) && Model.CanSelfVerify)
                                 {
                                     @if (Model.MobileNumberVerified == false)
@@ -320,19 +324,19 @@
                         </h3>
                         <div class="form-group">
                             <label class="col-sm-2 control-label">@localizer["AddressLabel"]</label>
-                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["AddressPlaceholder"]" asp-for="PhysicalAddress1"></div>
+                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["AddressPlaceholder"]" asp-for="PhysicalAddress1"><span asp-validation-for="PhysicalAddress1" class="text-danger"></span></div>
                         </div>
                         <div class="form-group">
                             <label class="col-sm-2 control-label">@localizer["CityLabel"]</label>
-                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["CityPlaceholder"]" asp-for="PhysicalCity"></div>
+                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["CityPlaceholder"]" asp-for="PhysicalCity"><span asp-validation-for="PhysicalCity" class="text-danger"></span></div>
                         </div>
                         <div class="form-group">
                             <label class="col-sm-2 control-label">@localizer["StateLabel"]</label>
-                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["StatePlaceholder"]" asp-for="PhysicalState"></div>
+                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["StatePlaceholder"]" asp-for="PhysicalState"><span asp-validation-for="PhysicalState" class="text-danger"></span></div>
                         </div>
                         <div class="form-group">
                             <label class="col-sm-2 control-label">@localizer["PostalCodeLabel"]</label>
-                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["PostalCodePlaceholder"]" asp-for="PhysicalPostalCode"></div>
+                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["PostalCodePlaceholder"]" asp-for="PhysicalPostalCode"><span asp-validation-for="PhysicalPostalCode" class="text-danger"></span></div>
                         </div>
                         <div class="form-group">
                             <label class="col-sm-2 control-label">@localizer["CountryLabel"]</label>
@@ -348,19 +352,19 @@
                         </div>
                         <div class="form-group">
                             <label class="col-sm-2 control-label">@localizer["MailingAddressLabel"]</label>
-                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["MailingAddressPlaceholder"]" asp-for="MailingAddress1"></div>
+                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["MailingAddressPlaceholder"]" asp-for="MailingAddress1"><span asp-validation-for="MailingAddress1" class="text-danger"></span></div>
                         </div>
                         <div class="form-group">
                             <label class="col-sm-2 control-label">@localizer["MailingCityLabel"]</label>
-                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["MailingCityPlaceholder"]" asp-for="MailingCity"></div>
+                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["MailingCityPlaceholder"]" asp-for="MailingCity"><span asp-validation-for="MailingCity" class="text-danger"></span></div>
                         </div>
                         <div class="form-group">
                             <label class="col-sm-2 control-label">@localizer["MailingStateLabel"]</label>
-                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["MailingStatePlaceholder"]" asp-for="MailingState"></div>
+                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["MailingStatePlaceholder"]" asp-for="MailingState"><span asp-validation-for="MailingState" class="text-danger"></span></div>
                         </div>
                         <div class="form-group">
                             <label class="col-sm-2 control-label">@localizer["MailingPostalCodeLabel"]</label>
-                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["MailingPostalCodePlaceholder"]" asp-for="MailingPostalCode"></div>
+                            <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["MailingPostalCodePlaceholder"]" asp-for="MailingPostalCode"><span asp-validation-for="MailingPostalCode" class="text-danger"></span></div>
                         </div>
                         <div class="form-group">
                             <label class="col-sm-2 control-label">@localizer["MailingCountryLabel"]</label>
@@ -821,6 +825,10 @@
 
 @section Scripts
 {
+    <partial name="_ValidationScriptsPartial" />
+
+    <script src="~/js/app/resgrid.phonevalidate.js"></script>
+
     <script>
         var sameAddress = '@Model.MailingAddressSameAsPhysical';
         var rgVerifySendUrl = resgrid.absoluteBaseUrl + '/User/Home/SendContactVerificationCode';

--- a/Web/Resgrid.Web/Areas/User/Views/Personnel/AddPerson.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Personnel/AddPerson.cshtml
@@ -218,6 +218,7 @@
 
 @section Scripts
   {
+  <partial name="_ValidationScriptsPartial" />
   <script>
 		var isUserGroupAdmin = '@Model.IsUserGroupAdmin';
   </script>

--- a/Web/Resgrid.Web/Areas/User/Views/Personnel/AddPerson.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Personnel/AddPerson.cshtml
@@ -113,7 +113,7 @@
             </h3>
             <div class="form-group">
               <label class="col-sm-2 control-label">@localizer["MobileNumberLabel"]</label>
-              <div class="col-sm-10"><input type="text" class="form-control" placeholder="@localizer["MobileNumberPlaceholder"]" asp-for="Profile.MobileNumber"></div>
+              <div class="col-sm-10"><input type="text" class="form-control js-phone-validate" placeholder="@localizer["MobileNumberPlaceholder"]" asp-for="Profile.MobileNumber"><span asp-validation-for="Profile.MobileNumber" class="text-danger"></span><div class="js-phone-feedback small"></div></div>
             </div>
             <div class="form-group">
               <label class="col-sm-2 control-label">@localizer["MobileCarrierLabel"]</label>
@@ -247,4 +247,5 @@
               });
             });
     </script>
+    <script src="~/js/app/resgrid.phonevalidate.js"></script>
 }

--- a/Web/Resgrid.Web/Helpers/PhoneValidationHelper.cs
+++ b/Web/Resgrid.Web/Helpers/PhoneValidationHelper.cs
@@ -1,0 +1,32 @@
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Resgrid.Framework;
+using Resgrid.Model.Providers;
+
+namespace Resgrid.Web.Helpers
+{
+	/// <summary>
+	/// Server-side phone-number backstop shared by the phone-entry controllers (matches the EditUserProfile flow).
+	/// Validates a number (blanks are allowed/skipped) and returns its canonical E.164 form so callers can persist a
+	/// Twilio-sendable value. On an invalid number it adds a ModelState error against <paramref name="fieldKey"/>
+	/// (so the matching asp-validation-for span shows it) and returns the original value unchanged.
+	/// </summary>
+	public static class PhoneValidationHelper
+	{
+		public static string ValidateAndNormalize(IPhoneNumberProcesserProvider processer, ModelStateDictionary modelState,
+			string fieldKey, string label, string number, string countryName)
+		{
+			if (string.IsNullOrWhiteSpace(number))
+				return number;
+
+			var result = processer?.Process(number, PhoneRegionHelper.ToIso(countryName));
+			if (result == null || !result.IsValid || string.IsNullOrWhiteSpace(result.InternationalNumber))
+			{
+				modelState.AddModelError(fieldKey,
+					$"The {label} doesn't look valid. Enter it in full international format, starting with the country code (for example +27 82 446 1783).");
+				return number;
+			}
+
+			return result.InternationalNumber;
+		}
+	}
+}

--- a/Web/Resgrid.Web/wwwroot/js/app/resgrid.phonevalidate.js
+++ b/Web/Resgrid.Web/wwwroot/js/app/resgrid.phonevalidate.js
@@ -1,0 +1,102 @@
+// Shared live phone-number validation for entry forms.
+// Any <input class="js-phone-validate"> is validated on blur against the server's ValidatePhoneNumber endpoint
+// (read from data-validate-url, default /User/Home/ValidatePhoneNumber). Inline feedback (a sibling
+// .js-phone-feedback element, or the first one within the surrounding .form-group) shows a warning and a
+// one-click "Use this" button to apply the canonical E.164 form. An optional data-region-source attribute
+// names the id of a country <select>/<input> whose value is sent as the region hint so a national-format
+// number (e.g. "082446...") can be recognized and normalized.
+(function () {
+    var DEFAULT_URL = '/User/Home/ValidatePhoneNumber';
+
+    function urlFor(input) {
+        return input.getAttribute('data-validate-url') || DEFAULT_URL;
+    }
+
+    function regionFor(input) {
+        // Explicit data-region-source wins; otherwise fall back to a physical-country dropdown if the form has one
+        // (the profile, contact and personnel forms all use the id "PhysicalCountry"), so locals can be normalized.
+        var id = input.getAttribute('data-region-source') || 'PhysicalCountry';
+        var el = document.getElementById(id);
+        return el ? (el.value || '') : '';
+    }
+
+    function feedbackFor(input) {
+        // Prefer an adjacent feedback element (handles several phone fields in one .form-group)...
+        var n = input.nextElementSibling;
+        while (n) {
+            if (n.classList && n.classList.contains('js-phone-feedback')) return n;
+            n = n.nextElementSibling;
+        }
+        // ...otherwise fall back to the first one in the surrounding form group.
+        var scope = (input.closest && input.closest('.form-group')) || input.parentNode;
+        return scope ? scope.querySelector('.js-phone-feedback') : null;
+    }
+
+    function makeUseButton(input, value, feedback) {
+        var btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'btn btn-xs btn-default';
+        btn.style.marginLeft = '6px';
+        btn.textContent = 'Use this';
+        btn.addEventListener('click', function () {
+            input.value = value;
+            feedback.innerHTML = '<span class="text-success">Updated to ' + value + '</span>';
+        });
+        return btn;
+    }
+
+    function render(feedback, input, data) {
+        feedback.innerHTML = '';
+        if (!data) return;
+        if (data.isValid) {
+            if (data.formatted && data.formatted !== (input.value || '').trim()) {
+                var ok = document.createElement('div');
+                ok.className = 'text-success';
+                ok.innerHTML = 'Looks good — standard format: <strong>' + data.formatted + '</strong>';
+                ok.appendChild(makeUseButton(input, data.formatted, feedback));
+                feedback.appendChild(ok);
+            }
+            return;
+        }
+        var warn = document.createElement('div');
+        warn.className = 'text-danger';
+        warn.textContent = data.message || 'This number does not look valid.';
+        feedback.appendChild(warn);
+        if (data.formatted) {
+            var sug = document.createElement('div');
+            sug.className = 'text-warning';
+            sug.innerHTML = 'Did you mean <strong>' + data.formatted + '</strong>?';
+            sug.appendChild(makeUseButton(input, data.formatted, feedback));
+            feedback.appendChild(sug);
+        }
+    }
+
+    function validate(input) {
+        var feedback = feedbackFor(input);
+        if (!feedback) return;
+        var num = (input.value || '').trim();
+        if (!num) { feedback.innerHTML = ''; return; }
+        fetch(urlFor(input), {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ number: num, country: regionFor(input) })
+        }).then(function (r) { return r.ok ? r.json() : null; })
+          .then(function (data) { render(feedback, input, data); })
+          .catch(function () { /* network error: server-side save still validates */ });
+    }
+
+    function wire() {
+        var inputs = document.querySelectorAll('.js-phone-validate');
+        for (var i = 0; i < inputs.length; i++) {
+            (function (input) {
+                input.addEventListener('blur', function () { validate(input); });
+            })(inputs[i]);
+        }
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', wire);
+    } else {
+        wire();
+    }
+})();

--- a/docs/architecture/offline-first-architecture.md
+++ b/docs/architecture/offline-first-architecture.md
@@ -1,0 +1,416 @@
+# Resgrid Offline-First Architecture
+
+**Status:** Design / proposal
+**Author:** Resgrid IC backend work (RIC-T39 follow-on)
+**Last updated:** 2026-06-24
+**Applies to:** Resgrid **IC** app (new, `../IC`), Resgrid **Unit** app (existing, `../Unit`), Resgrid **Core** backend (this repo)
+
+> This document is the single source of truth for how the Resgrid mobile apps work
+> **fully offline** and **sync back** when reconnected. It is written so the **Unit**
+> app team can implement the identical pattern — both apps share one design.
+
+---
+
+## 1. Goal & scenario
+
+A responder logs in and **syncs at the start of a shift** (online, usually on station
+WiFi) and pulls down everything they need. They then drive to an incident where there is
+**no cell or WiFi**. The app must remain **useful offline** — they can view calls / the
+command board / roster / maps, and they can **take actions** (set status, set location,
+check in, assign resources, complete objectives, add annotations, etc.). Those actions are
+**captured locally** and **synced back** to Resgrid automatically when the device returns
+to connectivity (at the incident if cell returns, or back at station/office).
+
+**Hard requirements**
+
+1. Full read functionality offline for the shift's working data set.
+2. Full write capture offline, replayed on reconnect, with no lost or duplicated work.
+3. **Offline mapping** — map tiles for the operational area must be available with no network.
+4. One design, documented, implementable in **both IC and Unit**.
+
+**Non-goals (v1)**
+
+- Real-time multi-device collaborative editing while offline (no CRDTs). Resgrid writes are
+  overwhelmingly *additive, timestamped intent-events*, not concurrent edits to a shared document.
+- Offline geocoding / turn-by-turn routing (vector search + routing need network; we cache
+  tiles and known POIs/destinations only). Documented as a limitation.
+
+---
+
+## 2. Why this design (decision record)
+
+**Decision:** *Evolve* the persistence + outbox stack the Unit app already uses
+(**Zustand + MMKV + an offline event queue**) into a complete sync layer. Do **not**
+introduce a new on-device database or a managed sync engine for v1.
+
+The Unit app is already ~40% of the way here. State of the world today (`../Unit`):
+
+| Capability | Today | Gap to close |
+|---|---|---|
+| Persistence | Zustand 4.5.7 + **MMKV 3.1.0** (encrypted), `zustandStorage` adapter | Most domain stores (e.g. `calls`) are **not persisted** → nothing to read offline |
+| Write outbox | **Exists**: `src/stores/offline-queue/store.ts` (4 event types, retry/backoff) drained by `src/services/offline-event-manager.service.ts` | Only 4 event types; **no ordering, no idempotency, no dependencies**; relies on backend being idempotent |
+| Read cache | `src/api/common/cached-client.ts` + `cache-manager.ts`, 5-min TTL in MMKV | **Does not serve stale data when offline** — returns only *fresh* entries. Biggest single blocker |
+| Maps | **@rnmapbox/maps 10.2.10** (Mapbox, native v11.16.2) | `offlineManager.createPack()` supported but unused |
+| Realtime | `@microsoft/signalr 8.0.17`, 2 hubs (update + geo) | Needs reconnect reconciliation |
+| Auth offline | Tokens in MMKV, `offline_access` scope, network-vs-401 already distinguished in `client.tsx` | Mostly fine |
+
+**Alternatives considered and rejected for v1:**
+
+- **Embedded SQLite (op-sqlite + Drizzle).** More robust at scale, but the per-shift/per-incident
+  working set is hundreds–low-thousands of records, not millions; SQL's query/row-write edge is
+  marginal here, and retrofitting both apps' domain stores onto a new persistence layer is a large
+  migration. **Kept as a documented upgrade path** for individual hot datasets (see §11).
+- **Managed sync engine (PowerSync / ElectricSQL / WatermelonDB / RxDB).** Least custom sync code,
+  but PowerSync/Electric sync from the *database* via Postgres CDC and route writes around your
+  service layer — that fights Resgrid's heavy server-side business logic (billing, workflows,
+  accountability) and its dual SQL Server + PostgreSQL backends. WatermelonDB/RxDB still require a
+  full persistence-layer rewrite in both apps. Rejected.
+
+**Consequences:** lowest risk, fastest to ship in both apps, one mental model. The cost is that we
+own the sync logic (orchestrator, conflict rules, idempotency) — which this document specifies.
+
+---
+
+## 3. Architecture overview
+
+```
+┌──────────────────────────── Device (IC app / Unit app) ────────────────────────────┐
+│                                                                                      │
+│   UI (React / Expo Router)                                                           │
+│     │  reads (reactive)              ▲ optimistic apply                              │
+│     ▼                                │                                               │
+│   Zustand stores  ──── persist ────► MMKV (encrypted)  ◄── stale-while-offline reads │
+│     │                                                                                │
+│     │ write intent                                                                   │
+│     ▼                                                                                │
+│   Outbox (offline-queue store, MMKV)  ── ordered, idempotent ──┐                     │
+│                                                                │                     │
+│   Sync Orchestrator  ◄─────────────────────────────────────────┘                    │
+│     • fullSync()  (shift start)                                                      │
+│     • drain()     (replay outbox on reconnect)                                       │
+│     • pullDelta() (reconcile server-authoritative truth)                             │
+│     • map pre-download (offlineManager.createPack)                                   │
+│     │                                                                                │
+│   NetInfo (online/offline)        SignalR (live updates when online)                │
+└─────┼────────────────────────────────────┼─────────────────────────────────────────┘
+      │ REST v4                             │ CQRS push (callsUpdated, incidentCommandUpdated…)
+      ▼                                     ▼
+┌──────────────────────────── Resgrid Core backend (this repo) ───────────────────────┐
+│  v4 REST controllers + Services + Repos    CQRS/SignalR (ICoreEventService)          │
+│  NEW: delta endpoints, idempotent creates, tombstones, sync bundle (see §9)          │
+└──────────────────────────────────────────────────────────────────────────────────┘
+```
+
+Three sync phases, described in §6–§8: **(1) shift-start hydration**, **(2) offline operation**,
+**(3) reconnect sync-back**.
+
+---
+
+## 4. Local persistence model
+
+**Keep MMKV + Zustand `persist`.** Every store that holds data needed offline must:
+
+1. Wrap its store in `persist(...)` using the existing `zustandStorage` adapter
+   (`src/lib/storage/index.tsx` → `createJSONStorage(() => zustandStorage)`).
+2. Use `partialize` to persist only durable server data + sync metadata (exclude transient flags
+   like `isLoading`).
+3. Carry per-store sync metadata: `lastSyncAt: number`, and where applicable a server `syncToken`/
+   high-water timestamp for delta pulls.
+
+> **Action item:** the `calls` store (and any other currently-ephemeral domain store) must be
+> converted to `persist`. Today `src/stores/calls/store.ts` re-fetches on launch and has nothing to
+> show offline. This is the first concrete code change in the Unit app and the default for every IC
+> store.
+
+**Stale-while-offline (critical fix).** Upgrade `cached-client.ts` so that when
+`NetInfo.isConnected === false` (or a request fails with a network error), it **returns the last
+cached value even if its TTL expired**, flagged as stale. Today it only returns *fresh* entries, so
+offline reads return nothing. The cache becomes the read fallback; persisted Zustand stores are the
+primary offline read source.
+
+Read precedence offline: **persisted store → stale cache → empty/typed-default** (never throw).
+
+**Storage budget.** MMKV holds JSON; keep persisted payloads to the working set. Prune on incident
+close (drop closed-incident command boards, their map packs, completed/uploaded outbox entries).
+
+---
+
+## 5. The outbox (generalized write model)
+
+Generalize the existing `offline-queue` from 4 hard-coded event types to a **typed intent-event**
+that can represent any mutation in either app.
+
+### 5.1 Event contract
+
+```ts
+interface QueuedEvent {
+  id: string;                 // client UUID — ALSO the idempotency key sent to the server
+  type: QueuedEventType;      // discriminator → handler + endpoint (see registry below)
+  entityType: string;         // 'IncidentCommand' | 'UnitStatus' | 'CheckIn' | 'Annotation' | …
+  op: 'create' | 'update' | 'delete' | 'action';
+  payload: Record<string, unknown>;   // request body; for creates, INCLUDES the client-generated GUID PK
+  dependsOn?: string;         // id of a prior queued event that must COMPLETE first (FK ordering)
+  clientCreatedAt: number;    // ms — authoritative timestamp for last-write-wins
+  // existing fields retained:
+  status: 'pending' | 'processing' | 'failed' | 'completed';
+  retryCount: number; maxRetries: number;
+  createdAt: number; lastAttemptAt?: number; nextRetryAt?: number; error?: string;
+}
+```
+
+This is a superset of today's shape — existing events migrate by adding `entityType`/`op`/
+`clientCreatedAt`/`dependsOn`. Persistence (MMKV key `offline-queue-storage`, `partialize`) is unchanged.
+
+### 5.2 Handler registry
+
+Replace the per-type `switch` in `offline-event-manager.service.ts` with a registry mapping
+`QueuedEventType → { apiCall, onSuccess(serverResult), isIdempotent }`. Adding a new offline
+mutation = one registry entry, in either app. Today's 4 handlers (UNIT_STATUS, LOCATION_UPDATE,
+CALL_IMAGE_UPLOAD, CHECK_IN) become registry entries.
+
+### 5.3 Drainer changes (correctness)
+
+The current drainer (`Promise.allSettled`, 3 concurrent, **no ordering**) is unsafe once events have
+dependencies (e.g. *assign resource* offline before *establish command* has synced). Required changes:
+
+- **Order by `createdAt`** and **honor `dependsOn`**: an event whose dependency is not yet
+  `completed` is skipped this pass (stays pending). Independent events may still run concurrently.
+- **Idempotency on replay** (see §5.4) so a partial success + retry never double-applies.
+- Keep: netinfo gate, AppState trigger + 10 s interval, exponential backoff, max-retries → `failed`
+  with manual retry. Add a **dead-letter** surfacing UI for permanently failed events (today they
+  silently sit in `failed`).
+
+### 5.4 Idempotency (the key to safe replay)
+
+Two mechanisms, chosen per entity:
+
+- **Client-generated GUID PK for creates.** Resgrid entities already use string-GUID PKs that the
+  *service* sets via `Guid.NewGuid().ToString()`. Change create endpoints to **honor a client-supplied
+  id when present** and **upsert by PK**. The client generates the GUID offline, stores it locally,
+  and includes it in the payload → replaying the create is a no-op the second time. This makes
+  additive records (annotations, objectives, resource/role assignments, ad-hoc resources) safe.
+- **Idempotency key for actions.** Append/telemetry actions (check-in, set status, set location)
+  send `id` (the event UUID) as an idempotency key; the server dedups on
+  `(DepartmentId, UserId, IdempotencyKey)` within a window, or simply accepts last-write-wins by
+  `clientCreatedAt` (a replayed status with the same timestamp is harmless).
+
+### 5.5 Optimistic apply
+
+On a write the app: (1) generates the GUID/event, (2) **applies the change to the Zustand store
+immediately** (so the UI updates offline) with a `_pendingSync` flag, (3) enqueues the outbox event.
+On successful drain, clear `_pendingSync` and reconcile with the server result. On permanent failure,
+mark the local record `_syncError` and surface it (do **not** silently roll back field work).
+
+---
+
+## 6. Phase 1 — Shift-start hydration (online)
+
+`SyncOrchestrator.fullSync()`, run on login / "Sync now":
+
+1. **Bulk pull** all working data in parallel and persist to stores. For IC: active calls + call
+   metadata, command boards for active incidents, lanes/resources/objectives/timers/roles/annotations,
+   accountability/check-in status, mutual-aid + ad-hoc resources, department units/personnel/statuses,
+   groups, POIs/destinations, protocols, contacts, config. For Unit: its existing `init()` set, now
+   persisted, plus routes/protocols/weather.
+2. **Download offline map packs** (see §10) for the operational area and any active-incident bounds.
+3. Record `lastSyncAt` / per-store high-water timestamps; show progress + a "Synced ✓ (time)" state.
+4. Pre-warm SignalR so live updates keep the cache hot while still online.
+
+Optional backend optimization: a single `/Sync/Bundle` aggregate endpoint (§9) to cut round-trips.
+v1 can fan out existing `GetAll*` calls.
+
+---
+
+## 7. Phase 2 — Offline operation
+
+- **Reads**: served from persisted Zustand stores; `cached-client` returns stale-when-offline.
+  NetInfo drives a global "Offline" banner + per-record "pending sync" chips.
+- **Writes**: optimistic apply (§5.5) → outbox enqueue. The UI never blocks on the network.
+- **Maps**: render from the downloaded offline pack; user location from GPS (works offline);
+  annotations/markers are local store data.
+- **Auth**: tokens already persist in MMKV; refresh fails gracefully offline (existing
+  network-vs-401 logic in `client.tsx`). Ensure the access token's absence/expiry while offline does
+  **not** force logout — gate logout on a *non-network* 401 only (already the case) and allow the app
+  to operate read/write-to-outbox with an expired token; the outbox drains after a successful refresh
+  on reconnect.
+
+---
+
+## 8. Phase 3 — Reconnect sync-back
+
+NetInfo offline→online transition triggers, in order:
+
+1. **Refresh auth** if needed (existing flow).
+2. **Drain the outbox** (§5.3) — ordered, dependency-aware, idempotent. Each success updates the
+   local record with the server's canonical result and clears `_pendingSync`.
+3. **Pull delta / reconcile** (§9): fetch server changes since `lastSyncAt` and merge using the
+   conflict policy (§8.1). This catches edits made by *others* (dispatch, other responders) while
+   this device was offline.
+4. **Reconnect SignalR** and resume live updates; set `lastSyncAt = now`.
+
+### 8.1 Conflict-resolution policy (per entity class)
+
+| Class | Examples | Policy |
+|---|---|---|
+| **Telemetry / time-series** | unit/personnel status, location, check-in | **Server-authoritative, accept by timestamp (LWW).** Replays harmless. |
+| **Additive records** | annotations, timeline/log entries, objectives, resource & role assignments, ad-hoc resources, call notes/images | **Client GUID PK → idempotent create.** No real conflict; duplicates impossible via PK. |
+| **Mutable singletons** | the IncidentCommand, lane structure, action plan, call fields | **LWW by `ModifiedOn`**; last writer wins, prior value recorded to the timeline. The one-active-command unique index (M0077) already prevents the worst split-brain. |
+| **Deletes** | removed lanes/assignments/resources | **Tombstones** (soft-delete `DeletedOn`) so delta pull propagates the removal to all clients. |
+
+Field-ops reality: contention is rare because each responder mostly writes *their own* status/location/
+check-in and *adds* records. LWW + idempotent-additive covers the overwhelming majority; the timeline
+preserves an audit trail when a singleton is overwritten.
+
+---
+
+## 9. Backend changes required (Core repo)
+
+These land in this repo as the next backend chunk (migrations start at **M0081**, never renumber —
+see the IC backend state doc). All are additive and apply to **both** SQL Server and PostgreSQL.
+
+1. **Consistent change-tracking columns.** Ensure offline-relevant entities have
+   `CreatedOn`, `ModifiedOn` (set on every write), and `DeletedOn` (soft-delete/tombstone). Many IC
+   entities have `CreatedOn`/`Timestamp` already; audit and backfill the rest.
+2. **Idempotent creates.** v4 create endpoints honor a **client-supplied GUID PK** and upsert by PK
+   (today the services overwrite with `Guid.NewGuid()`). Guard for cross-department ownership exactly
+   as the existing IC create paths do.
+3. **Action idempotency keys.** Check-in / status / location endpoints accept an `IdempotencyKey`
+   (the outbox event id) and dedup on `(DepartmentId, UserId, IdempotencyKey)` within a window — or
+   rely on LWW-by-timestamp where natural.
+4. **Delta endpoint(s).** `GET /api/v4/Sync/Changes?since={utcIso}&types=Calls,IncidentCommand,…`
+   returning, per type, `created/updated` rows and `deleted` ids (from tombstones) with a new
+   server high-water `syncToken`. v1 may implement per-domain `GetChangedSince` and full-refetch the
+   small reference sets; build true deltas first for the large sets (messages, call/audit history).
+5. **(Optional) `GET /api/v4/Sync/Bundle`** — one aggregate shift-start pull to reduce round-trips.
+
+> CQRS/SignalR already publishes live updates including `IncidentCommandUpdated = 22`
+> (`ICoreEventService.IncidentCommandUpdatedAsync`). The delta endpoints are the *catch-up* path for
+> what was missed while offline; SignalR is the *live* path while online. Keep both.
+
+---
+
+## 10. Offline mapping (@rnmapbox/maps)
+
+Mapbox is already the map engine (`@rnmapbox/maps 10.2.10`, native v11). Use its **offline pack**
+API — no map-library change.
+
+```ts
+await offlineManager.createPack({
+  name: `incident-${callId}`,
+  styleURL: StyleURL.Street,   // the style already in use
+  minZoom: 10,
+  maxZoom: 16,                 // cap to bound size; see caveats
+  bounds: [[swLng, swLat], [neLng, neLat]],
+}, onProgress, onError);
+```
+
+**What to pre-download at shift start (§6):**
+
+- **Operational area pack** — wide bounds (department/station AO), lower max zoom (~13–14) for
+  context.
+- **Per-incident pack(s)** — tight bounds around each active call location, higher max zoom (~16) for
+  tactical detail. Created on incident establish; deleted on incident close to reclaim space.
+
+**Caveats (from the rnmapbox issue tracker — design around these):**
+
+- The **Mapbox access token must be set before `createPack`** or iOS can crash. Sequence map init
+  before any offline download.
+- **Tile-count limits / Mapbox ToS** apply (`setTileCountLimit`); do not bypass. Cap `maxZoom` and
+  bounds so a pack stays within budget; surface download size to the user.
+- Historical Android bugs around zoom > 15 and pack usability — validate on target devices; keep
+  `maxZoom ≤ 16` unless verified.
+- All `offlineManager` methods are async (SQLite-backed); show progress and handle partial downloads
+  / resume.
+
+**Limitations (documented):** offline geocoding/search and routing are **not** available without
+network — cache known POIs/destinations/routes as store data instead. Satellite/imagery packs are
+large; default to the vector street style offline.
+
+---
+
+## 11. Reuse across IC and Unit (shared module)
+
+Both apps must run the *same* implementation. Neither app is a monorepo today.
+
+**Recommended:** extract the sync layer into a single shared TypeScript module with a stable public
+API, consumed by both apps:
+
+- `SyncOrchestrator` (`fullSync`, `drain`, `pullDelta`, map pre-download)
+- the generalized outbox store + handler-registry types
+- the `zustandStorage`/MMKV persist helpers (already identical in spirit)
+- the stale-while-offline `cached-client` wrapper
+- the conflict-resolution helpers + entity policy table
+- the Mapbox offline-pack helper
+
+Packaging options, in order of preference:
+1. **Private package** `@resgrid/offline-sync` (local `file:`/workspace link or private registry) —
+   one source of truth, versioned.
+2. A shared folder consumed by both via path alias / git submodule.
+3. **Copy with a documented contract** (this doc) — acceptable for v1 if packaging is deferred, as
+   long as both copies stay in lockstep.
+
+App-specific pieces stay in each app: the **entity registry** (which stores/endpoints exist), the
+**data scope** to hydrate, and the **map bounds** logic. The orchestrator, outbox, conflict engine,
+and map helper are shared verbatim.
+
+---
+
+## 12. Per-app offline data scope
+
+**IC app** — "useful offline at an incident": the command board for active incidents (lanes,
+resources, objectives, timers, roles, annotations, timeline), accountability/PAR status, mutual-aid +
+ad-hoc resources, department units/personnel/statuses, call detail + metadata, POIs/destinations,
+protocols, maps for the incident area. Offline writes: establish/transfer/close command, lane CRUD,
+resource assign/move/release, role assign/remove, objective complete, timer start/ack, annotations,
+check-ins, status/location.
+
+**Unit app** — its current `init()` data made durable: active calls + metadata, units, personnel +
+statuses + staffing, dispatches, contacts, groups, POIs, routes, protocols, weather. Offline writes:
+the existing 4 (status, location, call image, check-in) plus call notes/files/close as needed.
+
+---
+
+## 13. Implementation sequencing
+
+1. **Backend (this repo):** change-tracking columns + idempotent creates + action idempotency keys
+   (migrations M0081+), then delta endpoint(s). Each is additive and independently shippable.
+2. **Shared sync module:** generalize the outbox + handler registry; build `SyncOrchestrator`;
+   upgrade `cached-client` to stale-while-offline; Mapbox offline-pack helper.
+3. **Unit app adoption (lower risk, proves the pattern):** persist the ephemeral stores; wire the
+   orchestrator; pre-download maps; move the 4 existing events onto the generalized outbox.
+4. **IC app (Part B):** built offline-first from the start on the shared module.
+5. **Reconnect reconciliation + SignalR catch-up:** delta pull on reconnect; conflict policy; dead-letter UI.
+
+---
+
+## 14. Risks & open questions
+
+- **Backfilling `ModifiedOn`/tombstones** across legacy Resgrid entities is the largest backend
+  effort; scope delta sync to offline-relevant entities first.
+- **Idempotent creates** require auditing every targeted v4 create endpoint to honor a client PK
+  safely (ownership guards must hold).
+- **Mapbox tile budget / ToS** for fleet-wide offline downloads — confirm licensing/limits with
+  Mapbox for the expected device count and AO sizes.
+- **MMKV size ceiling** for very large datasets (long message/call history) — the documented upgrade
+  path is op-sqlite for *that dataset only*, behind the same store interface.
+- **Clock skew** affects LWW — prefer server `ModifiedOn` for singletons; use `clientCreatedAt` only
+  for the device's own telemetry.
+- **Long-offline token expiry** — verify the refresh-token lifetime (`offline_access`) exceeds a
+  realistic offline shift; if not, allow a longer-lived refresh for the mobile scope.
+
+---
+
+## 15. References
+
+- Unit app stack: Zustand+MMKV stores (`src/stores/*`), outbox (`src/stores/offline-queue/store.ts`,
+  `src/services/offline-event-manager.service.ts`), cache (`src/api/common/cached-client.ts`,
+  `src/lib/cache/cache-manager.ts`), client (`src/api/common/client.tsx`), maps
+  (`src/components/maps/*`), SignalR (`src/services/signalr.service.ts`).
+- IC backend (this repo): `Core/Resgrid.Model/IncidentCommand/*`, `Core/Resgrid.Services/IncidentCommandService.cs`,
+  v4 controllers under `Web/Resgrid.Web.Services/Controllers/v4/`, CQRS `CqrsEventTypes.IncidentCommandUpdated = 22`.
+- Mapbox offline: rnmapbox `offlineManager` docs — https://rnmapbox.github.io/docs/components/offlineManager
+- Local-first / sync background: PowerSync RN local-DB options
+  (https://powersync.com/blog/react-native-local-database-options), Expo local-first guide
+  (https://docs.expo.dev/guides/local-first/), RxDB RN (https://rxdb.info/react-native-database.html).
+- Sync patterns: outbox + idempotency (https://microservices.io/patterns/data/transactional-outbox.html),
+  offline conflict resolution (https://www.sachith.co.uk/offline-sync-conflict-resolution-patterns-architecture-trade%E2%80%91offs-practical-guide-feb-19-2026/).


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Pull Request Description

This PR delivers the **backend foundation for offline-first Incident Command (IC)** plus several **SMS deliverability**, **phone-number validation**, and **data-truncation** fixes.

### 1. Offline-First Sync Foundation (RIC-T39)
Establishes the server-side primitives the mobile apps need to work fully offline and reconcile on reconnect (documented in the new `docs/architecture/offline-first-architecture.md`):

- **Change tracking**: adds a `ModifiedOn` cursor (and a `DeletedOn` soft-delete tombstone for lanes) to all mutable incident-command entities via the new `IChangeTracked` interface. Every insert/update stamps it through the new `Touch()` / `UpsertOwnedAsync()` helpers.
- **Delta sync endpoint**: new `GET /api/v4/Sync/Changes?since=` returns every changed row (including soft-deleted/closed/released) for the caller's department, with a `ServerTimestampMs` cursor for the next pull.
- **Idempotent creates**: create paths now **honor a client-supplied GUID PK** and upsert by existence (not by id-presence), so an offline-created row replays without duplicating; foreign-department rows are rejected.
- **Idempotency keys for check-ins**: `CheckInRecord.IdempotencyKey` (with a filtered unique index) dedups replayed offline check-ins; a post-violation recovery adopts the winning row instead of erroring.
- **Soft-delete for lanes**: `DeleteNodeAsync` now sets a tombstone instead of hard-deleting, so removals propagate on delta sync.
- DB migrations M0081–M0083 (SQL Server + PostgreSQL twins) add the columns/indexes.

### 2. SMS Deliverability & Cost
New `SmsContentHelper` applied at the single chokepoint (and the workflow SMS executor) before sending:
- **Strips non-allow-listed URLs** (A2P 10DLC carrier filtering) while preserving Resgrid/map domains and bit.ly.
- **Normalizes smart punctuation** to keep messages in cheaper GSM-7 encoding.
- **Truncates** to a configurable max length (avoids Twilio error 21617).
- Invalid/unreachable "To" numbers from Twilio are now logged quietly instead of surfacing as fatal errors.
- Adds configurable `SmsMaxLength` and `SmsAllowedUrlDomains` settings.

### 3. Phone-Number Validation & E.164 Normalization
- New `PhoneRegionHelper` maps country names to ISO region codes so national-format numbers can be recognized.
- `ContactVerificationService` now validates/normalizes to E.164 before sending SMS or voice calls (prevents Twilio "Invalid 'To'" failures).
- Profile editing validates and normalizes mobile/home numbers server-side, with a new AJAX `ValidatePhoneNumber` endpoint and a shared client-side `resgrid.phonevalidate.js` that offers a one-click canonical fix on the profile, contact, and personnel forms.

### 4. Data-Truncation Fixes
- **Addresses**: widens `Addresses` columns (street to max, others generously) and tightens model-level `StringLength` validation across all address-entry view models so client + server reject oversized values before save. M0085 (both DBs).
- **Autofills.Data**: widened from `nvarchar(255)` to max to prevent truncation of long call-note templates. M0084 (both DBs).

### 5. Other Fixes
- **HealthRepository**: now uses the configured connection provider and `CURRENT_TIMESTAMP` so the health check works on PostgreSQL-backed datacenters (was hardcoded to SQL Server + `GETDATE()`).
- **Contacts Index view**: corrected a model-indexer bug (`Model.Contacts[i]` → `Model.ContactCategories[i]`).
- Switched append-only timeline/transfer inserts from `SaveOrUpdateAsync` to explicit `InsertAsync` (pre-set GUIDs would otherwise cause silent 0-row updates).

### Tests
Adds comprehensive coverage for idempotent check-ins (incl. concurrent-replay race), offline-aware IC service behavior (change tracking, idempotent creates, soft-delete, delta pull), ad-hoc resource idempotency/delta, `SmsContentHelper`, and `PhoneRegionHelper`.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added offline sync support for incident command and ad-hoc resources, letting clients pull only changes since their last update.
  * Added phone-number validation and formatting across contact, personnel, and profile forms, with instant feedback and a “use this” suggestion when a number is corrected.
  * Improved check-in handling so repeated submissions won’t create duplicate records.

* **Bug Fixes**
  * Expanded address field limits and validation messages across user and department forms.
  * Improved SMS delivery by filtering unsupported links and shortening messages to reduce send failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->