### PR TITLE
RE1-T122 Bug fixes for audio tts

### DIFF
--- a/Tests/Resgrid.Tests/Web/Services/TwilioVoiceResponseServiceTests.cs
+++ b/Tests/Resgrid.Tests/Web/Services/TwilioVoiceResponseServiceTests.cs
@@ -132,5 +132,63 @@ namespace Resgrid.Tests.Web.Services
 				x => x.GenerateSpeechUrlAsync("Hello from Resgrid", null, null, It.IsAny<CancellationToken>()),
 				Times.Once);
 		}
+
+		[Test]
+		public async Task pre_warm_prompt_async_should_not_throw_for_multi_chunk_text()
+		{
+			// Regression (Sentry RESGRID-API-78): long dispatch text spans multiple TTS chunks.
+			// PreWarmPromptAsync previously threw ArgumentException for multi-chunk input, faulting
+			// the voice-dispatch pre-warm/redirect path. It must now warm every chunk without throwing.
+			var originalMaxLength = Resgrid.Config.TtsConfig.MaxTextLength;
+			Resgrid.Config.TtsConfig.MaxTextLength = 30;
+			try
+			{
+				var ttsAudioService = new Mock<ITtsAudioService>();
+				ttsAudioService
+					.Setup(x => x.GenerateSpeechUrlAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+					.ReturnsAsync(new Uri("https://tts.example.com/tts/audio/chunk.wav"));
+
+				var service = new TwilioVoiceResponseService(ttsAudioService.Object);
+				var text = "Engine one respond to the structure fire. Ladder two stage at the corner. Battalion three assume command. All units use caution.";
+
+				Func<Task> act = () => service.PreWarmPromptAsync(text);
+
+				await act.Should().NotThrowAsync();
+			}
+			finally
+			{
+				Resgrid.Config.TtsConfig.MaxTextLength = originalMaxLength;
+			}
+		}
+
+		[Test]
+		public async Task append_prompt_async_should_emit_a_play_per_chunk_for_multi_chunk_text()
+		{
+			// Regression (Sentry RESGRID-API-78): the dispatch playback path now routes long text
+			// through AppendPromptAsync, which must fan multi-chunk text out to one <Play> per chunk
+			// rather than throwing like the single-chunk GetPromptUrlAsync did.
+			var originalMaxLength = Resgrid.Config.TtsConfig.MaxTextLength;
+			Resgrid.Config.TtsConfig.MaxTextLength = 30;
+			try
+			{
+				var ttsAudioService = new Mock<ITtsAudioService>();
+				ttsAudioService
+					.Setup(x => x.GenerateSpeechUrlAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+					.ReturnsAsync(new Uri("https://tts.example.com/tts/audio/chunk.wav"));
+
+				var service = new TwilioVoiceResponseService(ttsAudioService.Object);
+				var response = new VoiceResponse();
+				var text = "Engine one respond to the structure fire. Ladder two stage at the corner. Battalion three assume command. All units use caution.";
+
+				await service.AppendPromptAsync(response, text, CancellationToken.None);
+
+				var playCount = response.ToString().Split("<Play>").Length - 1;
+				playCount.Should().BeGreaterThan(1);
+			}
+			finally
+			{
+				Resgrid.Config.TtsConfig.MaxTextLength = originalMaxLength;
+			}
+		}
 	}
 }

--- a/Web/Resgrid.Web.Services/Controllers/TwilioController.cs
+++ b/Web/Resgrid.Web.Services/Controllers/TwilioController.cs
@@ -1246,8 +1246,10 @@ namespace Resgrid.Web.Services.Controllers
 
 			try
 			{
-				var url = await _twilioVoiceResponseService.GetPromptUrlAsync(dispatchText, ttsLanguage, linkedCts.Token);
-				response.Append(new Play { Url = url });
+				// Dispatch text can exceed the TTS chunk limit (long notes/address), so use the
+				// multi-chunk-aware AppendPromptAsync (one <Play> per chunk) instead of GetPromptUrlAsync,
+				// which only supports single-chunk text and throws ArgumentException otherwise.
+				await _twilioVoiceResponseService.AppendPromptAsync(response, dispatchText, linkedCts.Token, ttsLanguage);
 				return true;
 			}
 			catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)

--- a/Web/Resgrid.Web.Services/Twilio/TwilioVoiceResponseService.cs
+++ b/Web/Resgrid.Web.Services/Twilio/TwilioVoiceResponseService.cs
@@ -188,19 +188,19 @@ namespace Resgrid.Web.Services.Twilio
 		{
 			ArgumentException.ThrowIfNullOrWhiteSpace(text);
 
-			var chunks = ChunkText(text).ToList();
-			if (chunks.Count != 1)
-				throw new ArgumentException($"PreWarmPromptAsync does not support multi-chunk input (got {chunks.Count} chunks). Use AppendPromptAsync for multi-chunk text.", nameof(text));
-
-			// Start the generation task (or return the existing one) without
-			// necessarily awaiting it. The TTS microservice's internal cache
-			// persists across requests, so a subsequent call will find the URL.
-			GetOrCreatePromptUrlAsync(chunks[0], voice, CancellationToken.None)
-				.ContinueWith(t =>
-				{
-					if (t.IsFaulted && t.Exception != null)
-						Logging.LogException(t.Exception);
-				}, TaskContinuationOptions.OnlyOnFaulted);
+			// Start generation for each chunk (or return the existing task) without
+			// necessarily awaiting it. The TTS microservice's internal cache persists
+			// across requests, so a subsequent call (GetPromptUrlAsync/AppendPromptAsync)
+			// will find the URLs. Long dispatch text spans multiple chunks, so warm them all.
+			foreach (var chunk in ChunkText(text))
+			{
+				GetOrCreatePromptUrlAsync(chunk, voice, CancellationToken.None)
+					.ContinueWith(t =>
+					{
+						if (t.IsFaulted && t.Exception != null)
+							Logging.LogException(t.Exception);
+					}, TaskContinuationOptions.OnlyOnFaulted);
+			}
 			return System.Threading.Tasks.Task.CompletedTask;
 		}
 


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Description

This PR fixes bugs in the voice dispatch TTS (text-to-speech) path where long dispatch text exceeding the TTS chunk limit would cause `ArgumentException` failures, breaking voice dispatch playback (Sentry: RESGRID-API-78).

### Changes

- **Pre-warm path (`PreWarmPromptAsync`)**: Previously threw `ArgumentException` for any input spanning more than one TTS chunk. It now iterates over all chunks and pre-warms each individually, so long dispatch text no longer faults the pre-warm/redirect flow.

- **Playback path (`TryAppendDispatchPlaybackAsync` in `TwilioController`)**: Switched from `GetPromptUrlAsync` (single-chunk only) to the multi-chunk-aware `AppendPromptAsync`, which emits one `<Play>` element per chunk. This prevents failures when dispatch text (e.g., long notes or addresses) exceeds the chunk limit.

- **Tests**: Added two regression tests verifying that `PreWarmPromptAsync` no longer throws for multi-chunk text and that `AppendPromptAsync` produces a `<Play>` per chunk for multi-chunk input.
<!-- kody-pr-summary:end -->