### PR TITLE
RIC-T39 More Backend IC work

### DIFF
--- a/Core/Resgrid.Model/EventingTypes.cs
+++ b/Core/Resgrid.Model/EventingTypes.cs
@@ -9,6 +9,7 @@
 		CallAdded = 5,
 		CallClosed = 6,
 		PersonnelLocationUpdated = 7,
-		UnitLocationUpdated = 8
+		UnitLocationUpdated = 8,
+		IncidentCommandUpdated = 9
 	}
 }

--- a/Core/Resgrid.Model/Events/IncidentCommandEvents.cs
+++ b/Core/Resgrid.Model/Events/IncidentCommandEvents.cs
@@ -93,4 +93,15 @@ namespace Resgrid.Model.Events
 		public int CallId { get; set; }
 		public string UserId { get; set; }
 	}
+
+	/// <summary>
+	/// Raised whenever an incident command board changes (establish/transfer/close, lane/resource/objective/timer/
+	/// annotation/role mutations, check-in/PAR). Drives the real-time SignalR "Real Time Sync" fan-out to connected
+	/// IC clients via the eventing topic, mirroring <see cref="CallUpdatedEvent"/>.
+	/// </summary>
+	public class IncidentCommandUpdatedEvent
+	{
+		public int DepartmentId { get; set; }
+		public int CallId { get; set; }
+	}
 }

--- a/Core/Resgrid.Model/IncidentCommand/IncidentCommandBundle.cs
+++ b/Core/Resgrid.Model/IncidentCommand/IncidentCommandBundle.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+
+namespace Resgrid.Model
+{
+	/// <summary>
+	/// Shift-start aggregate for offline IC clients: a render-ready snapshot of every ACTIVE incident command in the
+	/// caller's department in a single round-trip. Each <see cref="IncidentCommandBoard"/> carries the COMPUTED
+	/// accountability / PAR status that the row-based <see cref="IncidentCommandChanges"/> delta cannot, plus the
+	/// active ad-hoc resources. The client stores <see cref="ServerTimestampMs"/> and uses it as the <c>since</c>
+	/// cursor for subsequent incremental <c>/Sync/Changes</c> pulls. See
+	/// docs/architecture/offline-first-architecture.md (§6 / §9.5).
+	/// </summary>
+	public class IncidentCommandBundle
+	{
+		/// <summary>Server clock (Unix epoch ms) captured at the start of the read; seeds the next /Sync/Changes cursor.</summary>
+		public long ServerTimestampMs { get; set; }
+
+		/// <summary>One render-ready board (incl. accountability / PAR) per active incident command in the department.</summary>
+		public List<IncidentCommandBoard> Boards { get; set; } = new List<IncidentCommandBoard>();
+
+		/// <summary>Active ad-hoc units across the department's active incidents (aggregated by the caller).</summary>
+		public List<IncidentAdHocUnit> AdHocUnits { get; set; } = new List<IncidentAdHocUnit>();
+
+		/// <summary>Active ad-hoc personnel across the department's active incidents (aggregated by the caller).</summary>
+		public List<IncidentAdHocPersonnel> AdHocPersonnel { get; set; } = new List<IncidentAdHocPersonnel>();
+	}
+}

--- a/Core/Resgrid.Model/IncidentCommand/SyncReferenceData.cs
+++ b/Core/Resgrid.Model/IncidentCommand/SyncReferenceData.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using ProtoBuf;
 
 namespace Resgrid.Model
 {
@@ -86,5 +87,17 @@ namespace Resgrid.Model
 		public int? Type { get; set; }
 
 		public int? ParentGroupId { get; set; }
+	}
+
+	/// <summary>
+	/// Protobuf-safe cache envelope for the reference bootstrap. The cache provider serializes via protobuf-net, but
+	/// most of <see cref="SyncReferenceData"/>'s contained entities are not <c>[ProtoContract]</c>; rather than
+	/// ProtoContract-tag ~8 shared entities, the reference payload is cached as a JSON snapshot inside this contract.
+	/// </summary>
+	[ProtoContract]
+	public class ReferenceCacheEnvelope
+	{
+		[ProtoMember(1)]
+		public string Json { get; set; }
 	}
 }

--- a/Core/Resgrid.Model/IncidentCommand/SyncReferenceData.cs
+++ b/Core/Resgrid.Model/IncidentCommand/SyncReferenceData.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+
+namespace Resgrid.Model
+{
+	/// <summary>
+	/// Offline shift-start REFERENCE data: the slowly-changing department configuration + roster an IC app needs to
+	/// START and RUN an incident in the field (call types, command templates, units, personnel, groups, POIs,
+	/// protocols, accountability config, statuses, feature flags). Pulled once at shift start / on manual refresh;
+	/// the LIVE per-incident state comes from /Sync/Bundle (active boards) and /Sync/Changes (deltas). See
+	/// docs/architecture/offline-first-architecture.md. Personnel is a SAFE PROJECTION (<see cref="ReferencePersonnel"/>)
+	/// — never the raw IdentityUser/UserProfile (which carry credentials + verification codes).
+	/// </summary>
+	public class SyncReferenceData
+	{
+		/// <summary>Server clock (Unix epoch ms) captured at the start of the read.</summary>
+		public long ServerTimestampMs { get; set; }
+
+		public List<CallType> CallTypes { get; set; } = new List<CallType>();
+
+		public List<DepartmentCallPriority> CallPriorities { get; set; } = new List<DepartmentCallPriority>();
+
+		/// <summary>Command-definition templates (predefined swimlanes per call type) used to seed a new command.</summary>
+		public List<CommandDefinition> CommandTemplates { get; set; } = new List<CommandDefinition>();
+
+		public List<Unit> Units { get; set; } = new List<Unit>();
+
+		public List<UnitType> UnitTypes { get; set; } = new List<UnitType>();
+
+		public List<ReferenceGroup> Groups { get; set; } = new List<ReferenceGroup>();
+
+		public List<Poi> Pois { get; set; } = new List<Poi>();
+
+		public List<PoiType> PoiTypes { get; set; } = new List<PoiType>();
+
+		public List<DispatchProtocol> Protocols { get; set; } = new List<DispatchProtocol>();
+
+		public List<CheckInTimerConfig> CheckInTimerConfigs { get; set; } = new List<CheckInTimerConfig>();
+
+		/// <summary>Department-defined personnel custom statuses.</summary>
+		public List<CustomState> PersonnelStates { get; set; } = new List<CustomState>();
+
+		/// <summary>Department-defined unit custom statuses.</summary>
+		public List<CustomState> UnitStates { get; set; } = new List<CustomState>();
+
+		/// <summary>Safe personnel roster projection (no credentials / contact-verification secrets).</summary>
+		public List<ReferencePersonnel> Personnel { get; set; } = new List<ReferencePersonnel>();
+
+		/// <summary>Resolved feature flags for the department (drives addon/feature gating offline).</summary>
+		public List<FeatureFlagEvaluation> Features { get; set; } = new List<FeatureFlagEvaluation>();
+	}
+
+	/// <summary>
+	/// Safe, minimal personnel projection for offline rosters — mirrors the field exposure of the existing v4
+	/// PersonnelInfoResultData. Deliberately EXCLUDES the IdentityUser nav, password/security fields, and the
+	/// UserProfile contact-verification codes + CalendarSyncToken.
+	/// </summary>
+	public class ReferencePersonnel
+	{
+		public string UserId { get; set; }
+
+		public string FirstName { get; set; }
+
+		public string LastName { get; set; }
+
+		public string MobilePhone { get; set; }
+
+		/// <summary>Primary group/station membership, if any.</summary>
+		public int? GroupId { get; set; }
+
+		public string GroupName { get; set; }
+
+		/// <summary>Current personnel state (UserState.State); 0 when unknown.</summary>
+		public int StateId { get; set; }
+
+		public DateTime? StateTimestamp { get; set; }
+	}
+
+	/// <summary>Safe, minimal department group/station projection — excludes the member IdentityUser navs.</summary>
+	public class ReferenceGroup
+	{
+		public int GroupId { get; set; }
+
+		public string Name { get; set; }
+
+		public int? Type { get; set; }
+
+		public int? ParentGroupId { get; set; }
+	}
+}

--- a/Core/Resgrid.Model/Providers/IRabbitInboundEventProvider.cs
+++ b/Core/Resgrid.Model/Providers/IRabbitInboundEventProvider.cs
@@ -14,6 +14,7 @@ namespace Resgrid.Model.Providers
 							   Func<int, string, Task> callAdded,
 							   Func<int, string, Task> callClosed,
 							   Func<int, PersonnelLocationUpdatedEvent, Task> personnelLocationUpdated,
-							   Func<int, UnitLocationUpdatedEvent, Task> unitLocationUpdated);
+							   Func<int, UnitLocationUpdatedEvent, Task> unitLocationUpdated,
+							   Func<int, string, Task> incidentCommandUpdated);
 	}
 }

--- a/Core/Resgrid.Model/Services/ICoreEventService.cs
+++ b/Core/Resgrid.Model/Services/ICoreEventService.cs
@@ -10,8 +10,9 @@ namespace Resgrid.Model.Services
 	{
 		/// <summary>
 		/// Publishes a real-time "incident command updated" notification for a call so connected IC clients
-		/// re-sync the board (Tablet Command-style Real Time Sync). Fans out via the CQRS/eventing pipeline
-		/// to the per-department SignalR group.
+		/// re-sync the board (Tablet Command-style Real Time Sync). Fans out via the eventing topic pipeline
+		/// (OutboundEventProvider -> RabbitTopicProvider -> EventingTopic -> Eventing Worker) to the
+		/// per-department SignalR group as the "incidentCommandUpdated" client message.
 		/// </summary>
 		Task IncidentCommandUpdatedAsync(int departmentId, int callId);
 	}

--- a/Core/Resgrid.Model/Services/IIncidentCommandService.cs
+++ b/Core/Resgrid.Model/Services/IIncidentCommandService.cs
@@ -26,6 +26,16 @@ namespace Resgrid.Model.Services
 		/// </summary>
 		Task<IncidentCommandChanges> GetChangesSinceAsync(int departmentId, System.DateTime sinceUtc);
 
+		/// <summary>Returns every ACTIVE incident command for the department (Status == Active).</summary>
+		Task<List<IncidentCommand>> GetActiveCommandsForDepartmentAsync(int departmentId);
+
+		/// <summary>
+		/// Offline shift-start aggregate: a render-ready board (incl. computed accountability / PAR) for every active
+		/// incident in the department, plus the next-sync cursor, in one pull — cutting shift-start round-trips vs.
+		/// fanning out per incident. Ad-hoc resources live in a sibling service and are aggregated by the caller.
+		/// </summary>
+		Task<IncidentCommandBundle> GetBundleForDepartmentAsync(int departmentId, bool includeAccountability = true);
+
 		/// <summary>
 		/// Sweeps personnel accountability (PAR) for the call and raises <c>CriticalParDetectedEvent</c> once per
 		/// member each time they transition into the Critical (overdue) state. Idempotent via a timeline marker —

--- a/Core/Resgrid.Model/Services/IIncidentResourcesService.cs
+++ b/Core/Resgrid.Model/Services/IIncidentResourcesService.cs
@@ -33,5 +33,11 @@ namespace Resgrid.Model.Services
 		/// Aggregated into the unified /Sync/Changes payload by SyncController. See offline-first-architecture.md.
 		/// </summary>
 		Task<(List<IncidentAdHocUnit> Units, List<IncidentAdHocPersonnel> Personnel)> GetAdHocChangesSinceAsync(int departmentId, System.DateTime sinceUtc);
+
+		/// <summary>
+		/// Returns all ACTIVE (non-released) ad-hoc units + personnel across the department's active incidents in one
+		/// batched read (one scan per ad-hoc table), for the shift-start bundle — replaces the per-incident N+1 lookups.
+		/// </summary>
+		Task<(List<IncidentAdHocUnit> Units, List<IncidentAdHocPersonnel> Personnel)> GetActiveAdHocResourcesForDepartmentAsync(int departmentId);
 	}
 }

--- a/Core/Resgrid.Model/Services/ISyncService.cs
+++ b/Core/Resgrid.Model/Services/ISyncService.cs
@@ -9,6 +9,6 @@ namespace Resgrid.Model.Services
 	/// </summary>
 	public interface ISyncService
 	{
-		Task<SyncReferenceData> GetReferenceDataAsync(int departmentId);
+		Task<SyncReferenceData> GetReferenceDataAsync(int departmentId, bool bypassCache = false);
 	}
 }

--- a/Core/Resgrid.Model/Services/ISyncService.cs
+++ b/Core/Resgrid.Model/Services/ISyncService.cs
@@ -1,0 +1,14 @@
+using System.Threading.Tasks;
+
+namespace Resgrid.Model.Services
+{
+	/// <summary>
+	/// Aggregates the offline shift-start REFERENCE data set (department configuration + a safe personnel roster) into
+	/// a single payload, so an IC/Unit app can pull everything it needs to start and run an incident in one round-trip.
+	/// The live per-incident state is delivered separately by IIncidentCommandService (board bundle + change deltas).
+	/// </summary>
+	public interface ISyncService
+	{
+		Task<SyncReferenceData> GetReferenceDataAsync(int departmentId);
+	}
+}

--- a/Core/Resgrid.Services/CoreEventService.cs
+++ b/Core/Resgrid.Services/CoreEventService.cs
@@ -11,12 +11,10 @@ namespace Resgrid.Services
 	public class CoreEventService : ICoreEventService
 	{
 		private readonly IEventAggregator _eventAggregator;
-		private static ICqrsProvider _cqrsProvider;
 
-		public CoreEventService(IEventAggregator eventAggregator, ICqrsProvider cqrsProvider)
+		public CoreEventService(IEventAggregator eventAggregator)
 		{
 			_eventAggregator = eventAggregator;
-			_cqrsProvider = cqrsProvider;
 
 			_eventAggregator.AddListener(departmentSettingsUpdateHandler);
 		}
@@ -27,16 +25,18 @@ namespace Resgrid.Services
 			var result = await departmentSettingsService.SaveOrUpdateSettingAsync(message.DepartmentId, DateTime.UtcNow.ToString("G"), DepartmentSettingTypes.UpdateTimestamp);
 		};
 
-		public async Task IncidentCommandUpdatedAsync(int departmentId, int callId)
+		public Task IncidentCommandUpdatedAsync(int departmentId, int callId)
 		{
-			var cqrsEvent = new CqrsEvent
+			// Raise the domain event onto the eventing/topic rail (OutboundEventProvider ->
+			// RabbitTopicProvider -> EventingTopic -> Eventing Worker -> SignalR "incidentCommandUpdated"),
+			// mirroring how CallUpdatedEvent drives "callsUpdated".
+			_eventAggregator.SendMessage<IncidentCommandUpdatedEvent>(new IncidentCommandUpdatedEvent
 			{
-				Type = (int)CqrsEventTypes.IncidentCommandUpdated,
-				AggregateId = callId.ToString(),
-				Data = $"{{\"departmentId\":{departmentId},\"callId\":{callId}}}"
-			};
+				DepartmentId = departmentId,
+				CallId = callId
+			});
 
-			await _cqrsProvider.EnqueueCqrsEventAsync(cqrsEvent);
+			return Task.CompletedTask;
 		}
 	}
 }

--- a/Core/Resgrid.Services/IncidentCommandService.cs
+++ b/Core/Resgrid.Services/IncidentCommandService.cs
@@ -157,6 +157,15 @@ namespace Resgrid.Services
 			return items?.FirstOrDefault(x => x.CallId == callId && x.Status == (int)IncidentCommandStatus.Active);
 		}
 
+		public async Task<List<IncidentCommand>> GetActiveCommandsForDepartmentAsync(int departmentId)
+		{
+			var items = await _incidentCommandRepository.GetAllByDepartmentIdAsync(departmentId);
+			if (items == null)
+				return new List<IncidentCommand>();
+
+			return items.Where(x => x.Status == (int)IncidentCommandStatus.Active).ToList();
+		}
+
 		public async Task<IncidentCommand> GetCommandByIdAsync(string incidentCommandId)
 		{
 			return await _incidentCommandRepository.GetByIdAsync(incidentCommandId);
@@ -350,6 +359,61 @@ namespace Resgrid.Services
 
 			return board;
 		}
+
+		public async Task<IncidentCommandBundle> GetBundleForDepartmentAsync(int departmentId, bool includeAccountability = true)
+		{
+			// Capture the cursor before reading so the client's first incremental /Sync/Changes call doesn't miss a
+			// row committed during this read (a re-returned row is harmless — the client upserts idempotently).
+			var bundle = new IncidentCommandBundle { ServerTimestampMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() };
+
+			var active = await GetActiveCommandsForDepartmentAsync(departmentId);
+			if (active.Count == 0)
+				return bundle;
+
+			// Pull each board table ONCE for the whole department and index by CallId, instead of re-scanning every
+			// table per incident. The per-call getters each do a full GetAllByDepartmentIdAsync, and GetCommandBoardAsync
+			// additionally fires the write-side PAR sweep — so assembling N boards that way is O(active incidents ×
+			// department size) plus N marker-writes / SignalR pushes. Doing it here keeps the bundle O(number of tables)
+			// and side-effect free, which is what hurts departments with many open/active incidents.
+			var nodes = ToCallLookup(await _commandStructureNodeRepository.GetAllByDepartmentIdAsync(departmentId), x => x.CallId);
+			var assignments = ToCallLookup(await _resourceAssignmentRepository.GetAllByDepartmentIdAsync(departmentId), x => x.CallId);
+			var objectives = ToCallLookup(await _tacticalObjectiveRepository.GetAllByDepartmentIdAsync(departmentId), x => x.CallId);
+			var timers = ToCallLookup(await _incidentTimerRepository.GetAllByDepartmentIdAsync(departmentId), x => x.CallId);
+			var annotations = ToCallLookup(await _incidentMapAnnotationRepository.GetAllByDepartmentIdAsync(departmentId), x => x.CallId);
+			var roles = ToCallLookup(await _incidentRoleAssignmentRepository.GetAllByDepartmentIdAsync(departmentId), x => x.CallId);
+
+			foreach (var command in active)
+			{
+				var callId = command.CallId;
+
+				var board = new IncidentCommandBoard
+				{
+					Command = command,
+					// These mirror the per-call getter filters exactly (DeletedOn / ReleasedOn / RemovedOn tombstones +
+					// the active-timer rule), so the bundled board matches what GetCommandBoardAsync would return.
+					Nodes = nodes[callId].Where(x => x.DeletedOn == null).OrderBy(x => x.SortOrder).ToList(),
+					Assignments = assignments[callId].Where(x => x.ReleasedOn == null).ToList(),
+					Objectives = objectives[callId].OrderBy(x => x.SortOrder).ToList(),
+					Timers = timers[callId].Where(x => x.Status != (int)IncidentTimerStatus.Stopped).ToList(),
+					Annotations = annotations[callId].Where(x => x.DeletedOn == null).ToList(),
+					Roles = roles[callId].Where(x => x.RemovedOn == null).ToList()
+				};
+
+				// Accountability/PAR is the one per-incident read here, and it is READ-ONLY (no marker writes / SignalR
+				// pushes — unlike GetCommandBoardAsync's sweep). A department with very many open incidents can opt out
+				// via includeAccountability=false and fetch PAR per incident on demand.
+				if (includeAccountability)
+					board.Accountability = await GetAccountabilityForCallAsync(departmentId, callId);
+
+				bundle.Boards.Add(board);
+			}
+
+			return bundle;
+		}
+
+		/// <summary>Indexes a department-wide row set by CallId; a missing key yields an empty sequence (no exception).</summary>
+		private static ILookup<int, T> ToCallLookup<T>(IEnumerable<T> items, Func<T, int> callIdSelector)
+			=> (items ?? Enumerable.Empty<T>()).ToLookup(callIdSelector);
 
 		public async Task<IncidentCommandChanges> GetChangesSinceAsync(int departmentId, DateTime sinceUtc)
 		{

--- a/Core/Resgrid.Services/IncidentResourcesService.cs
+++ b/Core/Resgrid.Services/IncidentResourcesService.cs
@@ -217,6 +217,21 @@ namespace Resgrid.Services
 				personnel?.Where(Changed).ToList() ?? new List<IncidentAdHocPersonnel>());
 		}
 
+		public async Task<(List<IncidentAdHocUnit> Units, List<IncidentAdHocPersonnel> Personnel)> GetActiveAdHocResourcesForDepartmentAsync(int departmentId)
+		{
+			// Scope to the department's active incidents and exclude released rows, in ONE scan per ad-hoc table —
+			// replaces the bundle's previous per-board (N+1) GetAdHoc*ForCallAsync lookups.
+			var activeCallIds = (await _incidentCommandService.GetActiveCommandsForDepartmentAsync(departmentId))
+				.Select(c => c.CallId).ToHashSet();
+
+			var units = await _adHocUnitRepository.GetAllByDepartmentIdAsync(departmentId);
+			var personnel = await _adHocPersonnelRepository.GetAllByDepartmentIdAsync(departmentId);
+
+			return (
+				units?.Where(u => u.ReleasedOn == null && activeCallIds.Contains(u.CallId)).ToList() ?? new List<IncidentAdHocUnit>(),
+				personnel?.Where(p => p.ReleasedOn == null && activeCallIds.Contains(p.CallId)).ToList() ?? new List<IncidentAdHocPersonnel>());
+		}
+
 		#endregion Offline sync
 
 		#region Private helpers

--- a/Core/Resgrid.Services/ServicesModule.cs
+++ b/Core/Resgrid.Services/ServicesModule.cs
@@ -20,6 +20,7 @@ namespace Resgrid.Services
 			builder.RegisterType<IncidentVoiceService>().As<IIncidentVoiceService>().InstancePerLifetimeScope();
 			builder.RegisterType<MutualAidService>().As<IMutualAidService>().InstancePerLifetimeScope();
 			builder.RegisterType<IncidentResourcesService>().As<IIncidentResourcesService>().InstancePerLifetimeScope();
+			builder.RegisterType<SyncService>().As<ISyncService>().InstancePerLifetimeScope();
 			builder.RegisterType<IncidentReportingService>().As<IIncidentReportingService>().InstancePerLifetimeScope();
 			builder.RegisterType<WorkflowTemplateContextBuilder>().As<Resgrid.Model.Providers.IWorkflowTemplateContextBuilder>().InstancePerLifetimeScope();
 			builder.RegisterType<LogService>().As<ILogService>().InstancePerLifetimeScope();

--- a/Core/Resgrid.Services/SyncService.cs
+++ b/Core/Resgrid.Services/SyncService.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Resgrid.Model;
+using Resgrid.Model.Services;
+
+namespace Resgrid.Services
+{
+	/// <summary>
+	/// Aggregates the offline shift-start REFERENCE data set (department configuration + a SAFE personnel roster) into
+	/// one payload. Read-only. Personnel is projected to <see cref="ReferencePersonnel"/> so no credentials, security
+	/// fields, or contact-verification secrets are exposed. The live per-incident state is delivered separately by the
+	/// incident-command bundle (/Sync/Bundle) and delta (/Sync/Changes) endpoints.
+	/// </summary>
+	public class SyncService : ISyncService
+	{
+		private readonly ICallsService _callsService;
+		private readonly ICommandsService _commandsService;
+		private readonly IUnitsService _unitsService;
+		private readonly IDepartmentGroupsService _departmentGroupsService;
+		private readonly IMappingService _mappingService;
+		private readonly IProtocolsService _protocolsService;
+		private readonly ICheckInTimerService _checkInTimerService;
+		private readonly ICustomStateService _customStateService;
+		private readonly IUserProfileService _userProfileService;
+		private readonly IUserStateService _userStateService;
+		private readonly IFeatureToggleService _featureToggleService;
+
+		public SyncService(
+			ICallsService callsService,
+			ICommandsService commandsService,
+			IUnitsService unitsService,
+			IDepartmentGroupsService departmentGroupsService,
+			IMappingService mappingService,
+			IProtocolsService protocolsService,
+			ICheckInTimerService checkInTimerService,
+			ICustomStateService customStateService,
+			IUserProfileService userProfileService,
+			IUserStateService userStateService,
+			IFeatureToggleService featureToggleService)
+		{
+			_callsService = callsService;
+			_commandsService = commandsService;
+			_unitsService = unitsService;
+			_departmentGroupsService = departmentGroupsService;
+			_mappingService = mappingService;
+			_protocolsService = protocolsService;
+			_checkInTimerService = checkInTimerService;
+			_customStateService = customStateService;
+			_userProfileService = userProfileService;
+			_userStateService = userStateService;
+			_featureToggleService = featureToggleService;
+		}
+
+		public async Task<SyncReferenceData> GetReferenceDataAsync(int departmentId)
+		{
+			var data = new SyncReferenceData { ServerTimestampMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() };
+
+			// Configuration / reference entities returned as-is (audited: no secret scalar fields, no IdentityUser navs).
+			data.CallTypes = await _callsService.GetCallTypesForDepartmentAsync(departmentId) ?? new List<CallType>();
+			data.CallPriorities = await _callsService.GetCallPrioritiesForDepartmentAsync(departmentId) ?? new List<DepartmentCallPriority>();
+			data.CommandTemplates = await _commandsService.GetAllCommandsForDepartmentAsync(departmentId) ?? new List<CommandDefinition>();
+			data.Units = await _unitsService.GetUnitsForDepartmentAsync(departmentId) ?? new List<Unit>();
+			data.UnitTypes = await _unitsService.GetUnitTypesForDepartmentAsync(departmentId) ?? new List<UnitType>();
+			data.Pois = await _mappingService.GetPOIsForDepartmentAsync(departmentId) ?? new List<Poi>();
+			data.PoiTypes = await _mappingService.GetPOITypesForDepartmentAsync(departmentId) ?? new List<PoiType>();
+			data.Protocols = await _protocolsService.GetAllProtocolsForDepartmentAsync(departmentId) ?? new List<DispatchProtocol>();
+			data.CheckInTimerConfigs = await _checkInTimerService.GetTimerConfigsForDepartmentAsync(departmentId) ?? new List<CheckInTimerConfig>();
+			data.PersonnelStates = await _customStateService.GetAllActiveCustomStatesForDepartmentAsync(departmentId) ?? new List<CustomState>();
+			data.UnitStates = await _customStateService.GetAllActiveUnitStatesForDepartmentAsync(departmentId) ?? new List<CustomState>();
+			data.Features = await _featureToggleService.EvaluateAllForDepartmentAsync(departmentId) ?? new List<FeatureFlagEvaluation>();
+
+			// Groups: project to a safe shape. The raw DepartmentGroup.Members carry IdentityUser navs we must not leak,
+			// and mutating the (possibly cached) entities to strip them would be unsafe.
+			var groups = await _departmentGroupsService.GetAllGroupsForDepartmentAsync(departmentId) ?? new List<DepartmentGroup>();
+			data.Groups = groups.Select(g => new ReferenceGroup
+			{
+				GroupId = g.DepartmentGroupId,
+				Name = g.Name,
+				Type = g.Type,
+				ParentGroupId = g.ParentDepartmentGroupId
+			}).ToList();
+
+			data.Personnel = await BuildPersonnelAsync(departmentId, groups);
+
+			return data;
+		}
+
+		/// <summary>
+		/// Builds the SAFE personnel roster (name + mobile, primary group, current state) projected from UserProfile +
+		/// UserState — never exposing the IdentityUser nav, password/security fields, or the UserProfile contact-
+		/// verification codes / CalendarSyncToken. Mirrors the field exposure of the existing v4 PersonnelInfoResultData.
+		/// </summary>
+		private async Task<List<ReferencePersonnel>> BuildPersonnelAsync(int departmentId, List<DepartmentGroup> groups)
+		{
+			var personnel = new List<ReferencePersonnel>();
+
+			var profiles = await _userProfileService.GetAllProfilesForDepartmentAsync(departmentId);
+			if (profiles == null || profiles.Count == 0)
+				return personnel;
+
+			// First group membership wins as the member's "primary" group.
+			var userGroup = new Dictionary<string, ReferenceGroup>();
+			foreach (var g in groups)
+			{
+				if (g.Members == null)
+					continue;
+
+				foreach (var m in g.Members)
+				{
+					if (!string.IsNullOrWhiteSpace(m.UserId) && !userGroup.ContainsKey(m.UserId))
+						userGroup[m.UserId] = new ReferenceGroup { GroupId = g.DepartmentGroupId, Name = g.Name };
+				}
+			}
+
+			var states = await _userStateService.GetStatesForDepartmentAsync(departmentId) ?? new List<UserState>();
+			var stateByUser = states
+				.Where(s => !string.IsNullOrWhiteSpace(s.UserId))
+				.GroupBy(s => s.UserId)
+				.ToDictionary(grp => grp.Key, grp => grp.OrderByDescending(s => s.Timestamp).First());
+
+			foreach (var profile in profiles.Values)
+			{
+				if (profile == null || string.IsNullOrWhiteSpace(profile.UserId))
+					continue;
+
+				var person = new ReferencePersonnel
+				{
+					UserId = profile.UserId,
+					FirstName = profile.FirstName,
+					LastName = profile.LastName,
+					MobilePhone = profile.MobileNumber
+				};
+
+				if (userGroup.TryGetValue(profile.UserId, out var grp))
+				{
+					person.GroupId = grp.GroupId;
+					person.GroupName = grp.Name;
+				}
+
+				if (stateByUser.TryGetValue(profile.UserId, out var state))
+				{
+					person.StateId = state.State;
+					person.StateTimestamp = state.Timestamp;
+				}
+
+				personnel.Add(person);
+			}
+
+			return personnel;
+		}
+	}
+}

--- a/Core/Resgrid.Services/SyncService.cs
+++ b/Core/Resgrid.Services/SyncService.cs
@@ -2,7 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
 using Resgrid.Model;
+using Resgrid.Model.Providers;
 using Resgrid.Model.Services;
 
 namespace Resgrid.Services
@@ -26,6 +28,10 @@ namespace Resgrid.Services
 		private readonly IUserProfileService _userProfileService;
 		private readonly IUserStateService _userStateService;
 		private readonly IFeatureToggleService _featureToggleService;
+		private readonly ICacheProvider _cacheProvider;
+
+		private static readonly string CacheKey = "SyncReferenceData_{0}";
+		private static readonly TimeSpan CacheLength = TimeSpan.FromMinutes(5);
 
 		public SyncService(
 			ICallsService callsService,
@@ -38,7 +44,8 @@ namespace Resgrid.Services
 			ICustomStateService customStateService,
 			IUserProfileService userProfileService,
 			IUserStateService userStateService,
-			IFeatureToggleService featureToggleService)
+			IFeatureToggleService featureToggleService,
+			ICacheProvider cacheProvider)
 		{
 			_callsService = callsService;
 			_commandsService = commandsService;
@@ -51,40 +58,59 @@ namespace Resgrid.Services
 			_userProfileService = userProfileService;
 			_userStateService = userStateService;
 			_featureToggleService = featureToggleService;
+			_cacheProvider = cacheProvider;
 		}
 
-		public async Task<SyncReferenceData> GetReferenceDataAsync(int departmentId)
+		public async Task<SyncReferenceData> GetReferenceDataAsync(int departmentId, bool bypassCache = false)
 		{
-			var data = new SyncReferenceData { ServerTimestampMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() };
-
-			// Configuration / reference entities returned as-is (audited: no secret scalar fields, no IdentityUser navs).
-			data.CallTypes = await _callsService.GetCallTypesForDepartmentAsync(departmentId) ?? new List<CallType>();
-			data.CallPriorities = await _callsService.GetCallPrioritiesForDepartmentAsync(departmentId) ?? new List<DepartmentCallPriority>();
-			data.CommandTemplates = await _commandsService.GetAllCommandsForDepartmentAsync(departmentId) ?? new List<CommandDefinition>();
-			data.Units = await _unitsService.GetUnitsForDepartmentAsync(departmentId) ?? new List<Unit>();
-			data.UnitTypes = await _unitsService.GetUnitTypesForDepartmentAsync(departmentId) ?? new List<UnitType>();
-			data.Pois = await _mappingService.GetPOIsForDepartmentAsync(departmentId) ?? new List<Poi>();
-			data.PoiTypes = await _mappingService.GetPOITypesForDepartmentAsync(departmentId) ?? new List<PoiType>();
-			data.Protocols = await _protocolsService.GetAllProtocolsForDepartmentAsync(departmentId) ?? new List<DispatchProtocol>();
-			data.CheckInTimerConfigs = await _checkInTimerService.GetTimerConfigsForDepartmentAsync(departmentId) ?? new List<CheckInTimerConfig>();
-			data.PersonnelStates = await _customStateService.GetAllActiveCustomStatesForDepartmentAsync(departmentId) ?? new List<CustomState>();
-			data.UnitStates = await _customStateService.GetAllActiveUnitStatesForDepartmentAsync(departmentId) ?? new List<CustomState>();
-			data.Features = await _featureToggleService.EvaluateAllForDepartmentAsync(departmentId) ?? new List<FeatureFlagEvaluation>();
-
-			// Groups: project to a safe shape. The raw DepartmentGroup.Members carry IdentityUser navs we must not leak,
-			// and mutating the (possibly cached) entities to strip them would be unsafe.
-			var groups = await _departmentGroupsService.GetAllGroupsForDepartmentAsync(departmentId) ?? new List<DepartmentGroup>();
-			data.Groups = groups.Select(g => new ReferenceGroup
+			async Task<SyncReferenceData> build()
 			{
-				GroupId = g.DepartmentGroupId,
-				Name = g.Name,
-				Type = g.Type,
-				ParentGroupId = g.ParentDepartmentGroupId
-			}).ToList();
+				var data = new SyncReferenceData { ServerTimestampMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() };
 
-			data.Personnel = await BuildPersonnelAsync(departmentId, groups);
+				// Configuration / reference entities returned as-is (audited: no secret scalar fields, no IdentityUser navs).
+				data.CallTypes = await _callsService.GetCallTypesForDepartmentAsync(departmentId) ?? new List<CallType>();
+				data.CallPriorities = await _callsService.GetCallPrioritiesForDepartmentAsync(departmentId) ?? new List<DepartmentCallPriority>();
+				data.CommandTemplates = await _commandsService.GetAllCommandsForDepartmentAsync(departmentId) ?? new List<CommandDefinition>();
+				data.Units = await _unitsService.GetUnitsForDepartmentAsync(departmentId) ?? new List<Unit>();
+				data.UnitTypes = await _unitsService.GetUnitTypesForDepartmentAsync(departmentId) ?? new List<UnitType>();
+				data.Pois = await _mappingService.GetPOIsForDepartmentAsync(departmentId) ?? new List<Poi>();
+				data.PoiTypes = await _mappingService.GetPOITypesForDepartmentAsync(departmentId) ?? new List<PoiType>();
+				data.Protocols = await _protocolsService.GetAllProtocolsForDepartmentAsync(departmentId) ?? new List<DispatchProtocol>();
+				data.CheckInTimerConfigs = await _checkInTimerService.GetTimerConfigsForDepartmentAsync(departmentId) ?? new List<CheckInTimerConfig>();
+				data.PersonnelStates = await _customStateService.GetAllActiveCustomStatesForDepartmentAsync(departmentId) ?? new List<CustomState>();
+				data.UnitStates = await _customStateService.GetAllActiveUnitStatesForDepartmentAsync(departmentId) ?? new List<CustomState>();
+				data.Features = await _featureToggleService.EvaluateAllForDepartmentAsync(departmentId) ?? new List<FeatureFlagEvaluation>();
 
-			return data;
+				// Groups: project to a safe shape. The raw DepartmentGroup.Members carry IdentityUser navs we must not leak,
+				// and mutating the (possibly cached) entities to strip them would be unsafe.
+				var groups = await _departmentGroupsService.GetAllGroupsForDepartmentAsync(departmentId) ?? new List<DepartmentGroup>();
+				data.Groups = groups.Select(g => new ReferenceGroup
+				{
+					GroupId = g.DepartmentGroupId,
+					Name = g.Name,
+					Type = g.Type,
+					ParentGroupId = g.ParentDepartmentGroupId
+				}).ToList();
+
+				data.Personnel = await BuildPersonnelAsync(departmentId, groups);
+
+				return data;
+			}
+
+			if (bypassCache || !Config.SystemBehaviorConfig.CacheEnabled)
+				return await build();
+
+			// Cache-aside, department-scoped. The cache provider serializes via protobuf-net and SyncReferenceData's
+			// contained entities are mostly not [ProtoContract], so the payload is cached as a JSON snapshot inside a
+			// protobuf-safe envelope rather than ProtoContract-tagging ~8 shared entities (see ReferenceCacheEnvelope).
+			var envelope = await _cacheProvider.RetrieveAsync<ReferenceCacheEnvelope>(
+				string.Format(CacheKey, departmentId),
+				async () => new ReferenceCacheEnvelope { Json = JsonConvert.SerializeObject(await build()) },
+				CacheLength);
+
+			return !string.IsNullOrEmpty(envelope?.Json)
+				? JsonConvert.DeserializeObject<SyncReferenceData>(envelope.Json)
+				: await build();
 		}
 
 		/// <summary>

--- a/Providers/Resgrid.Providers.Bus.Rabbit/RabbitInboundEventProvider.cs
+++ b/Providers/Resgrid.Providers.Bus.Rabbit/RabbitInboundEventProvider.cs
@@ -27,6 +27,7 @@ namespace Resgrid.Providers.Bus.Rabbit
 		public Func<int, string, Task> ProcessPersonnelStaffingChanged;
 		public Func<int, PersonnelLocationUpdatedEvent, Task> PersonnelLocationUpdated;
 		public Func<int, UnitLocationUpdatedEvent, Task> UnitLocationUpdated;
+		public Func<int, string, Task> ProcessIncidentCommandUpdated;
 
 		public async Task Start(string clientName, string queueName)
 		{
@@ -114,6 +115,10 @@ namespace Resgrid.Providers.Bus.Rabbit
 							if (UnitLocationUpdated != null)
 								await UnitLocationUpdated.Invoke(eventingMessage.DepartmentId, JsonConvert.DeserializeObject<UnitLocationUpdatedEvent>(eventingMessage.Payload));
 							break;
+						case EventingTypes.IncidentCommandUpdated:
+							if (ProcessIncidentCommandUpdated != null)
+								await ProcessIncidentCommandUpdated.Invoke(eventingMessage.DepartmentId, eventingMessage.ItemId);
+							break;
 						default:
 							throw new ArgumentOutOfRangeException();
 					}
@@ -139,7 +144,8 @@ namespace Resgrid.Providers.Bus.Rabbit
 									  Func<int, string, Task> callAdded,
 									  Func<int, string, Task> callClosed,
 									  Func<int, PersonnelLocationUpdatedEvent, Task> personnelLocationUpdated,
-									  Func<int, UnitLocationUpdatedEvent, Task> unitLocationUpdated)
+									  Func<int, UnitLocationUpdatedEvent, Task> unitLocationUpdated,
+									  Func<int, string, Task> incidentCommandUpdated)
 		{
 			ProcessPersonnelStatusChanged = personnelStatusChanged;
 			ProcessUnitStatusChanged = unitStatusChanged;
@@ -149,6 +155,7 @@ namespace Resgrid.Providers.Bus.Rabbit
 			ProcessCallClosed = callClosed;
 			PersonnelLocationUpdated = personnelLocationUpdated;
 			UnitLocationUpdated = unitLocationUpdated;
+			ProcessIncidentCommandUpdated = incidentCommandUpdated;
 		}
 	}
 }

--- a/Providers/Resgrid.Providers.Bus.Rabbit/RabbitInboundEventProvider.cs
+++ b/Providers/Resgrid.Providers.Bus.Rabbit/RabbitInboundEventProvider.cs
@@ -77,51 +77,58 @@ namespace Resgrid.Providers.Bus.Rabbit
 				var body = ea.Body.ToArray();
 				var message = Encoding.UTF8.GetString(body);
 
-				var eventingMessage = JsonConvert.DeserializeObject<EventingMessage>(message);
-
-				if (eventingMessage != null)
+				try
 				{
-					switch ((EventingTypes)eventingMessage.Type)
+					var eventingMessage = JsonConvert.DeserializeObject<EventingMessage>(message);
+
+					if (eventingMessage != null)
 					{
-						case EventingTypes.PersonnelStatusUpdated:
-							if (ProcessPersonnelStatusChanged != null)
-								await ProcessPersonnelStatusChanged(eventingMessage.DepartmentId, eventingMessage.ItemId);
-							break;
-						case EventingTypes.UnitStatusUpdated:
-							if (ProcessUnitStatusChanged != null)
-								await ProcessUnitStatusChanged.Invoke(eventingMessage.DepartmentId, eventingMessage.ItemId);
-							break;
-						case EventingTypes.CallsUpdated:
-							if (ProcessCallStatusChanged != null)
-								await ProcessCallStatusChanged.Invoke(eventingMessage.DepartmentId, eventingMessage.ItemId);
-							break;
-						case EventingTypes.CallAdded:
-							if (ProcessCallAdded != null)
-								await ProcessCallAdded.Invoke(eventingMessage.DepartmentId, eventingMessage.ItemId);
-							break;
-						case EventingTypes.CallClosed:
-							if (ProcessCallClosed != null)
-								await ProcessCallClosed.Invoke(eventingMessage.DepartmentId, eventingMessage.ItemId);
-							break;
-						case EventingTypes.PersonnelStaffingUpdated:
-							if (ProcessPersonnelStaffingChanged != null)
-								await ProcessPersonnelStaffingChanged.Invoke(eventingMessage.DepartmentId, eventingMessage.ItemId);
-							break;
-						case EventingTypes.PersonnelLocationUpdated:
-							if (PersonnelLocationUpdated != null)
-								await PersonnelLocationUpdated.Invoke(eventingMessage.DepartmentId, JsonConvert.DeserializeObject<PersonnelLocationUpdatedEvent>(eventingMessage.Payload));
-							break;
-						case EventingTypes.UnitLocationUpdated:
-							if (UnitLocationUpdated != null)
-								await UnitLocationUpdated.Invoke(eventingMessage.DepartmentId, JsonConvert.DeserializeObject<UnitLocationUpdatedEvent>(eventingMessage.Payload));
-							break;
-						case EventingTypes.IncidentCommandUpdated:
-							if (ProcessIncidentCommandUpdated != null)
-								await ProcessIncidentCommandUpdated.Invoke(eventingMessage.DepartmentId, eventingMessage.ItemId);
-							break;
-						default:
-							throw new ArgumentOutOfRangeException();
+						switch ((EventingTypes)eventingMessage.Type)
+						{
+							case EventingTypes.PersonnelStatusUpdated:
+								if (ProcessPersonnelStatusChanged != null)
+									await ProcessPersonnelStatusChanged(eventingMessage.DepartmentId, eventingMessage.ItemId);
+								break;
+							case EventingTypes.UnitStatusUpdated:
+								if (ProcessUnitStatusChanged != null)
+									await ProcessUnitStatusChanged.Invoke(eventingMessage.DepartmentId, eventingMessage.ItemId);
+								break;
+							case EventingTypes.CallsUpdated:
+								if (ProcessCallStatusChanged != null)
+									await ProcessCallStatusChanged.Invoke(eventingMessage.DepartmentId, eventingMessage.ItemId);
+								break;
+							case EventingTypes.CallAdded:
+								if (ProcessCallAdded != null)
+									await ProcessCallAdded.Invoke(eventingMessage.DepartmentId, eventingMessage.ItemId);
+								break;
+							case EventingTypes.CallClosed:
+								if (ProcessCallClosed != null)
+									await ProcessCallClosed.Invoke(eventingMessage.DepartmentId, eventingMessage.ItemId);
+								break;
+							case EventingTypes.PersonnelStaffingUpdated:
+								if (ProcessPersonnelStaffingChanged != null)
+									await ProcessPersonnelStaffingChanged.Invoke(eventingMessage.DepartmentId, eventingMessage.ItemId);
+								break;
+							case EventingTypes.PersonnelLocationUpdated:
+								if (PersonnelLocationUpdated != null)
+									await PersonnelLocationUpdated.Invoke(eventingMessage.DepartmentId, JsonConvert.DeserializeObject<PersonnelLocationUpdatedEvent>(eventingMessage.Payload));
+								break;
+							case EventingTypes.UnitLocationUpdated:
+								if (UnitLocationUpdated != null)
+									await UnitLocationUpdated.Invoke(eventingMessage.DepartmentId, JsonConvert.DeserializeObject<UnitLocationUpdatedEvent>(eventingMessage.Payload));
+								break;
+							case EventingTypes.IncidentCommandUpdated:
+								if (ProcessIncidentCommandUpdated != null)
+									await ProcessIncidentCommandUpdated.Invoke(eventingMessage.DepartmentId, eventingMessage.ItemId);
+								break;
+							default:
+								throw new ArgumentOutOfRangeException();
+						}
 					}
+				}
+				catch (Exception ex)
+				{
+					Logging.LogException(ex);
 				}
 			};
 			await _channel.BasicConsumeAsync(queue: queue.QueueName,

--- a/Providers/Resgrid.Providers.Bus.Rabbit/RabbitTopicProvider.cs
+++ b/Providers/Resgrid.Providers.Bus.Rabbit/RabbitTopicProvider.cs
@@ -81,6 +81,18 @@ namespace Resgrid.Providers.Bus.Rabbit
 			}.SerializeJson());
 		}
 
+		public async Task<bool> IncidentCommandUpdated(IncidentCommandUpdatedEvent message)
+		{
+			return await SendMessage(Topics.EventingTopic, new EventingMessage
+			{
+				Id = Guid.NewGuid(),
+				Type = (int)EventingTypes.IncidentCommandUpdated,
+				TimeStamp = DateTime.UtcNow,
+				DepartmentId = message.DepartmentId,
+				ItemId = message.CallId.ToString()
+			}.SerializeJson());
+		}
+
 		public async Task<bool> CallClosed(CallClosedEvent message)
 		{
 			return await SendMessage(Topics.EventingTopic, new EventingMessage

--- a/Providers/Resgrid.Providers.Bus/OutboundEventProvider.cs
+++ b/Providers/Resgrid.Providers.Bus/OutboundEventProvider.cs
@@ -56,6 +56,7 @@ namespace Resgrid.Providers.Bus
 			_eventAggregator.AddListener(callAddedTopicHandler);
 			_eventAggregator.AddListener(callUpdatedTopicHandler);
 			_eventAggregator.AddListener(callClosedTopicHandler);
+			_eventAggregator.AddListener(incidentCommandUpdatedTopicHandler);
 			_eventAggregator.AddListener(personnelLocationUpdatedTopicHandler);
 			_eventAggregator.AddListener(unitLocationUpdatedTopicHandler);
 		}
@@ -583,6 +584,14 @@ namespace Resgrid.Providers.Bus
 				_rabbitTopicProvider = new RabbitTopicProvider();
 
 			_rabbitTopicProvider.CallUpdated(message);
+		};
+
+		public Action<IncidentCommandUpdatedEvent> incidentCommandUpdatedTopicHandler = async delegate (IncidentCommandUpdatedEvent message)
+		{
+			if (_rabbitTopicProvider == null)
+				_rabbitTopicProvider = new RabbitTopicProvider();
+
+			_rabbitTopicProvider.IncidentCommandUpdated(message);
 		};
 
 		public Action<CallClosedEvent> callClosedTopicHandler = async delegate (CallClosedEvent message)

--- a/Tests/Resgrid.Tests/Services/CoreEventServiceTests.cs
+++ b/Tests/Resgrid.Tests/Services/CoreEventServiceTests.cs
@@ -1,0 +1,31 @@
+using System.Threading.Tasks;
+using Moq;
+using NUnit.Framework;
+using Resgrid.Model.Events;
+using Resgrid.Model.Providers;
+using Resgrid.Services;
+
+namespace Resgrid.Tests.Services
+{
+	/// <summary>
+	/// Covers the IC real-time publish side. IncidentCommandUpdatedAsync must raise an IncidentCommandUpdatedEvent
+	/// onto the eventing/topic rail (OutboundEventProvider -> RabbitTopicProvider -> EventingTopic -> Eventing Worker
+	/// -> SignalR "incidentCommandUpdated"), mirroring how CallUpdatedEvent drives "callsUpdated" — NOT the CQRS rail.
+	/// </summary>
+	[TestFixture]
+	public class CoreEventServiceTests
+	{
+		[Test]
+		public async Task IncidentCommandUpdatedAsync_RaisesIncidentCommandUpdatedEvent_WithDeptAndCall()
+		{
+			var eventAggregator = new Mock<IEventAggregator>();
+			var service = new CoreEventService(eventAggregator.Object);
+
+			await service.IncidentCommandUpdatedAsync(42, 1001);
+
+			eventAggregator.Verify(x => x.SendMessage(
+				It.Is<IncidentCommandUpdatedEvent>(e => e.DepartmentId == 42 && e.CallId == 1001)),
+				Times.Once);
+		}
+	}
+}

--- a/Tests/Resgrid.Tests/Services/IncidentCommandServiceParTests.cs
+++ b/Tests/Resgrid.Tests/Services/IncidentCommandServiceParTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -112,6 +113,96 @@ namespace Resgrid.Tests.Services
 			MinutesRemaining = -3,
 			LastCheckIn = lastCheckIn
 		};
+
+		[Test]
+		public async Task GetActiveCommandsForDepartmentAsync_ReturnsOnlyActiveCommands()
+		{
+			_commandRepo.Setup(x => x.GetAllByDepartmentIdAsync(Dept)).ReturnsAsync(new List<IncidentCommand>
+			{
+				new IncidentCommand { IncidentCommandId = "ic1", DepartmentId = Dept, CallId = 1, Status = (int)IncidentCommandStatus.Active },
+				new IncidentCommand { IncidentCommandId = "ic2", DepartmentId = Dept, CallId = 2, Status = (int)IncidentCommandStatus.Closed },
+				new IncidentCommand { IncidentCommandId = "ic3", DepartmentId = Dept, CallId = 3, Status = (int)IncidentCommandStatus.Active }
+			});
+
+			var active = await _service.GetActiveCommandsForDepartmentAsync(Dept);
+
+			active.Should().HaveCount(2);
+			active.Select(c => c.IncidentCommandId).Should().BeEquivalentTo(new[] { "ic1", "ic3" });
+		}
+
+		[Test]
+		public async Task GetBundleForDepartmentAsync_IncludesABoardPerActiveCommand_AndSetsCursor()
+		{
+			ArrangeCall();          // call on CallId=1, check-in timers enabled, owned by Dept
+			ArrangeActiveCommand(); // one active command on CallId=1
+
+			var bundle = await _service.GetBundleForDepartmentAsync(Dept);
+
+			bundle.ServerTimestampMs.Should().BeGreaterThan(0);
+			bundle.Boards.Should().ContainSingle();
+			bundle.Boards[0].Command.CallId.Should().Be(CallId);
+		}
+
+		[Test]
+		public async Task GetBundleForDepartmentAsync_ReturnsEmptyBoards_WhenNoActiveCommands()
+		{
+			_commandRepo.Setup(x => x.GetAllByDepartmentIdAsync(Dept)).ReturnsAsync(new List<IncidentCommand>
+			{
+				new IncidentCommand { IncidentCommandId = "ic9", DepartmentId = Dept, CallId = 9, Status = (int)IncidentCommandStatus.Closed }
+			});
+
+			var bundle = await _service.GetBundleForDepartmentAsync(Dept);
+
+			bundle.Boards.Should().BeEmpty();
+			bundle.ServerTimestampMs.Should().BeGreaterThan(0);
+		}
+
+		[Test]
+		public async Task GetBundleForDepartmentAsync_AssemblesBoardContent_AndAppliesTombstoneFilters()
+		{
+			ArrangeCall();
+			ArrangeActiveCommand(); // one active command on CallId=1
+
+			_nodeRepo.Setup(x => x.GetAllByDepartmentIdAsync(Dept)).ReturnsAsync(new List<CommandStructureNode>
+			{
+				new CommandStructureNode { CommandStructureNodeId = "n1", DepartmentId = Dept, CallId = CallId, Name = "Division A", SortOrder = 0 },
+				new CommandStructureNode { CommandStructureNodeId = "n2", DepartmentId = Dept, CallId = CallId, Name = "Removed lane", DeletedOn = DateTime.UtcNow },
+				new CommandStructureNode { CommandStructureNodeId = "n3", DepartmentId = Dept, CallId = 999, Name = "Other call lane" }
+			});
+			_assignmentRepo.Setup(x => x.GetAllByDepartmentIdAsync(Dept)).ReturnsAsync(new List<ResourceAssignment>
+			{
+				new ResourceAssignment { ResourceAssignmentId = "a1", DepartmentId = Dept, CallId = CallId },
+				new ResourceAssignment { ResourceAssignmentId = "a2", DepartmentId = Dept, CallId = CallId, ReleasedOn = DateTime.UtcNow }
+			});
+
+			var bundle = await _service.GetBundleForDepartmentAsync(Dept);
+
+			bundle.Boards.Should().ContainSingle();
+			var board = bundle.Boards[0];
+			board.Nodes.Should().ContainSingle().Which.Name.Should().Be("Division A");        // deleted + other-call excluded
+			board.Assignments.Should().ContainSingle().Which.ResourceAssignmentId.Should().Be("a1"); // released excluded
+		}
+
+		[Test]
+		public async Task GetBundleForDepartmentAsync_IsReadOnly_AndHonorsIncludeAccountabilityFlag()
+		{
+			ArrangeCall();
+			ArrangeActiveCommand();
+			ArrangeStatuses(Critical("user1")); // would be flagged PAR-critical if the write-side sweep ran
+
+			var without = await _service.GetBundleForDepartmentAsync(Dept, includeAccountability: false);
+			without.Boards.Should().ContainSingle();
+			without.Boards[0].Accountability.Should().BeEmpty();
+
+			var with = await _service.GetBundleForDepartmentAsync(Dept, includeAccountability: true);
+			with.Boards[0].Accountability.Should().ContainSingle().Which.UserId.Should().Be("user1");
+
+			// The bundle must NOT run the write-side PAR sweep (no ParCritical marker writes / SignalR storm).
+			_logRepo.Verify(x => x.InsertAsync(
+				It.Is<CommandLogEntry>(e => e.EntryType == (int)CommandLogEntryType.ParCritical),
+				It.IsAny<CancellationToken>(), It.IsAny<bool>()), Times.Never);
+			_eventAggregator.Verify(x => x.SendMessage(It.IsAny<CriticalParDetectedEvent>()), Times.Never);
+		}
 
 		[Test]
 		public async Task EvaluateCriticalParAsync_RaisesEventAndWritesMarker_OnFirstTransitionToCritical()

--- a/Tests/Resgrid.Tests/Services/IncidentResourcesServiceTests.cs
+++ b/Tests/Resgrid.Tests/Services/IncidentResourcesServiceTests.cs
@@ -50,6 +50,36 @@ namespace Resgrid.Tests.Services
 		}
 
 		[Test]
+		public async Task GetActiveAdHocResourcesForDepartmentAsync_ReturnsActiveScopedToActiveIncidents_InOneBatch()
+		{
+			_commandService.Setup(x => x.GetActiveCommandsForDepartmentAsync(Dept)).ReturnsAsync(new List<IncidentCommand>
+			{
+				new IncidentCommand { IncidentCommandId = "ic1", DepartmentId = Dept, CallId = CallId, Status = (int)IncidentCommandStatus.Active }
+			});
+
+			_unitRepo.Setup(x => x.GetAllByDepartmentIdAsync(Dept)).ReturnsAsync(new List<IncidentAdHocUnit>
+			{
+				new IncidentAdHocUnit { IncidentAdHocUnitId = "u1", DepartmentId = Dept, CallId = CallId },                                  // active incident + active row
+				new IncidentAdHocUnit { IncidentAdHocUnitId = "u2", DepartmentId = Dept, CallId = CallId, ReleasedOn = DateTime.UtcNow },    // released → excluded
+				new IncidentAdHocUnit { IncidentAdHocUnitId = "u3", DepartmentId = Dept, CallId = 99 }                                       // not an active incident → excluded
+			});
+			_personnelRepo.Setup(x => x.GetAllByDepartmentIdAsync(Dept)).ReturnsAsync(new List<IncidentAdHocPersonnel>
+			{
+				new IncidentAdHocPersonnel { IncidentAdHocPersonnelId = "p1", DepartmentId = Dept, CallId = CallId },
+				new IncidentAdHocPersonnel { IncidentAdHocPersonnelId = "p2", DepartmentId = Dept, CallId = 99 }                             // not active → excluded
+			});
+
+			var (units, personnel) = await _service.GetActiveAdHocResourcesForDepartmentAsync(Dept);
+
+			units.Should().ContainSingle().Which.IncidentAdHocUnitId.Should().Be("u1");
+			personnel.Should().ContainSingle().Which.IncidentAdHocPersonnelId.Should().Be("p1");
+
+			// Batched: ONE scan per ad-hoc table regardless of incident count (no N+1).
+			_unitRepo.Verify(x => x.GetAllByDepartmentIdAsync(Dept), Times.Once);
+			_personnelRepo.Verify(x => x.GetAllByDepartmentIdAsync(Dept), Times.Once);
+		}
+
+		[Test]
 		public async Task CreateAdHocUnitAsync_ReturnsNull_WhenNoActiveCommandForCall()
 		{
 			_commandService.Setup(x => x.GetActiveCommandForCallAsync(Dept, CallId)).ReturnsAsync((IncidentCommand)null);

--- a/Tests/Resgrid.Tests/Services/SyncServiceTests.cs
+++ b/Tests/Resgrid.Tests/Services/SyncServiceTests.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using Resgrid.Model;
+using Resgrid.Model.Services;
+using Resgrid.Services;
+
+namespace Resgrid.Tests.Services
+{
+	/// <summary>
+	/// Covers <see cref="SyncService.GetReferenceDataAsync"/>: the shift-start reference aggregate. Focuses on the
+	/// SAFE personnel projection (group + current-state join, and that the DTO structurally cannot carry the
+	/// UserProfile secrets) plus passthrough of the raw config lists.
+	/// </summary>
+	[TestFixture]
+	public class SyncServiceTests
+	{
+		private const int Dept = 10;
+
+		private Mock<ICallsService> _calls;
+		private Mock<ICommandsService> _commands;
+		private Mock<IUnitsService> _units;
+		private Mock<IDepartmentGroupsService> _groups;
+		private Mock<IMappingService> _mapping;
+		private Mock<IProtocolsService> _protocols;
+		private Mock<ICheckInTimerService> _checkInTimers;
+		private Mock<ICustomStateService> _customStates;
+		private Mock<IUserProfileService> _profiles;
+		private Mock<IUserStateService> _userStates;
+		private Mock<IFeatureToggleService> _features;
+		private SyncService _service;
+
+		[SetUp]
+		public void SetUp()
+		{
+			_calls = new Mock<ICallsService>();
+			_commands = new Mock<ICommandsService>();
+			_units = new Mock<IUnitsService>();
+			_groups = new Mock<IDepartmentGroupsService>();
+			_mapping = new Mock<IMappingService>();
+			_protocols = new Mock<IProtocolsService>();
+			_checkInTimers = new Mock<ICheckInTimerService>();
+			_customStates = new Mock<ICustomStateService>();
+			_profiles = new Mock<IUserProfileService>();
+			_userStates = new Mock<IUserStateService>();
+			_features = new Mock<IFeatureToggleService>();
+
+			// Unset methods return null under Loose mocks; SyncService coalesces those to empty lists.
+			_service = new SyncService(_calls.Object, _commands.Object, _units.Object, _groups.Object,
+				_mapping.Object, _protocols.Object, _checkInTimers.Object, _customStates.Object,
+				_profiles.Object, _userStates.Object, _features.Object);
+		}
+
+		[Test]
+		public async Task GetReferenceDataAsync_ProjectsSafePersonnel_WithGroupAndState()
+		{
+			_calls.Setup(x => x.GetCallTypesForDepartmentAsync(Dept))
+				.ReturnsAsync(new List<CallType> { new CallType { CallTypeId = 1, DepartmentId = Dept } });
+
+			_profiles.Setup(x => x.GetAllProfilesForDepartmentAsync(Dept, It.IsAny<bool>()))
+				.ReturnsAsync(new Dictionary<string, UserProfile>
+				{
+					["u1"] = new UserProfile
+					{
+						UserId = "u1", FirstName = "John", LastName = "Doe", MobileNumber = "5551234",
+						// Secrets that must NEVER reach the client — ReferencePersonnel structurally cannot carry them.
+						EmailVerificationCode = "SECRET", CalendarSyncToken = "SECRET-TOKEN"
+					}
+				});
+
+			_groups.Setup(x => x.GetAllGroupsForDepartmentAsync(Dept))
+				.ReturnsAsync(new List<DepartmentGroup>
+				{
+					new DepartmentGroup
+					{
+						DepartmentGroupId = 5, DepartmentId = Dept, Name = "Station 1",
+						Members = new List<DepartmentGroupMember> { new DepartmentGroupMember { UserId = "u1", DepartmentGroupId = 5 } }
+					}
+				});
+
+			_userStates.Setup(x => x.GetStatesForDepartmentAsync(Dept))
+				.ReturnsAsync(new List<UserState> { new UserState { UserId = "u1", State = 2, Timestamp = DateTime.UtcNow } });
+
+			var data = await _service.GetReferenceDataAsync(Dept);
+
+			data.ServerTimestampMs.Should().BeGreaterThan(0);
+			data.CallTypes.Should().ContainSingle();                          // raw config list passthrough
+			data.Groups.Should().ContainSingle().Which.GroupId.Should().Be(5); // projected to the safe ReferenceGroup
+
+			var person = data.Personnel.Should().ContainSingle().Subject;
+			person.UserId.Should().Be("u1");
+			person.FirstName.Should().Be("John");
+			person.LastName.Should().Be("Doe");
+			person.MobilePhone.Should().Be("5551234");
+			person.GroupId.Should().Be(5);
+			person.GroupName.Should().Be("Station 1");
+			person.StateId.Should().Be(2);
+			person.StateTimestamp.Should().NotBeNull();
+		}
+
+		[Test]
+		public async Task GetReferenceDataAsync_ReturnsEmptyPersonnel_WhenNoProfiles()
+		{
+			_profiles.Setup(x => x.GetAllProfilesForDepartmentAsync(Dept, It.IsAny<bool>()))
+				.ReturnsAsync(new Dictionary<string, UserProfile>());
+
+			var data = await _service.GetReferenceDataAsync(Dept);
+
+			data.Personnel.Should().BeEmpty();
+			data.ServerTimestampMs.Should().BeGreaterThan(0);
+		}
+	}
+}

--- a/Tests/Resgrid.Tests/Services/SyncServiceTests.cs
+++ b/Tests/Resgrid.Tests/Services/SyncServiceTests.cs
@@ -5,7 +5,9 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
+using Resgrid.Config;
 using Resgrid.Model;
+using Resgrid.Model.Providers;
 using Resgrid.Model.Services;
 using Resgrid.Services;
 
@@ -32,11 +34,13 @@ namespace Resgrid.Tests.Services
 		private Mock<IUserProfileService> _profiles;
 		private Mock<IUserStateService> _userStates;
 		private Mock<IFeatureToggleService> _features;
+		private Mock<ICacheProvider> _cacheProvider;
 		private SyncService _service;
 
 		[SetUp]
 		public void SetUp()
 		{
+			SystemBehaviorConfig.CacheEnabled = false; // exercise the direct build() path unless a test opts into caching
 			_calls = new Mock<ICallsService>();
 			_commands = new Mock<ICommandsService>();
 			_units = new Mock<IUnitsService>();
@@ -48,11 +52,12 @@ namespace Resgrid.Tests.Services
 			_profiles = new Mock<IUserProfileService>();
 			_userStates = new Mock<IUserStateService>();
 			_features = new Mock<IFeatureToggleService>();
+			_cacheProvider = new Mock<ICacheProvider>();
 
 			// Unset methods return null under Loose mocks; SyncService coalesces those to empty lists.
 			_service = new SyncService(_calls.Object, _commands.Object, _units.Object, _groups.Object,
 				_mapping.Object, _protocols.Object, _checkInTimers.Object, _customStates.Object,
-				_profiles.Object, _userStates.Object, _features.Object);
+				_profiles.Object, _userStates.Object, _features.Object, _cacheProvider.Object);
 		}
 
 		[Test]
@@ -112,6 +117,53 @@ namespace Resgrid.Tests.Services
 
 			data.Personnel.Should().BeEmpty();
 			data.ServerTimestampMs.Should().BeGreaterThan(0);
+		}
+
+		[Test]
+		public async Task GetReferenceDataAsync_UsesDepartmentScopedCacheAside_WhenCacheEnabled()
+		{
+			SystemBehaviorConfig.CacheEnabled = true;
+			try
+			{
+				_profiles.Setup(x => x.GetAllProfilesForDepartmentAsync(Dept, It.IsAny<bool>()))
+					.ReturnsAsync(new Dictionary<string, UserProfile>());
+
+				// Simulate a cache miss: invoke the fallback and return its result (round-trips through the envelope).
+				_cacheProvider
+					.Setup(c => c.RetrieveAsync<ReferenceCacheEnvelope>(It.IsAny<string>(), It.IsAny<Func<Task<ReferenceCacheEnvelope>>>(), It.IsAny<TimeSpan>()))
+					.Returns<string, Func<Task<ReferenceCacheEnvelope>>, TimeSpan>((key, fallback, ttl) => fallback());
+
+				var data = await _service.GetReferenceDataAsync(Dept);
+
+				data.Should().NotBeNull();
+				_cacheProvider.Verify(c => c.RetrieveAsync<ReferenceCacheEnvelope>(
+					"SyncReferenceData_" + Dept, It.IsAny<Func<Task<ReferenceCacheEnvelope>>>(), It.IsAny<TimeSpan>()), Times.Once);
+			}
+			finally
+			{
+				SystemBehaviorConfig.CacheEnabled = false;
+			}
+		}
+
+		[Test]
+		public async Task GetReferenceDataAsync_BypassesCache_WhenBypassCacheTrue()
+		{
+			SystemBehaviorConfig.CacheEnabled = true;
+			try
+			{
+				_profiles.Setup(x => x.GetAllProfilesForDepartmentAsync(Dept, It.IsAny<bool>()))
+					.ReturnsAsync(new Dictionary<string, UserProfile>());
+
+				var data = await _service.GetReferenceDataAsync(Dept, bypassCache: true);
+
+				data.Should().NotBeNull();
+				_cacheProvider.Verify(c => c.RetrieveAsync<ReferenceCacheEnvelope>(
+					It.IsAny<string>(), It.IsAny<Func<Task<ReferenceCacheEnvelope>>>(), It.IsAny<TimeSpan>()), Times.Never);
+			}
+			finally
+			{
+				SystemBehaviorConfig.CacheEnabled = false;
+			}
 		}
 	}
 }

--- a/Tests/Resgrid.Tests/Web/Services/RequiresIncidentCapabilityFilterTests.cs
+++ b/Tests/Resgrid.Tests/Web/Services/RequiresIncidentCapabilityFilterTests.cs
@@ -1,0 +1,242 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Routing;
+using Moq;
+using NUnit.Framework;
+using Resgrid.Model;
+using Resgrid.Model.Services;
+using Resgrid.Web.Services.Filters;
+
+namespace Resgrid.Tests.Web.Services
+{
+	/// <summary>
+	/// Unit tests for <see cref="RequiresIncidentCapabilityAttribute"/> — the per-endpoint incident-capability gate
+	/// layered on top of the broad Command_* claims. Verifies the three Call-resolution strategies, the
+	/// allow/deny decision, the ownership check, and the fail-open behaviour when the target Call can't be classified.
+	/// </summary>
+	[TestFixture]
+	public class RequiresIncidentCapabilityFilterTests
+	{
+		private const int DepartmentId = 10;
+		private const string UserId = "user-1";
+
+		private Mock<IIncidentCommandService> _service;
+
+		[SetUp]
+		public void SetUp()
+		{
+			_service = new Mock<IIncidentCommandService>(MockBehavior.Loose);
+		}
+
+		[Test]
+		public async Task AllowsRequest_WhenUserHasRequiredCapability_ViaIncidentCommandId()
+		{
+			// Arrange — SaveNode-style: body carries IncidentCommandId, which resolves to its owned Call.
+			_service.Setup(s => s.GetCommandByIdAsync("cmd-1"))
+				.ReturnsAsync(new IncidentCommand { CallId = 5, DepartmentId = DepartmentId });
+			_service.Setup(s => s.GetCapabilitiesForUserAsync(DepartmentId, 5, UserId))
+				.ReturnsAsync(IncidentCapabilities.ViewBoard | IncidentCapabilities.ManageStructure);
+
+			var filter = new RequiresIncidentCapabilityAttribute(IncidentCapabilities.ManageStructure);
+			var context = BuildContext(
+				args: new Dictionary<string, object> { ["node"] = new CommandStructureNode { IncidentCommandId = "cmd-1" } });
+
+			// Act
+			var nextCalled = await Invoke(filter, context);
+
+			// Assert
+			nextCalled.Should().BeTrue();
+			context.Result.Should().BeNull();
+		}
+
+		[Test]
+		public async Task Returns403_WhenUserLacksRequiredCapability_ViaIncidentCommandId()
+		{
+			// Arrange — same path, but the user's role only grants ViewBoard.
+			_service.Setup(s => s.GetCommandByIdAsync("cmd-1"))
+				.ReturnsAsync(new IncidentCommand { CallId = 5, DepartmentId = DepartmentId });
+			_service.Setup(s => s.GetCapabilitiesForUserAsync(DepartmentId, 5, UserId))
+				.ReturnsAsync(IncidentCapabilities.ViewBoard);
+
+			var filter = new RequiresIncidentCapabilityAttribute(IncidentCapabilities.ManageStructure);
+			var context = BuildContext(
+				args: new Dictionary<string, object> { ["node"] = new CommandStructureNode { IncidentCommandId = "cmd-1" } });
+
+			// Act
+			var nextCalled = await Invoke(filter, context);
+
+			// Assert
+			nextCalled.Should().BeFalse();
+			context.Result.Should().BeOfType<ObjectResult>()
+				.Which.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+		}
+
+		[Test]
+		public async Task AllowsRequest_WhenCapabilityPresent_ViaExplicitRouteCallId()
+		{
+			// Arrange — EvaluateAccountability/{callId}: callId comes from the route, no body.
+			_service.Setup(s => s.GetCapabilitiesForUserAsync(DepartmentId, 7, UserId))
+				.ReturnsAsync(IncidentCapabilities.All);
+
+			var filter = new RequiresIncidentCapabilityAttribute(IncidentCapabilities.ManageAccountability);
+			var context = BuildContext(
+				args: new Dictionary<string, object> { ["callId"] = 7 },
+				routeValues: new Dictionary<string, object> { ["callId"] = 7 });
+
+			// Act
+			var nextCalled = await Invoke(filter, context);
+
+			// Assert
+			nextCalled.Should().BeTrue();
+			context.Result.Should().BeNull();
+			_service.Verify(s => s.GetCommandByIdAsync(It.IsAny<string>()), Times.Never);
+		}
+
+		[Test]
+		public async Task AllowsRequest_WhenCapabilityPresent_ViaBodyCallId()
+		{
+			// Arrange — CreateAdHocUnit-style: the body object exposes CallId (no IncidentCommandId).
+			_service.Setup(s => s.GetCapabilitiesForUserAsync(DepartmentId, 9, UserId))
+				.ReturnsAsync(IncidentCapabilities.ViewBoard | IncidentCapabilities.ManageResources);
+
+			var filter = new RequiresIncidentCapabilityAttribute(IncidentCapabilities.ManageResources);
+			var context = BuildContext(
+				args: new Dictionary<string, object> { ["unit"] = new IncidentAdHocUnit { CallId = 9 } });
+
+			// Act
+			var nextCalled = await Invoke(filter, context);
+
+			// Assert
+			nextCalled.Should().BeTrue();
+			context.Result.Should().BeNull();
+		}
+
+		[Test]
+		public async Task FailsOpen_WhenCallCannotBeResolved()
+		{
+			// Arrange — a release-style entity-id route (no callId / IncidentCommandId / CallId on the request).
+			// The filter must NOT block; the broad Command_* claim still governs. Capabilities are never evaluated.
+			var filter = new RequiresIncidentCapabilityAttribute(IncidentCapabilities.AssignResources);
+			var context = BuildContext(
+				args: new Dictionary<string, object> { ["resourceAssignmentId"] = "ra-1" });
+
+			// Act
+			var nextCalled = await Invoke(filter, context);
+
+			// Assert
+			nextCalled.Should().BeTrue();
+			context.Result.Should().BeNull();
+			_service.Verify(s => s.GetCapabilitiesForUserAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>()), Times.Never);
+		}
+
+		[Test]
+		public async Task FailsOpen_WhenIncidentCommandBelongsToAnotherDepartment()
+		{
+			// Arrange — a forged IncidentCommandId pointing at another department must not classify the request,
+			// so the filter falls through to fail-open (the service-layer ownership guard then rejects it).
+			_service.Setup(s => s.GetCommandByIdAsync("cmd-foreign"))
+				.ReturnsAsync(new IncidentCommand { CallId = 5, DepartmentId = 999 });
+
+			var filter = new RequiresIncidentCapabilityAttribute(IncidentCapabilities.ManageStructure);
+			var context = BuildContext(
+				args: new Dictionary<string, object> { ["node"] = new CommandStructureNode { IncidentCommandId = "cmd-foreign" } });
+
+			// Act
+			var nextCalled = await Invoke(filter, context);
+
+			// Assert
+			nextCalled.Should().BeTrue();
+			context.Result.Should().BeNull();
+			_service.Verify(s => s.GetCapabilitiesForUserAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>()), Times.Never);
+		}
+
+		[Test]
+		public async Task FailsOpen_WhenCallerHasNoIdentity()
+		{
+			// Arrange — no claims principal; identity can't be established, so defer to the [Authorize] gate.
+			var filter = new RequiresIncidentCapabilityAttribute(IncidentCapabilities.ManageCommand);
+			var context = BuildContext(
+				args: new Dictionary<string, object> { ["callId"] = 7 },
+				routeValues: new Dictionary<string, object> { ["callId"] = 7 },
+				authenticated: false);
+
+			// Act
+			var nextCalled = await Invoke(filter, context);
+
+			// Assert
+			nextCalled.Should().BeTrue();
+			context.Result.Should().BeNull();
+			_service.Verify(s => s.GetCapabilitiesForUserAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>()), Times.Never);
+		}
+
+		#region Helpers
+
+		private ActionExecutingContext BuildContext(
+			IDictionary<string, object> args,
+			IDictionary<string, object> routeValues = null,
+			bool authenticated = true)
+		{
+			var httpContext = new DefaultHttpContext
+			{
+				RequestServices = new StubServiceProvider(_service.Object)
+			};
+
+			if (authenticated)
+			{
+				var identity = new ClaimsIdentity(new[]
+				{
+					new Claim(ClaimTypes.PrimarySid, UserId),
+					new Claim(ClaimTypes.PrimaryGroupSid, DepartmentId.ToString())
+				}, "TestAuth");
+				httpContext.User = new ClaimsPrincipal(identity);
+			}
+
+			var routeData = new RouteData();
+			if (routeValues != null)
+			{
+				foreach (var kvp in routeValues)
+					routeData.Values[kvp.Key] = kvp.Value;
+			}
+
+			var actionContext = new ActionContext(httpContext, routeData, new ActionDescriptor());
+			return new ActionExecutingContext(actionContext, new List<IFilterMetadata>(), args, controller: new object());
+		}
+
+		private static async Task<bool> Invoke(RequiresIncidentCapabilityAttribute filter, ActionExecutingContext context)
+		{
+			var nextCalled = false;
+
+			Task<ActionExecutedContext> Next()
+			{
+				nextCalled = true;
+				return Task.FromResult(new ActionExecutedContext(context, new List<IFilterMetadata>(), context.Controller));
+			}
+
+			await filter.OnActionExecutionAsync(context, Next);
+			return nextCalled;
+		}
+
+		private sealed class StubServiceProvider : IServiceProvider
+		{
+			private readonly IIncidentCommandService _service;
+
+			public StubServiceProvider(IIncidentCommandService service)
+			{
+				_service = service;
+			}
+
+			public object GetService(Type serviceType)
+				=> serviceType == typeof(IIncidentCommandService) ? _service : null;
+		}
+
+		#endregion Helpers
+	}
+}

--- a/Tests/Resgrid.Tests/Web/Services/RequiresIncidentCapabilityFilterTests.cs
+++ b/Tests/Resgrid.Tests/Web/Services/RequiresIncidentCapabilityFilterTests.cs
@@ -9,10 +9,12 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Authorization;
 using Moq;
 using NUnit.Framework;
 using Resgrid.Model;
 using Resgrid.Model.Services;
+using Resgrid.Web.Services.Controllers.v4;
 using Resgrid.Web.Services.Filters;
 
 namespace Resgrid.Tests.Web.Services
@@ -175,6 +177,17 @@ namespace Resgrid.Tests.Web.Services
 			nextCalled.Should().BeTrue();
 			context.Result.Should().BeNull();
 			_service.Verify(s => s.GetCapabilitiesForUserAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>()), Times.Never);
+		}
+
+		[Test]
+		public void EstablishCommand_IsNotCapabilityGated_SoBootstrapCanCreateTheCommand()
+		{
+			// EstablishCommand bootstraps the command — before it runs there is no command/commander/role and thus no
+			// IncidentCapabilities, so it must NOT carry [RequiresIncidentCapability]; it stays on the Command_Create claim.
+			var method = typeof(IncidentCommandController).GetMethod(nameof(IncidentCommandController.EstablishCommand));
+			method.Should().NotBeNull();
+			method.GetCustomAttributes(typeof(RequiresIncidentCapabilityAttribute), true).Should().BeEmpty();
+			method.GetCustomAttributes(typeof(AuthorizeAttribute), true).Should().NotBeEmpty();
 		}
 
 		#region Helpers

--- a/Web/Resgrid.Web.Eventing/Worker.cs
+++ b/Web/Resgrid.Web.Eventing/Worker.cs
@@ -45,7 +45,8 @@ namespace Resgrid.Web.Eventing
 															  CallAdded,
 															  CallClosed,
 															  PersonnelLocationUpdated,
-															  UnitLocationUpdated);
+															  UnitLocationUpdated,
+															  IncidentCommandUpdated);
 
 				_rabbitInboundEventProvider.Start("Eventing-Web", "EventingWeb").ConfigureAwait(false);
 
@@ -108,6 +109,16 @@ namespace Resgrid.Web.Eventing
 
 			if (group != null)
 				await group.SendAsync("callsUpdated", id);
+		}
+
+		public async Task IncidentCommandUpdated(int departmentId, string id)
+		{
+			Console.WriteLine($"Processing RabbitMQ IncidentCommandUpdated Event For {departmentId}");
+
+			var group = _eventingHub.Clients.Group(departmentId.ToString());
+
+			if (group != null)
+				await group.SendAsync("incidentCommandUpdated", id);
 		}
 
 		public async Task DepartmentUpdated(int departmentId)

--- a/Web/Resgrid.Web.Services/Controllers/v4/IncidentCommandController.cs
+++ b/Web/Resgrid.Web.Services/Controllers/v4/IncidentCommandController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 using Resgrid.Model;
 using Resgrid.Model.Services;
 using Resgrid.Providers.Claims;
+using Resgrid.Web.Services.Filters;
 using Resgrid.Web.Services.Helpers;
 using System.Threading;
 using System.Threading.Tasks;
@@ -35,6 +36,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 		[HttpPost("EstablishCommand")]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		[Authorize(Policy = ResgridResources.Command_Create)]
+		[RequiresIncidentCapability(IncidentCapabilities.ManageCommand)]
 		public async Task<ActionResult<ICModels.IncidentCommandResult>> EstablishCommand([FromBody] ICModels.EstablishCommandInput input)
 		{
 			if (input == null || input.CallId <= 0)
@@ -85,6 +87,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 		[HttpPost("TransferCommand")]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		[Authorize(Policy = ResgridResources.Command_Update)]
+		[RequiresIncidentCapability(IncidentCapabilities.ManageCommand)]
 		public async Task<ActionResult<ICModels.CommandTransferResult>> TransferCommand([FromBody] ICModels.TransferCommandInput input)
 		{
 			if (input == null || string.IsNullOrWhiteSpace(input.IncidentCommandId) || string.IsNullOrWhiteSpace(input.ToUserId))
@@ -111,6 +114,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 		[HttpPut("CloseCommand/{incidentCommandId}")]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		[Authorize(Policy = ResgridResources.Command_Update)]
+		[RequiresIncidentCapability(IncidentCapabilities.ManageCommand)]
 		public async Task<ActionResult<ICModels.IncidentCommandResult>> CloseCommand(string incidentCommandId)
 		{
 			var result = new ICModels.IncidentCommandResult();
@@ -134,6 +138,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 		[HttpPut("UpdateActionPlan")]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		[Authorize(Policy = ResgridResources.Command_Update)]
+		[RequiresIncidentCapability(IncidentCapabilities.ManageCommand)]
 		public async Task<ActionResult<ICModels.IncidentCommandResult>> UpdateActionPlan([FromBody] ICModels.UpdateActionPlanInput input)
 		{
 			if (input == null || string.IsNullOrWhiteSpace(input.IncidentCommandId))
@@ -178,6 +183,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 		[HttpPost("EvaluateAccountability/{callId}")]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		[Authorize(Policy = ResgridResources.Command_Update)]
+		[RequiresIncidentCapability(IncidentCapabilities.ManageAccountability)]
 		public async Task<ActionResult<ICModels.EvaluateAccountabilityResult>> EvaluateAccountability(int callId)
 		{
 			var result = new ICModels.EvaluateAccountabilityResult();
@@ -196,6 +202,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 		[HttpPost("SaveNode")]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		[Authorize(Policy = ResgridResources.Command_Update)]
+		[RequiresIncidentCapability(IncidentCapabilities.ManageStructure)]
 		public async Task<ActionResult<ICModels.CommandNodeResult>> SaveNode([FromBody] CommandStructureNode node)
 		{
 			if (node == null || string.IsNullOrWhiteSpace(node.IncidentCommandId))
@@ -242,6 +249,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 		[HttpPost("AssignResource")]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		[Authorize(Policy = ResgridResources.Command_Update)]
+		[RequiresIncidentCapability(IncidentCapabilities.AssignResources)]
 		public async Task<ActionResult<ICModels.ResourceAssignmentResult>> AssignResource([FromBody] ResourceAssignment assignment)
 		{
 			if (assignment == null || string.IsNullOrWhiteSpace(assignment.IncidentCommandId))
@@ -313,6 +321,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 		[HttpPost("SaveObjective")]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		[Authorize(Policy = ResgridResources.Command_Update)]
+		[RequiresIncidentCapability(IncidentCapabilities.ManageObjectives)]
 		public async Task<ActionResult<ICModels.TacticalObjectiveResult>> SaveObjective([FromBody] TacticalObjective objective)
 		{
 			if (objective == null || string.IsNullOrWhiteSpace(objective.IncidentCommandId))
@@ -368,6 +377,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 		[HttpPost("StartTimer")]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		[Authorize(Policy = ResgridResources.Command_Update)]
+		[RequiresIncidentCapability(IncidentCapabilities.ManageTimers)]
 		public async Task<ActionResult<ICModels.IncidentTimerResult>> StartTimer([FromBody] IncidentTimer timer)
 		{
 			if (timer == null || string.IsNullOrWhiteSpace(timer.IncidentCommandId))
@@ -423,6 +433,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 		[HttpPost("SaveAnnotation")]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		[Authorize(Policy = ResgridResources.Command_Update)]
+		[RequiresIncidentCapability(IncidentCapabilities.ManageAnnotations)]
 		public async Task<ActionResult<ICModels.IncidentMapAnnotationResult>> SaveAnnotation([FromBody] IncidentMapAnnotation annotation)
 		{
 			if (annotation == null || string.IsNullOrWhiteSpace(annotation.IncidentCommandId))

--- a/Web/Resgrid.Web.Services/Controllers/v4/IncidentCommandController.cs
+++ b/Web/Resgrid.Web.Services/Controllers/v4/IncidentCommandController.cs
@@ -33,10 +33,13 @@ namespace Resgrid.Web.Services.Controllers.v4
 		#region Command lifecycle
 
 		/// <summary>Establishes command on a call, optionally seeding lanes from a command definition.</summary>
+		// Bootstrap: intentionally NOT [RequiresIncidentCapability]. EstablishCommand CREATES the command, so at call
+		// time no command/commander/role (hence no IncidentCapabilities) exists yet — GetCapabilitiesForUserAsync would
+		// return None and 403 every establish. Department-level [Authorize(Command_Create)] is the correct gate here;
+		// the incident-scoped capability checks apply to the lifecycle endpoints that operate on an existing command.
 		[HttpPost("EstablishCommand")]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		[Authorize(Policy = ResgridResources.Command_Create)]
-		[RequiresIncidentCapability(IncidentCapabilities.ManageCommand)]
 		public async Task<ActionResult<ICModels.IncidentCommandResult>> EstablishCommand([FromBody] ICModels.EstablishCommandInput input)
 		{
 			if (input == null || input.CallId <= 0)

--- a/Web/Resgrid.Web.Services/Controllers/v4/IncidentResourcesController.cs
+++ b/Web/Resgrid.Web.Services/Controllers/v4/IncidentResourcesController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 using Resgrid.Model;
 using Resgrid.Model.Services;
 using Resgrid.Providers.Claims;
+using Resgrid.Web.Services.Filters;
 using Resgrid.Web.Services.Helpers;
 using System.Threading;
 using System.Threading.Tasks;
@@ -35,6 +36,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 		[HttpPost("CreateAdHocUnit")]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		[Authorize(Policy = ResgridResources.Command_Update)]
+		[RequiresIncidentCapability(IncidentCapabilities.ManageResources)]
 		public async Task<ActionResult<ICModels.AdHocUnitResult>> CreateAdHocUnit([FromBody] IncidentAdHocUnit unit)
 		{
 			if (unit == null || unit.CallId <= 0)
@@ -95,6 +97,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 		[HttpPost("CreateAdHocPersonnel")]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		[Authorize(Policy = ResgridResources.Command_Update)]
+		[RequiresIncidentCapability(IncidentCapabilities.ManageResources)]
 		public async Task<ActionResult<ICModels.AdHocPersonnelResult>> CreateAdHocPersonnel([FromBody] IncidentAdHocPersonnel personnel)
 		{
 			if (personnel == null || personnel.CallId <= 0)
@@ -180,6 +183,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 		[HttpPost("FormUnit")]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		[Authorize(Policy = ResgridResources.Command_Update)]
+		[RequiresIncidentCapability(IncidentCapabilities.ManageResources)]
 		public async Task<ActionResult<ICModels.AdHocUnitResult>> FormUnit([FromBody] ICModels.FormUnitInput input)
 		{
 			if (input == null || input.CallId <= 0 || string.IsNullOrWhiteSpace(input.Name))

--- a/Web/Resgrid.Web.Services/Controllers/v4/IncidentRolesController.cs
+++ b/Web/Resgrid.Web.Services/Controllers/v4/IncidentRolesController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 using Resgrid.Model;
 using Resgrid.Model.Services;
 using Resgrid.Providers.Claims;
+using Resgrid.Web.Services.Filters;
 using Resgrid.Web.Services.Helpers;
 using System;
 using System.Threading;
@@ -34,6 +35,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 		[HttpPost("AssignRole")]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		[Authorize(Policy = ResgridResources.Command_Update)]
+		[RequiresIncidentCapability(IncidentCapabilities.ManageCommand)]
 		public async Task<ActionResult<ICModels.IncidentRoleResult>> AssignRole([FromBody] IncidentRoleAssignment assignment)
 		{
 			if (assignment == null || string.IsNullOrWhiteSpace(assignment.IncidentCommandId) || string.IsNullOrWhiteSpace(assignment.UserId))

--- a/Web/Resgrid.Web.Services/Controllers/v4/IncidentVoiceController.cs
+++ b/Web/Resgrid.Web.Services/Controllers/v4/IncidentVoiceController.cs
@@ -1,8 +1,10 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Resgrid.Model;
 using Resgrid.Model.Services;
 using Resgrid.Providers.Claims;
+using Resgrid.Web.Services.Filters;
 using Resgrid.Web.Services.Helpers;
 using System.Threading;
 using System.Threading.Tasks;
@@ -31,6 +33,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 		[HttpPost("CreateIncidentChannel")]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		[Authorize(Policy = ResgridResources.Command_Update)]
+		[RequiresIncidentCapability(IncidentCapabilities.ManageChannels)]
 		public async Task<ActionResult<ICModels.IncidentVoiceChannelResult>> CreateIncidentChannel([FromBody] ICModels.CreateIncidentChannelInput input)
 		{
 			if (input == null || input.CallId <= 0)
@@ -72,6 +75,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 		[HttpPost("CloseIncidentChannels/{callId}")]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		[Authorize(Policy = ResgridResources.Command_Update)]
+		[RequiresIncidentCapability(IncidentCapabilities.ManageChannels)]
 		public async Task<ActionResult<ICModels.IncidentCommandActionResult>> CloseIncidentChannels(int callId)
 		{
 			var result = new ICModels.IncidentCommandActionResult();

--- a/Web/Resgrid.Web.Services/Controllers/v4/SyncController.cs
+++ b/Web/Resgrid.Web.Services/Controllers/v4/SyncController.cs
@@ -24,11 +24,13 @@ namespace Resgrid.Web.Services.Controllers.v4
 		#region Members and Constructors
 		private readonly IIncidentCommandService _incidentCommandService;
 		private readonly IIncidentResourcesService _incidentResourcesService;
+		private readonly ISyncService _syncService;
 
-		public SyncController(IIncidentCommandService incidentCommandService, IIncidentResourcesService incidentResourcesService)
+		public SyncController(IIncidentCommandService incidentCommandService, IIncidentResourcesService incidentResourcesService, ISyncService syncService)
 		{
 			_incidentCommandService = incidentCommandService;
 			_incidentResourcesService = incidentResourcesService;
+			_syncService = syncService;
 		}
 		#endregion Members and Constructors
 
@@ -58,6 +60,54 @@ namespace Resgrid.Web.Services.Controllers.v4
 			result.PageSize = changes.Commands.Count + changes.Nodes.Count + changes.Assignments.Count
 				+ changes.Objectives.Count + changes.Timers.Count + changes.Annotations.Count
 				+ changes.Roles.Count + changes.AdHocUnits.Count + changes.AdHocPersonnel.Count + changes.TimelineEntries.Count;
+			result.Status = ResponseHelper.Success;
+			ResponseHelper.PopulateV4ResponseData(result);
+			return result;
+		}
+
+		/// <summary>
+		/// Shift-start aggregate pull: a render-ready board (incl. computed accountability / PAR) for every ACTIVE
+		/// incident in the caller's department, plus the active ad-hoc resources and a next-sync cursor — in a single
+		/// round-trip. Persist <c>Data.ServerTimestampMs</c> and pass it as the next <see cref="Changes"/> `since`.
+		/// Unlike <see cref="Changes"/> (a row-based delta), this returns the computed PAR/accountability state.
+		/// </summary>
+		[HttpGet("Bundle")]
+		[ProducesResponseType(StatusCodes.Status200OK)]
+		[Authorize(Policy = ResgridResources.Command_View)]
+		public async Task<ActionResult<SyncBundleResult>> Bundle(bool includeAccountability = true)
+		{
+			var bundle = await _incidentCommandService.GetBundleForDepartmentAsync(DepartmentId, includeAccountability);
+
+			// Ad-hoc resources live in IncidentResourcesService; aggregate the active ones per incident into the bundle.
+			foreach (var board in bundle.Boards)
+			{
+				var callId = board.Command.CallId;
+				bundle.AdHocUnits.AddRange(await _incidentResourcesService.GetAdHocUnitsForCallAsync(DepartmentId, callId));
+				bundle.AdHocPersonnel.AddRange(await _incidentResourcesService.GetAdHocPersonnelForCallAsync(DepartmentId, callId));
+			}
+
+			var result = new SyncBundleResult { Data = bundle };
+			result.PageSize = bundle.Boards.Count;
+			result.Status = ResponseHelper.Success;
+			ResponseHelper.PopulateV4ResponseData(result);
+			return result;
+		}
+
+		/// <summary>
+		/// Shift-start REFERENCE pull: the slowly-changing department configuration + a safe personnel roster needed to
+		/// start and run an incident offline (call types, command templates, units, personnel, groups, POIs, protocols,
+		/// accountability config, statuses, feature flags). Pull once per shift / on manual refresh; the live incident
+		/// state comes from <see cref="Bundle"/> and <see cref="Changes"/>.
+		/// </summary>
+		[HttpGet("Reference")]
+		[ProducesResponseType(StatusCodes.Status200OK)]
+		[Authorize(Policy = ResgridResources.Command_View)]
+		public async Task<ActionResult<SyncReferenceResult>> Reference()
+		{
+			var data = await _syncService.GetReferenceDataAsync(DepartmentId);
+
+			var result = new SyncReferenceResult { Data = data };
+			result.PageSize = data.Units.Count + data.Personnel.Count;
 			result.Status = ResponseHelper.Success;
 			ResponseHelper.PopulateV4ResponseData(result);
 			return result;

--- a/Web/Resgrid.Web.Services/Controllers/v4/SyncController.cs
+++ b/Web/Resgrid.Web.Services/Controllers/v4/SyncController.cs
@@ -25,12 +25,14 @@ namespace Resgrid.Web.Services.Controllers.v4
 		private readonly IIncidentCommandService _incidentCommandService;
 		private readonly IIncidentResourcesService _incidentResourcesService;
 		private readonly ISyncService _syncService;
+		private readonly Model.Services.IAuthorizationService _authorizationService;
 
-		public SyncController(IIncidentCommandService incidentCommandService, IIncidentResourcesService incidentResourcesService, ISyncService syncService)
+		public SyncController(IIncidentCommandService incidentCommandService, IIncidentResourcesService incidentResourcesService, ISyncService syncService, Model.Services.IAuthorizationService authorizationService)
 		{
 			_incidentCommandService = incidentCommandService;
 			_incidentResourcesService = incidentResourcesService;
 			_syncService = syncService;
+			_authorizationService = authorizationService;
 		}
 		#endregion Members and Constructors
 
@@ -104,8 +106,21 @@ namespace Resgrid.Web.Services.Controllers.v4
 		{
 			var data = await _syncService.GetReferenceDataAsync(DepartmentId, bypassCache);
 
+			// PII gate: the reference snapshot is cached department-scoped and caller-agnostic, so mobile numbers are
+			// redacted here per-caller (NOT inside the cached build, which would let the first caller's permission
+			// decide what every later caller sees). Matches the CanUserViewPIIAsync check the Personnel/Dispatch
+			// endpoints apply to the same roster — Command_View alone must not expose personnel PII.
+			if (!await _authorizationService.CanUserViewPIIAsync(UserId, DepartmentId))
+			{
+				foreach (var person in data.Personnel)
+					person.MobilePhone = null;
+			}
+
 			var result = new SyncReferenceResult { Data = data };
-			result.PageSize = data.Units.Count + data.Personnel.Count;
+			result.PageSize = data.CallTypes.Count + data.CallPriorities.Count + data.CommandTemplates.Count
+				+ data.Units.Count + data.UnitTypes.Count + data.Groups.Count + data.Pois.Count + data.PoiTypes.Count
+				+ data.Protocols.Count + data.CheckInTimerConfigs.Count + data.PersonnelStates.Count + data.UnitStates.Count
+				+ data.Personnel.Count + data.Features.Count;
 			result.Status = ResponseHelper.Success;
 			ResponseHelper.PopulateV4ResponseData(result);
 			return result;

--- a/Web/Resgrid.Web.Services/Controllers/v4/SyncController.cs
+++ b/Web/Resgrid.Web.Services/Controllers/v4/SyncController.cs
@@ -78,13 +78,11 @@ namespace Resgrid.Web.Services.Controllers.v4
 		{
 			var bundle = await _incidentCommandService.GetBundleForDepartmentAsync(DepartmentId, includeAccountability);
 
-			// Ad-hoc resources live in IncidentResourcesService; aggregate the active ones per incident into the bundle.
-			foreach (var board in bundle.Boards)
-			{
-				var callId = board.Command.CallId;
-				bundle.AdHocUnits.AddRange(await _incidentResourcesService.GetAdHocUnitsForCallAsync(DepartmentId, callId));
-				bundle.AdHocPersonnel.AddRange(await _incidentResourcesService.GetAdHocPersonnelForCallAsync(DepartmentId, callId));
-			}
+			// Ad-hoc resources live in IncidentResourcesService; pull them for ALL active incidents in one batched call
+			// (the previous per-board loop was an N+1 — each call scanned the department's ad-hoc tables).
+			var adHoc = await _incidentResourcesService.GetActiveAdHocResourcesForDepartmentAsync(DepartmentId);
+			bundle.AdHocUnits = adHoc.Units;
+			bundle.AdHocPersonnel = adHoc.Personnel;
 
 			var result = new SyncBundleResult { Data = bundle };
 			result.PageSize = bundle.Boards.Count;
@@ -102,9 +100,9 @@ namespace Resgrid.Web.Services.Controllers.v4
 		[HttpGet("Reference")]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		[Authorize(Policy = ResgridResources.Command_View)]
-		public async Task<ActionResult<SyncReferenceResult>> Reference()
+		public async Task<ActionResult<SyncReferenceResult>> Reference(bool bypassCache = false)
 		{
-			var data = await _syncService.GetReferenceDataAsync(DepartmentId);
+			var data = await _syncService.GetReferenceDataAsync(DepartmentId, bypassCache);
 
 			var result = new SyncReferenceResult { Data = data };
 			result.PageSize = data.Units.Count + data.Personnel.Count;

--- a/Web/Resgrid.Web.Services/Filters/RequiresIncidentCapabilityAttribute.cs
+++ b/Web/Resgrid.Web.Services/Filters/RequiresIncidentCapabilityAttribute.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Reflection;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Resgrid.Model;
+using Resgrid.Model.Services;
+
+namespace Resgrid.Web.Services.Filters
+{
+	/// <summary>
+	/// Per-endpoint, incident-scoped capability gate (§3.11). Layered ON TOP of the broad
+	/// <c>[Authorize(Policy = Command_*)]</c> claims that already protect every IC endpoint, this filter
+	/// additionally enforces that the calling user's effective <see cref="IncidentCapabilities"/> for the
+	/// target incident include <see cref="Required"/>. The Incident Commander / Deputy / Unified-Command roles
+	/// (and the user who established command) get <see cref="IncidentCapabilities.All"/>, so they pass every
+	/// gate — see <see cref="IncidentRoleCapabilityMap"/> and
+	/// <see cref="IIncidentCommandService.GetCapabilitiesForUserAsync"/>.
+	///
+	/// It runs as an action filter (after model binding) so it can read the target Call from the bound request —
+	/// either an explicit <c>callId</c> route value, an <c>IncidentCommandId</c> on the body/route (resolved to
+	/// its Call, department-ownership checked), or a <c>CallId</c> on the request body. If the Call cannot be
+	/// determined the filter does NOT block: the broad Command_* claim and the service-layer department-ownership
+	/// guards still apply, so this filter only ever ADDS protection, never removes it.
+	///
+	/// Note: the entity-id "second action" verbs (delete/release/complete/acknowledge an existing row) are left on
+	/// the broad Command_* claim because the target Call isn't on the request — adding capability gating there
+	/// needs an entity-id → Call lookup and is a deliberate follow-up.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+	public sealed class RequiresIncidentCapabilityAttribute : Attribute, IAsyncActionFilter
+	{
+		/// <summary>The capability the caller must hold for the target incident to proceed.</summary>
+		public IncidentCapabilities Required { get; }
+
+		public RequiresIncidentCapabilityAttribute(IncidentCapabilities required)
+		{
+			Required = required;
+		}
+
+		public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
+		{
+			var service = context.HttpContext.RequestServices?.GetService(typeof(IIncidentCommandService)) as IIncidentCommandService;
+
+			// Identity from the same claims the controllers use (PrimarySid = userId, PrimaryGroupSid = departmentId).
+			var user = context.HttpContext.User;
+			var userId = user?.FindFirst(ClaimTypes.PrimarySid)?.Value;
+			int.TryParse(user?.FindFirst(ClaimTypes.PrimaryGroupSid)?.Value, out var departmentId);
+
+			// Without identity or the service we can't evaluate — defer to the broad [Authorize] gate.
+			if (service == null || departmentId <= 0 || string.IsNullOrWhiteSpace(userId))
+			{
+				await next();
+				return;
+			}
+
+			var callId = await ResolveCallIdAsync(context, service, departmentId);
+			if (callId == null || callId.Value <= 0)
+			{
+				// Couldn't classify the target incident — don't block; the broad Command_* claim still governs.
+				await next();
+				return;
+			}
+
+			var capabilities = await service.GetCapabilitiesForUserAsync(departmentId, callId.Value, userId);
+			if ((capabilities & Required) != Required)
+			{
+				context.Result = new ObjectResult("Insufficient incident-command capability for this action.")
+				{
+					StatusCode = StatusCodes.Status403Forbidden
+				};
+				return;
+			}
+
+			await next();
+		}
+
+		/// <summary>
+		/// Determines the target Call for the request, preferring the most authoritative source:
+		/// (1) an explicit <c>callId</c> route/argument, (2) an <c>IncidentCommandId</c> (route/arg/body) resolved
+		/// to its Call and department-ownership checked, then (3) a <c>CallId</c> on a bound request body object.
+		/// </summary>
+		private static async Task<int?> ResolveCallIdAsync(ActionExecutingContext context, IIncidentCommandService service, int departmentId)
+		{
+			// (1) Explicit callId (e.g. EvaluateAccountability/{callId}, CloseIncidentChannels/{callId}).
+			var directCallId = GetInt(context, "callId");
+			if (directCallId.HasValue && directCallId.Value > 0)
+				return directCallId;
+
+			// (2) IncidentCommandId — authoritative; resolve to its Call and confirm department ownership so a
+			// forged id from another department can't be used to classify the request.
+			var incidentCommandId = GetString(context, "incidentCommandId") ?? GetStringProperty(context, "IncidentCommandId");
+			if (!string.IsNullOrWhiteSpace(incidentCommandId))
+			{
+				var command = await service.GetCommandByIdAsync(incidentCommandId);
+				if (command != null && command.DepartmentId == departmentId && command.CallId > 0)
+					return command.CallId;
+			}
+
+			// (3) CallId on a bound body object (e.g. EstablishCommandInput, CreateIncidentChannelInput, ad-hoc creates, FormUnitInput).
+			var bodyCallId = GetIntProperty(context, "CallId");
+			if (bodyCallId.HasValue && bodyCallId.Value > 0)
+				return bodyCallId;
+
+			return null;
+		}
+
+		private static int? GetInt(ActionExecutingContext context, string key)
+		{
+			if (context.ActionArguments.TryGetValue(key, out var arg) && arg is int i)
+				return i;
+
+			if (context.RouteData.Values.TryGetValue(key, out var routeVal) && int.TryParse(routeVal?.ToString(), out var parsed))
+				return parsed;
+
+			return null;
+		}
+
+		private static string GetString(ActionExecutingContext context, string key)
+		{
+			if (context.ActionArguments.TryGetValue(key, out var arg) && arg is string s && !string.IsNullOrWhiteSpace(s))
+				return s;
+
+			if (context.RouteData.Values.TryGetValue(key, out var routeVal))
+			{
+				var rv = routeVal?.ToString();
+				if (!string.IsNullOrWhiteSpace(rv))
+					return rv;
+			}
+
+			return null;
+		}
+
+		private static string GetStringProperty(ActionExecutingContext context, string propertyName)
+		{
+			foreach (var arg in context.ActionArguments.Values)
+			{
+				if (arg is null or string)
+					continue;
+
+				var prop = arg.GetType().GetProperty(propertyName, BindingFlags.Public | BindingFlags.Instance);
+				if (prop != null && prop.PropertyType == typeof(string))
+				{
+					if (prop.GetValue(arg) is string value && !string.IsNullOrWhiteSpace(value))
+						return value;
+				}
+			}
+
+			return null;
+		}
+
+		private static int? GetIntProperty(ActionExecutingContext context, string propertyName)
+		{
+			foreach (var arg in context.ActionArguments.Values)
+			{
+				if (arg is null or string)
+					continue;
+
+				var prop = arg.GetType().GetProperty(propertyName, BindingFlags.Public | BindingFlags.Instance);
+				if (prop != null && prop.PropertyType == typeof(int))
+				{
+					if (prop.GetValue(arg) is int value && value > 0)
+						return value;
+				}
+			}
+
+			return null;
+		}
+	}
+}

--- a/Web/Resgrid.Web.Services/Models/v4/Sync/SyncModels.cs
+++ b/Web/Resgrid.Web.Services/Models/v4/Sync/SyncModels.cs
@@ -10,4 +10,24 @@ namespace Resgrid.Web.Services.Models.v4.Sync
 	{
 		public Resgrid.Model.IncidentCommandChanges Data { get; set; }
 	}
+
+	/// <summary>
+	/// Shift-start aggregate pull for offline clients: a render-ready board (incl. computed accountability / PAR) for
+	/// every active incident in the caller's department, plus active ad-hoc resources and the next-sync cursor, in a
+	/// single call. The client stores <c>Data.ServerTimestampMs</c> and passes it as the next <c>Changes</c> `since`.
+	/// </summary>
+	public class SyncBundleResult : StandardApiResponseV4Base
+	{
+		public Resgrid.Model.IncidentCommandBundle Data { get; set; }
+	}
+
+	/// <summary>
+	/// Shift-start REFERENCE payload: the slowly-changing department configuration + a safe personnel roster an IC/Unit
+	/// app needs to start and run an incident offline. Pull once per shift / on manual refresh; the live incident state
+	/// comes from /Sync/Bundle (active boards) and /Sync/Changes (deltas).
+	/// </summary>
+	public class SyncReferenceResult : StandardApiResponseV4Base
+	{
+		public Resgrid.Model.SyncReferenceData Data { get; set; }
+	}
 }

--- a/Web/Resgrid.Web.Services/Resgrid.Web.Services.xml
+++ b/Web/Resgrid.Web.Services/Resgrid.Web.Services.xml
@@ -1945,7 +1945,7 @@
             Unlike <see cref="M:Resgrid.Web.Services.Controllers.v4.SyncController.Changes(System.Int64)"/> (a row-based delta), this returns the computed PAR/accountability state.
             </summary>
         </member>
-        <member name="M:Resgrid.Web.Services.Controllers.v4.SyncController.Reference">
+        <member name="M:Resgrid.Web.Services.Controllers.v4.SyncController.Reference(System.Boolean)">
             <summary>
             Shift-start REFERENCE pull: the slowly-changing department configuration + a safe personnel roster needed to
             start and run an incident offline (call types, command templates, units, personnel, groups, POIs, protocols,

--- a/Web/Resgrid.Web.Services/Resgrid.Web.Services.xml
+++ b/Web/Resgrid.Web.Services/Resgrid.Web.Services.xml
@@ -1937,6 +1937,22 @@
             <paramref name="since"/>.
             </summary>
         </member>
+        <member name="M:Resgrid.Web.Services.Controllers.v4.SyncController.Bundle(System.Boolean)">
+            <summary>
+            Shift-start aggregate pull: a render-ready board (incl. computed accountability / PAR) for every ACTIVE
+            incident in the caller's department, plus the active ad-hoc resources and a next-sync cursor — in a single
+            round-trip. Persist <c>Data.ServerTimestampMs</c> and pass it as the next <see cref="M:Resgrid.Web.Services.Controllers.v4.SyncController.Changes(System.Int64)"/> `since`.
+            Unlike <see cref="M:Resgrid.Web.Services.Controllers.v4.SyncController.Changes(System.Int64)"/> (a row-based delta), this returns the computed PAR/accountability state.
+            </summary>
+        </member>
+        <member name="M:Resgrid.Web.Services.Controllers.v4.SyncController.Reference">
+            <summary>
+            Shift-start REFERENCE pull: the slowly-changing department configuration + a safe personnel roster needed to
+            start and run an incident offline (call types, command templates, units, personnel, groups, POIs, protocols,
+            accountability config, statuses, feature flags). Pull once per shift / on manual refresh; the live incident
+            state comes from <see cref="M:Resgrid.Web.Services.Controllers.v4.SyncController.Bundle(System.Boolean)"/> and <see cref="M:Resgrid.Web.Services.Controllers.v4.SyncController.Changes(System.Int64)"/>.
+            </summary>
+        </member>
         <member name="T:Resgrid.Web.Services.Controllers.v4.TemplatesController">
             <summary>
             Templates in the system. Templates can be call Templates, Autofills (i.e. Call Notes)
@@ -4557,6 +4573,37 @@
         <member name="P:Resgrid.Web.Services.Controllers.Version3.Models.Units.UnitStatusResult.Tmp">
             <summary>
             The Timestamp of the status
+            </summary>
+        </member>
+        <member name="T:Resgrid.Web.Services.Filters.RequiresIncidentCapabilityAttribute">
+             <summary>
+             Per-endpoint, incident-scoped capability gate (§3.11). Layered ON TOP of the broad
+             <c>[Authorize(Policy = Command_*)]</c> claims that already protect every IC endpoint, this filter
+             additionally enforces that the calling user's effective <see cref="T:Resgrid.Model.IncidentCapabilities"/> for the
+             target incident include <see cref="P:Resgrid.Web.Services.Filters.RequiresIncidentCapabilityAttribute.Required"/>. The Incident Commander / Deputy / Unified-Command roles
+             (and the user who established command) get <see cref="F:Resgrid.Model.IncidentCapabilities.All"/>, so they pass every
+             gate — see <see cref="T:Resgrid.Model.IncidentRoleCapabilityMap"/> and
+             <see cref="M:Resgrid.Model.Services.IIncidentCommandService.GetCapabilitiesForUserAsync(System.Int32,System.Int32,System.String)"/>.
+            
+             It runs as an action filter (after model binding) so it can read the target Call from the bound request —
+             either an explicit <c>callId</c> route value, an <c>IncidentCommandId</c> on the body/route (resolved to
+             its Call, department-ownership checked), or a <c>CallId</c> on the request body. If the Call cannot be
+             determined the filter does NOT block: the broad Command_* claim and the service-layer department-ownership
+             guards still apply, so this filter only ever ADDS protection, never removes it.
+            
+             Note: the entity-id "second action" verbs (delete/release/complete/acknowledge an existing row) are left on
+             the broad Command_* claim because the target Call isn't on the request — adding capability gating there
+             needs an entity-id → Call lookup and is a deliberate follow-up.
+             </summary>
+        </member>
+        <member name="P:Resgrid.Web.Services.Filters.RequiresIncidentCapabilityAttribute.Required">
+            <summary>The capability the caller must hold for the target incident to proceed.</summary>
+        </member>
+        <member name="M:Resgrid.Web.Services.Filters.RequiresIncidentCapabilityAttribute.ResolveCallIdAsync(Microsoft.AspNetCore.Mvc.Filters.ActionExecutingContext,Resgrid.Model.Services.IIncidentCommandService,System.Int32)">
+            <summary>
+            Determines the target Call for the request, preferring the most authoritative source:
+            (1) an explicit <c>callId</c> route/argument, (2) an <c>IncidentCommandId</c> (route/arg/body) resolved
+            to its Call and department-ownership checked, then (3) a <c>CallId</c> on a bound request body object.
             </summary>
         </member>
         <member name="P:Resgrid.Web.Services.Middleware.ResgridAuthenticationEvents.OnAuthenticationFailed">
@@ -9636,6 +9683,20 @@
             <summary>
             Delta sync payload for offline clients: incident-command rows changed since the client's cursor. The client
             stores <c>Data.ServerTimestampMs</c> and passes it back as the next `since`.
+            </summary>
+        </member>
+        <member name="T:Resgrid.Web.Services.Models.v4.Sync.SyncBundleResult">
+            <summary>
+            Shift-start aggregate pull for offline clients: a render-ready board (incl. computed accountability / PAR) for
+            every active incident in the caller's department, plus active ad-hoc resources and the next-sync cursor, in a
+            single call. The client stores <c>Data.ServerTimestampMs</c> and passes it as the next <c>Changes</c> `since`.
+            </summary>
+        </member>
+        <member name="T:Resgrid.Web.Services.Models.v4.Sync.SyncReferenceResult">
+            <summary>
+            Shift-start REFERENCE payload: the slowly-changing department configuration + a safe personnel roster an IC/Unit
+            app needs to start and run an incident offline. Pull once per shift / on manual refresh; the live incident state
+            comes from /Sync/Bundle (active boards) and /Sync/Changes (deltas).
             </summary>
         </member>
         <member name="T:Resgrid.Web.Services.Models.v4.Templates.CallNoteTemplatesResult">

--- a/docs/architecture/offline-first-architecture.md
+++ b/docs/architecture/offline-first-architecture.md
@@ -2,7 +2,7 @@
 
 **Status:** Design / proposal
 **Author:** Resgrid IC backend work (RIC-T39 follow-on)
-**Last updated:** 2026-06-24
+**Last updated:** 2026-06-27
 **Applies to:** Resgrid **IC** app (new, `../IC`), Resgrid **Unit** app (existing, `../Unit`), Resgrid **Core** backend (this repo)
 
 > This document is the single source of truth for how the Resgrid mobile apps work
@@ -216,8 +216,39 @@ mark the local record `_syncError` and surface it (do **not** silently roll back
 3. Record `lastSyncAt` / per-store high-water timestamps; show progress + a "Synced ✓ (time)" state.
 4. Pre-warm SignalR so live updates keep the cache hot while still online.
 
-Optional backend optimization: a single `/Sync/Bundle` aggregate endpoint (§9) to cut round-trips.
-v1 can fan out existing `GetAll*` calls.
+### 6.1 Authoritative shift-start manifest (what the app MUST pull to be field-ready)
+
+The app is "field-ready" — able to **start and run** an incident fully offline — once it has pulled ALL of
+the following. Each row names its delivery endpoint. Three Sync endpoints now exist
+(`Web/Resgrid.Web.Services/Controllers/v4/SyncController.cs`); everything else rides existing v4 `GetAll*`
+endpoints. This list is the single source of truth — if a dataset isn't here with a delivery mechanism, the
+app is not field-complete.
+
+**A. Reference data (slowly-changing) — `GET /api/v4/Sync/Reference`** (one call → `SyncReferenceData`):
+call types, call priorities, command-definition **templates** (needed to establish/seed command), units +
+unit types, **personnel roster** (SAFE projection — name / mobile / primary group / current state, NO
+credentials), groups, POIs + POI types, dispatch protocols, check-in timer configs, personnel + unit custom
+statuses, resolved feature flags. Pull once per shift / on manual refresh; cache aggressively.
+
+**B. Live incident state — `GET /api/v4/Sync/Bundle`** (one call → `IncidentCommandBundle`): a render-ready
+board per ACTIVE incident (lanes, resources, objectives, timers, roles, annotations) **including computed
+accountability / PAR**, plus active ad-hoc resources, plus a `ServerTimestampMs` cursor.
+`?includeAccountability=false` skips the per-incident PAR computation for departments with very many open
+incidents.
+
+**C. Incremental catch-up — `GET /api/v4/Sync/Changes?since={cursor}`** (→ `IncidentCommandChanges`): the
+row-based delta of incident-command rows (incl. tombstones / closed / released) changed since the cursor, for
+reconnect reconciliation. `since=0` is a full row pull.
+
+**D. Delivered by other means (existing v4 endpoints — documented, intentionally not re-bundled):** the Call
+list + metadata (Calls API — incidents are CAD-dispatched), mutual-aid assignable resources
+(`MutualAidController`, per-call), indoor maps / custom GIS layers (Mapping API), detailed per-user
+roles/certs (Personnel API), and Mapbox offline tile packs (§10, client-side download). The app pulls these
+alongside A–C at shift start.
+
+> Delivery split rationale: **A** is static/cacheable, **B** is live and bounded by active-incident count,
+> **C** is the reconnect delta. Keeping them separate keeps each call cacheable/paginatable and avoids one
+> mega-endpoint that couples every subsystem and is impossible to keep performant.
 
 ---
 
@@ -277,11 +308,20 @@ see the IC backend state doc). All are additive and apply to **both** SQL Server
 3. **Action idempotency keys.** Check-in / status / location endpoints accept an `IdempotencyKey`
    (the outbox event id) and dedup on `(DepartmentId, UserId, IdempotencyKey)` within a window — or
    rely on LWW-by-timestamp where natural.
-4. **Delta endpoint(s).** `GET /api/v4/Sync/Changes?since={utcIso}&types=Calls,IncidentCommand,…`
-   returning, per type, `created/updated` rows and `deleted` ids (from tombstones) with a new
-   server high-water `syncToken`. v1 may implement per-domain `GetChangedSince` and full-refetch the
-   small reference sets; build true deltas first for the large sets (messages, call/audit history).
-5. **(Optional) `GET /api/v4/Sync/Bundle`** — one aggregate shift-start pull to reduce round-trips.
+4. **Delta endpoint — DONE.** `GET /api/v4/Sync/Changes?since={epochMs}` (`SyncController.Changes`) returns
+   every change-tracked incident-command row (incl. tombstones / closed / released) changed since the cursor,
+   scoped to the caller's department, with a `ServerTimestampMs` high-water cursor; `since=0` = full row pull.
+   (Covers the IC command working set; broader-domain deltas remain future work.)
+5. **Shift-start aggregates — DONE.**
+   - `GET /api/v4/Sync/Bundle` (`SyncController.Bundle` → `IIncidentCommandService.GetBundleForDepartmentAsync`):
+     a render-ready board per ACTIVE incident incl. computed accountability/PAR + active ad-hoc + cursor.
+     **Performance:** assembled with ONE scan per board table (grouped by CallId in memory) — O(tables), not
+     O(active incidents × department size) — and READ-ONLY (no PAR write-sweep / SignalR storm). The
+     per-incident PAR read is skippable with `?includeAccountability=false` for very busy departments.
+   - `GET /api/v4/Sync/Reference` (`SyncController.Reference` → `ISyncService.GetReferenceDataAsync`): the
+     reference manifest (§6.1.A). Personnel is a SAFE projection (`ReferencePersonnel`) — never raw
+     `IdentityUser` / `UserProfile` (which carry password hashes + contact-verification codes + CalendarSyncToken);
+     groups are projected to `ReferenceGroup` to drop the member `IdentityUser` navs.
 
 > CQRS/SignalR already publishes live updates including `IncidentCommandUpdated = 22`
 > (`ICoreEventService.IncidentCommandUpdatedAsync`). The delta endpoints are the *catch-up* path for


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

This PR implements the backend infrastructure for the Resgrid **IC (Incident Command)** app's offline-first shift-start workflow, comprising three major additions: (1) two new aggregate sync endpoints that let a field client pull everything it needs in minimal round-trips, (2) a per-endpoint incident-capability authorization layer, and (3) associated tests and documentation.

### 1. Shift-start aggregate sync endpoints

**`GET /api/v4/Sync/Bundle`** — Returns a render-ready `IncidentCommandBoard` (lanes, resources, objectives, timers, roles, annotations, and computed accountability/PAR) for every **active** incident in the caller's department, plus active ad-hoc units and personnel, in a single call. The client uses the returned `ServerTimestampMs` as the cursor for subsequent incremental `/Sync/Changes` pulls.

- `IncidentCommandService.GetBundleForDepartmentAsync` scans each board table **once** for the whole department and groups by `CallId` in memory — O(tables) instead of the previous O(active incidents × department size) per-incident N+1 pattern.
- The bundle is **read-only**: unlike the per-call `GetCommandBoardAsync`, it does not run the write-side PAR sweep (no marker writes or SignalR pushes).
- `?includeAccountability=false` lets very busy departments skip the per-incident PAR computation.

**`GET /api/v4/Sync/Reference`** — Returns the slowly-changing department configuration and a **safe personnel roster** needed to start and run an incident offline (call types, priorities, command templates, units, groups, POIs, protocols, custom statuses, feature flags).

- A new `SyncService` aggregates data from 12 existing services into a single `SyncReferenceData` payload.
- Personnel and groups are projected to safe DTOs (`ReferencePersonnel`, `ReferenceGroup`) that structurally exclude `IdentityUser` navs, password/security fields, and `UserProfile` contact-verification secrets.
- Department-scoped cache-aside (5-minute TTL) via a protobuf-safe JSON envelope (`ReferenceCacheEnvelope`); `?bypassCache=true` forces a fresh read.

**Batched ad-hoc resources**: `IncidentResourcesService.GetActiveAdHocResourcesForDepartmentAsync` returns all active (non-released) ad-hoc units and personnel scoped to the department's active incidents in one scan per table, replacing the per-incident N+1 lookups.

### 2. Incident-scoped capability authorization

A new `RequiresIncidentCapabilityAttribute` action filter enforces that the calling user holds the required `IncidentCapabilities` (e.g., `ManageStructure`, `AssignResources`, `ManageAccountability`) for the **specific incident** targeted by the request — layered on top of the existing broad `[Authorize(Policy = Command_*)]` claims.

- Resolves the target Call from the request via three strategies: explicit `callId` route value, `IncidentCommandId` (resolved to its Call with department-ownership verification), or `CallId` on the bound body.
- **Fails open** when the Call cannot be determined or belongs to another department — the broad Command_* claim and service-layer ownership guards still apply, so the filter only ever adds protection.
- Applied to 14 endpoints across `IncidentCommandController`, `IncidentResourcesController`, `IncidentRolesController`, and `IncidentVoiceController`.
- Intentionally **not** applied to `EstablishCommand` (it creates the command, so no capabilities exist yet) or to entity-id "second action" verbs where the target Call isn't on the request.

### 3. Tests & documentation

- Added unit tests for the bundle assembly, tombstone filtering, read-only behavior, ad-hoc batching, the safe personnel projection, cache behavior, and the capability filter's allow/deny/fail-open paths.
- Updated `docs/architecture/offline-first-architecture.md` with the authoritative shift-start manifest (§6.1) and marked the delta and aggregate endpoints as done (§9).
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added offline-ready sync endpoints for incident command bundles (active boards + optional accountability), department reference data, and cursor-based shift-start syncing.
  * Added real-time incident command update notifications to refresh affected clients automatically.
* **Bug Fixes**
  * Improved incident actions security with incident-scoped capability checks (in addition to existing command permissions).
  * Tightened access to incident resources/roles and ensured reference data PII is gated (e.g., mobile phone visibility).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->