### PR TITLE
RG-T124 Base Status Type Fixes and Helper Catalogs

### DIFF
--- a/Core/Resgrid.Localization/Areas/User/CustomStatuses/CustomStatuses.ar.resx
+++ b/Core/Resgrid.Localization/Areas/User/CustomStatuses/CustomStatuses.ar.resx
@@ -282,4 +282,40 @@
   <data name="UnitStatus" xml:space="preserve">
     <value>حالة الوحدة</value>
   </data>
+  <data name="Enroute" xml:space="preserve">
+    <value>في الطريق</value>
+  </data>
+  <data name="Transporting" xml:space="preserve">
+    <value>قيد النقل</value>
+  </data>
+  <data name="Delivering" xml:space="preserve">
+    <value>قيد التسليم</value>
+  </data>
+  <data name="AtPatient" xml:space="preserve">
+    <value>عند المريض</value>
+  </data>
+  <data name="AtHospital" xml:space="preserve">
+    <value>في المستشفى</value>
+  </data>
+  <data name="Searching" xml:space="preserve">
+    <value>قيد البحث</value>
+  </data>
+  <data name="Loading" xml:space="preserve">
+    <value>قيد التحميل</value>
+  </data>
+  <data name="Standby" xml:space="preserve">
+    <value>قيد الاستعداد</value>
+  </data>
+  <data name="OnPatrol" xml:space="preserve">
+    <value>في دورية</value>
+  </data>
+  <data name="Maintenance" xml:space="preserve">
+    <value>صيانة</value>
+  </data>
+  <data name="OnBreak" xml:space="preserve">
+    <value>في استراحة</value>
+  </data>
+  <data name="Completed" xml:space="preserve">
+    <value>مكتمل</value>
+  </data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/CustomStatuses/CustomStatuses.de.resx
+++ b/Core/Resgrid.Localization/Areas/User/CustomStatuses/CustomStatuses.de.resx
@@ -233,4 +233,40 @@
   <data name="UnitStatus" xml:space="preserve">
     <value>Unit Status</value>
   </data>
+  <data name="Enroute" xml:space="preserve">
+    <value>Unterwegs</value>
+  </data>
+  <data name="Transporting" xml:space="preserve">
+    <value>Transportiert</value>
+  </data>
+  <data name="Delivering" xml:space="preserve">
+    <value>Liefert</value>
+  </data>
+  <data name="AtPatient" xml:space="preserve">
+    <value>Beim Patienten</value>
+  </data>
+  <data name="AtHospital" xml:space="preserve">
+    <value>Im Krankenhaus</value>
+  </data>
+  <data name="Searching" xml:space="preserve">
+    <value>Sucht</value>
+  </data>
+  <data name="Loading" xml:space="preserve">
+    <value>Lädt</value>
+  </data>
+  <data name="Standby" xml:space="preserve">
+    <value>Bereitschaft</value>
+  </data>
+  <data name="OnPatrol" xml:space="preserve">
+    <value>Auf Streife</value>
+  </data>
+  <data name="Maintenance" xml:space="preserve">
+    <value>Wartung</value>
+  </data>
+  <data name="OnBreak" xml:space="preserve">
+    <value>Pause</value>
+  </data>
+  <data name="Completed" xml:space="preserve">
+    <value>Abgeschlossen</value>
+  </data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/CustomStatuses/CustomStatuses.en.resx
+++ b/Core/Resgrid.Localization/Areas/User/CustomStatuses/CustomStatuses.en.resx
@@ -282,4 +282,40 @@
   <data name="UnitStatus" xml:space="preserve">
     <value>Unit Status</value>
   </data>
+  <data name="Enroute" xml:space="preserve">
+    <value>En Route</value>
+  </data>
+  <data name="Transporting" xml:space="preserve">
+    <value>Transporting</value>
+  </data>
+  <data name="Delivering" xml:space="preserve">
+    <value>Delivering</value>
+  </data>
+  <data name="AtPatient" xml:space="preserve">
+    <value>At Patient</value>
+  </data>
+  <data name="AtHospital" xml:space="preserve">
+    <value>At Hospital</value>
+  </data>
+  <data name="Searching" xml:space="preserve">
+    <value>Searching</value>
+  </data>
+  <data name="Loading" xml:space="preserve">
+    <value>Loading</value>
+  </data>
+  <data name="Standby" xml:space="preserve">
+    <value>Standby</value>
+  </data>
+  <data name="OnPatrol" xml:space="preserve">
+    <value>On Patrol</value>
+  </data>
+  <data name="Maintenance" xml:space="preserve">
+    <value>Maintenance</value>
+  </data>
+  <data name="OnBreak" xml:space="preserve">
+    <value>On Break</value>
+  </data>
+  <data name="Completed" xml:space="preserve">
+    <value>Completed</value>
+  </data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/CustomStatuses/CustomStatuses.es.resx
+++ b/Core/Resgrid.Localization/Areas/User/CustomStatuses/CustomStatuses.es.resx
@@ -243,4 +243,76 @@
   <data name="UnitStatus" xml:space="preserve">
     <value>Estado de la unidad</value>
   </data>
+  <data name="None" xml:space="preserve">
+    <value>Ninguno</value>
+  </data>
+  <data name="Available" xml:space="preserve">
+    <value>Disponible</value>
+  </data>
+  <data name="NotResponding" xml:space="preserve">
+    <value>No responde</value>
+  </data>
+  <data name="Responding" xml:space="preserve">
+    <value>Respondiendo</value>
+  </data>
+  <data name="OnScene" xml:space="preserve">
+    <value>En el lugar</value>
+  </data>
+  <data name="MadeContact" xml:space="preserve">
+    <value>Contacto establecido</value>
+  </data>
+  <data name="Investigating" xml:space="preserve">
+    <value>Investigando</value>
+  </data>
+  <data name="Dispatched" xml:space="preserve">
+    <value>Despachado</value>
+  </data>
+  <data name="Cleared" xml:space="preserve">
+    <value>Liberado</value>
+  </data>
+  <data name="Returning" xml:space="preserve">
+    <value>Regresando</value>
+  </data>
+  <data name="Staging" xml:space="preserve">
+    <value>En zona de espera</value>
+  </data>
+  <data name="Unavailable" xml:space="preserve">
+    <value>No disponible</value>
+  </data>
+  <data name="Enroute" xml:space="preserve">
+    <value>En ruta</value>
+  </data>
+  <data name="Transporting" xml:space="preserve">
+    <value>Transportando</value>
+  </data>
+  <data name="Delivering" xml:space="preserve">
+    <value>Entregando</value>
+  </data>
+  <data name="AtPatient" xml:space="preserve">
+    <value>Con el paciente</value>
+  </data>
+  <data name="AtHospital" xml:space="preserve">
+    <value>En el hospital</value>
+  </data>
+  <data name="Searching" xml:space="preserve">
+    <value>En búsqueda</value>
+  </data>
+  <data name="Loading" xml:space="preserve">
+    <value>Cargando</value>
+  </data>
+  <data name="Standby" xml:space="preserve">
+    <value>En reserva</value>
+  </data>
+  <data name="OnPatrol" xml:space="preserve">
+    <value>En patrullaje</value>
+  </data>
+  <data name="Maintenance" xml:space="preserve">
+    <value>En mantenimiento</value>
+  </data>
+  <data name="OnBreak" xml:space="preserve">
+    <value>En descanso</value>
+  </data>
+  <data name="Completed" xml:space="preserve">
+    <value>Completado</value>
+  </data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/CustomStatuses/CustomStatuses.fr.resx
+++ b/Core/Resgrid.Localization/Areas/User/CustomStatuses/CustomStatuses.fr.resx
@@ -233,4 +233,40 @@
   <data name="UnitStatus" xml:space="preserve">
     <value>Unit Status</value>
   </data>
+  <data name="Enroute" xml:space="preserve">
+    <value>En route</value>
+  </data>
+  <data name="Transporting" xml:space="preserve">
+    <value>En transport</value>
+  </data>
+  <data name="Delivering" xml:space="preserve">
+    <value>En livraison</value>
+  </data>
+  <data name="AtPatient" xml:space="preserve">
+    <value>Auprès du patient</value>
+  </data>
+  <data name="AtHospital" xml:space="preserve">
+    <value>À l'hôpital</value>
+  </data>
+  <data name="Searching" xml:space="preserve">
+    <value>Recherche en cours</value>
+  </data>
+  <data name="Loading" xml:space="preserve">
+    <value>Chargement</value>
+  </data>
+  <data name="Standby" xml:space="preserve">
+    <value>En attente</value>
+  </data>
+  <data name="OnPatrol" xml:space="preserve">
+    <value>En patrouille</value>
+  </data>
+  <data name="Maintenance" xml:space="preserve">
+    <value>Maintenance</value>
+  </data>
+  <data name="OnBreak" xml:space="preserve">
+    <value>En pause</value>
+  </data>
+  <data name="Completed" xml:space="preserve">
+    <value>Terminé</value>
+  </data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/CustomStatuses/CustomStatuses.it.resx
+++ b/Core/Resgrid.Localization/Areas/User/CustomStatuses/CustomStatuses.it.resx
@@ -233,4 +233,40 @@
   <data name="UnitStatus" xml:space="preserve">
     <value>Unit Status</value>
   </data>
+  <data name="Enroute" xml:space="preserve">
+    <value>In viaggio</value>
+  </data>
+  <data name="Transporting" xml:space="preserve">
+    <value>In trasporto</value>
+  </data>
+  <data name="Delivering" xml:space="preserve">
+    <value>In consegna</value>
+  </data>
+  <data name="AtPatient" xml:space="preserve">
+    <value>Presso il paziente</value>
+  </data>
+  <data name="AtHospital" xml:space="preserve">
+    <value>In ospedale</value>
+  </data>
+  <data name="Searching" xml:space="preserve">
+    <value>In ricerca</value>
+  </data>
+  <data name="Loading" xml:space="preserve">
+    <value>In caricamento</value>
+  </data>
+  <data name="Standby" xml:space="preserve">
+    <value>In attesa</value>
+  </data>
+  <data name="OnPatrol" xml:space="preserve">
+    <value>In pattuglia</value>
+  </data>
+  <data name="Maintenance" xml:space="preserve">
+    <value>Manutenzione</value>
+  </data>
+  <data name="OnBreak" xml:space="preserve">
+    <value>In pausa</value>
+  </data>
+  <data name="Completed" xml:space="preserve">
+    <value>Completato</value>
+  </data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/CustomStatuses/CustomStatuses.pl.resx
+++ b/Core/Resgrid.Localization/Areas/User/CustomStatuses/CustomStatuses.pl.resx
@@ -233,4 +233,40 @@
   <data name="UnitStatus" xml:space="preserve">
     <value>Unit Status</value>
   </data>
+  <data name="Enroute" xml:space="preserve">
+    <value>W drodze</value>
+  </data>
+  <data name="Transporting" xml:space="preserve">
+    <value>W transporcie</value>
+  </data>
+  <data name="Delivering" xml:space="preserve">
+    <value>W dostawie</value>
+  </data>
+  <data name="AtPatient" xml:space="preserve">
+    <value>Przy pacjencie</value>
+  </data>
+  <data name="AtHospital" xml:space="preserve">
+    <value>W szpitalu</value>
+  </data>
+  <data name="Searching" xml:space="preserve">
+    <value>Poszukiwanie</value>
+  </data>
+  <data name="Loading" xml:space="preserve">
+    <value>Załadunek</value>
+  </data>
+  <data name="Standby" xml:space="preserve">
+    <value>W gotowości</value>
+  </data>
+  <data name="OnPatrol" xml:space="preserve">
+    <value>Na patrolu</value>
+  </data>
+  <data name="Maintenance" xml:space="preserve">
+    <value>Konserwacja</value>
+  </data>
+  <data name="OnBreak" xml:space="preserve">
+    <value>Na przerwie</value>
+  </data>
+  <data name="Completed" xml:space="preserve">
+    <value>Zakończono</value>
+  </data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/CustomStatuses/CustomStatuses.sv.resx
+++ b/Core/Resgrid.Localization/Areas/User/CustomStatuses/CustomStatuses.sv.resx
@@ -233,4 +233,40 @@
   <data name="UnitStatus" xml:space="preserve">
     <value>Unit Status</value>
   </data>
+  <data name="Enroute" xml:space="preserve">
+    <value>På väg</value>
+  </data>
+  <data name="Transporting" xml:space="preserve">
+    <value>Transporterar</value>
+  </data>
+  <data name="Delivering" xml:space="preserve">
+    <value>Levererar</value>
+  </data>
+  <data name="AtPatient" xml:space="preserve">
+    <value>Hos patient</value>
+  </data>
+  <data name="AtHospital" xml:space="preserve">
+    <value>På sjukhus</value>
+  </data>
+  <data name="Searching" xml:space="preserve">
+    <value>Söker</value>
+  </data>
+  <data name="Loading" xml:space="preserve">
+    <value>Lastar</value>
+  </data>
+  <data name="Standby" xml:space="preserve">
+    <value>I beredskap</value>
+  </data>
+  <data name="OnPatrol" xml:space="preserve">
+    <value>På patrull</value>
+  </data>
+  <data name="Maintenance" xml:space="preserve">
+    <value>Underhåll</value>
+  </data>
+  <data name="OnBreak" xml:space="preserve">
+    <value>På rast</value>
+  </data>
+  <data name="Completed" xml:space="preserve">
+    <value>Slutförd</value>
+  </data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/CustomStatuses/CustomStatuses.uk.resx
+++ b/Core/Resgrid.Localization/Areas/User/CustomStatuses/CustomStatuses.uk.resx
@@ -233,4 +233,40 @@
   <data name="UnitStatus" xml:space="preserve">
     <value>Unit Status</value>
   </data>
+  <data name="Enroute" xml:space="preserve">
+    <value>У дорозі</value>
+  </data>
+  <data name="Transporting" xml:space="preserve">
+    <value>Транспортування</value>
+  </data>
+  <data name="Delivering" xml:space="preserve">
+    <value>Доставка</value>
+  </data>
+  <data name="AtPatient" xml:space="preserve">
+    <value>Біля пацієнта</value>
+  </data>
+  <data name="AtHospital" xml:space="preserve">
+    <value>У лікарні</value>
+  </data>
+  <data name="Searching" xml:space="preserve">
+    <value>Пошук</value>
+  </data>
+  <data name="Loading" xml:space="preserve">
+    <value>Завантаження</value>
+  </data>
+  <data name="Standby" xml:space="preserve">
+    <value>Очікування</value>
+  </data>
+  <data name="OnPatrol" xml:space="preserve">
+    <value>На патрулюванні</value>
+  </data>
+  <data name="Maintenance" xml:space="preserve">
+    <value>Обслуговування</value>
+  </data>
+  <data name="OnBreak" xml:space="preserve">
+    <value>На перерві</value>
+  </data>
+  <data name="Completed" xml:space="preserve">
+    <value>Завершено</value>
+  </data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Units/Units.ar.resx
+++ b/Core/Resgrid.Localization/Areas/User/Units/Units.ar.resx
@@ -225,4 +225,10 @@
   <data name="YouCanAddType2" xml:space="preserve">
     <value>هنا</value>
   </data>
+  <data name="RequiredPersonnelRoleHeader" xml:space="preserve">
+    <value>دور الموظف المطلوب</value>
+  </data>
+  <data name="RequiredHeader" xml:space="preserve">
+    <value>مطلوب؟</value>
+  </data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Units/Units.de.resx
+++ b/Core/Resgrid.Localization/Areas/User/Units/Units.de.resx
@@ -176,4 +176,10 @@
   <data name="YouCanAddType2" xml:space="preserve">
     <value>here</value>
   </data>
+  <data name="RequiredPersonnelRoleHeader" xml:space="preserve">
+    <value>Erforderliche Personalrolle</value>
+  </data>
+  <data name="RequiredHeader" xml:space="preserve">
+    <value>Erforderlich?</value>
+  </data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Units/Units.en.resx
+++ b/Core/Resgrid.Localization/Areas/User/Units/Units.en.resx
@@ -225,4 +225,10 @@
   <data name="YouCanAddType2" xml:space="preserve">
     <value>here</value>
   </data>
+  <data name="RequiredPersonnelRoleHeader" xml:space="preserve">
+    <value>Required Personnel Role</value>
+  </data>
+  <data name="RequiredHeader" xml:space="preserve">
+    <value>Required?</value>
+  </data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Units/Units.es.resx
+++ b/Core/Resgrid.Localization/Areas/User/Units/Units.es.resx
@@ -222,4 +222,10 @@
   <data name="YouCanAddType2" xml:space="preserve">
     <value>aquí</value>
   </data>
+  <data name="RequiredPersonnelRoleHeader" xml:space="preserve">
+    <value>Rol de personal requerido</value>
+  </data>
+  <data name="RequiredHeader" xml:space="preserve">
+    <value>¿Requerido?</value>
+  </data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Units/Units.fr.resx
+++ b/Core/Resgrid.Localization/Areas/User/Units/Units.fr.resx
@@ -176,4 +176,10 @@
   <data name="YouCanAddType2" xml:space="preserve">
     <value>here</value>
   </data>
+  <data name="RequiredPersonnelRoleHeader" xml:space="preserve">
+    <value>Rôle du personnel requis</value>
+  </data>
+  <data name="RequiredHeader" xml:space="preserve">
+    <value>Requis ?</value>
+  </data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Units/Units.it.resx
+++ b/Core/Resgrid.Localization/Areas/User/Units/Units.it.resx
@@ -176,4 +176,10 @@
   <data name="YouCanAddType2" xml:space="preserve">
     <value>here</value>
   </data>
+  <data name="RequiredPersonnelRoleHeader" xml:space="preserve">
+    <value>Ruolo del personale richiesto</value>
+  </data>
+  <data name="RequiredHeader" xml:space="preserve">
+    <value>Richiesto?</value>
+  </data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Units/Units.pl.resx
+++ b/Core/Resgrid.Localization/Areas/User/Units/Units.pl.resx
@@ -176,4 +176,10 @@
   <data name="YouCanAddType2" xml:space="preserve">
     <value>here</value>
   </data>
+  <data name="RequiredPersonnelRoleHeader" xml:space="preserve">
+    <value>Wymagana rola personelu</value>
+  </data>
+  <data name="RequiredHeader" xml:space="preserve">
+    <value>Wymagane?</value>
+  </data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Units/Units.sv.resx
+++ b/Core/Resgrid.Localization/Areas/User/Units/Units.sv.resx
@@ -176,4 +176,10 @@
   <data name="YouCanAddType2" xml:space="preserve">
     <value>here</value>
   </data>
+  <data name="RequiredPersonnelRoleHeader" xml:space="preserve">
+    <value>Obligatorisk personalroll</value>
+  </data>
+  <data name="RequiredHeader" xml:space="preserve">
+    <value>Krävs?</value>
+  </data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Units/Units.uk.resx
+++ b/Core/Resgrid.Localization/Areas/User/Units/Units.uk.resx
@@ -176,4 +176,10 @@
   <data name="YouCanAddType2" xml:space="preserve">
     <value>here</value>
   </data>
+  <data name="RequiredPersonnelRoleHeader" xml:space="preserve">
+    <value>Необхідна роль персоналу</value>
+  </data>
+  <data name="RequiredHeader" xml:space="preserve">
+    <value>Обов'язково?</value>
+  </data>
 </root>

--- a/Core/Resgrid.Model/ActionBaseTypes.cs
+++ b/Core/Resgrid.Model/ActionBaseTypes.cs
@@ -1,59 +1,215 @@
-﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
 using System.ComponentModel;
 
 namespace Resgrid.Model
 {
 	/// <summary>
-	/// Enumeration of the all the Base System Action Types that a user can perform in the system for both Users and Units
+	/// Canonical, system-level "base type" that a Custom State (Custom Status) option maps to for both
+	/// Personnel and Units. A department can name and color their custom statuses however they like
+	/// (e.g. "Rolling", "Wheels Up", "Bus 12 to Mercy"), but the base type is how Resgrid understands
+	/// what that status actually *means* operationally so it can drive system-level logic such as
+	/// availability/utilization reporting, automations and downstream integrations.
+	///
+	/// The chosen value is stored on <c>CustomStateDetail.BaseType</c> and is resolved to an
+	/// <see cref="Resgrid.Model.Reporting.AvailabilityClass"/> through
+	/// <see cref="Resgrid.Model.Reporting.AvailabilityMatrix.ForCustomBaseType"/>. When you add a value
+	/// here you MUST also classify it in <see cref="Resgrid.Model.Reporting.AvailabilityMatrix"/>,
+	/// otherwise it will be treated as <c>Unknown</c> for availability purposes.
+	///
+	/// The <see cref="DescriptionAttribute"/> on each member is the user-facing explanation surfaced in
+	/// the add/edit Custom Status screens; keep it in sync with the help text shown in the UI. The
+	/// <see cref="DisplayAttribute"/> is the short label used in drop-downs.
 	/// </summary>
 	public enum ActionBaseTypes
 	{
-		[Description("None")]
+		/// <summary>
+		/// No canonical meaning. The custom status is treated as informational/labelling only and does
+		/// not drive availability, utilization or any automated system-level logic.
+		/// </summary>
+		[Description("No system meaning. The status is informational only and does not affect availability, reporting or automations.")]
 		[Display(Name = "None")]
 		None = -1,
 
-		[Description("Available")]
+		/// <summary>
+		/// The resource is in service and available to be assigned or dispatched. Classified as Available.
+		/// </summary>
+		[Description("The unit or responder is in service and available to be assigned or dispatched to a call or task.")]
 		[Display(Name = "Available")]
 		Available = 0,
 
-		[Description("Not Responding")]
+		/// <summary>
+		/// The responder has acknowledged the assignment but is declining or unable to respond.
+		/// Classified as Unavailable.
+		/// </summary>
+		[Description("The responder has acknowledged but is declining or is unable to respond to the current assignment.")]
 		[Display(Name = "Not Responding")]
 		NotResponding = 1,
 
-		[Description("Responding")]
+		/// <summary>
+		/// The resource is actively responding (en route) to an assigned call or incident, typically as
+		/// an emergency response. Classified as Committed.
+		/// </summary>
+		[Description("The unit or responder is actively responding (en route) to an assigned call or incident.")]
 		[Display(Name = "Responding")]
 		Responding = 2,
 
-		[Description("On Scene")]
+		/// <summary>
+		/// The resource has arrived and is operating at the scene of a call or incident. Classified as Committed.
+		/// </summary>
+		[Description("The unit or responder has arrived and is operating at the scene of a call or incident.")]
 		[Display(Name = "On Scene")]
 		OnScene = 3,
 
-		[Description("Made Contact")]
+		/// <summary>
+		/// The resource has made contact with the subject, patient, party or point of interest.
+		/// Classified as Committed.
+		/// </summary>
+		[Description("The unit or responder has made contact with the subject, patient, party or point of interest.")]
 		[Display(Name = "Made Contact")]
 		MadeContact = 4,
 
-		[Description("Investigating")]
+		/// <summary>
+		/// The resource is investigating, assessing or performing size-up of the situation. Classified as Committed.
+		/// </summary>
+		[Description("The unit or responder is investigating, assessing or sizing up the situation.")]
 		[Display(Name = "Investigating")]
 		Investigating = 5,
 
-		[Description("Dispatched")]
+		/// <summary>
+		/// The resource has been dispatched/assigned to a call but has not yet begun responding.
+		/// Classified as Committed.
+		/// </summary>
+		[Description("The unit or responder has been dispatched or assigned but has not yet begun responding.")]
 		[Display(Name = "Dispatched")]
 		Dispatched = 6,
 
-		[Description("Cleared")]
+		/// <summary>
+		/// The resource has cleared the call or incident and is returning to an available state.
+		/// Classified as Available.
+		/// </summary>
+		[Description("The unit or responder has cleared the call or incident and is returning to an available state.")]
 		[Display(Name = "Cleared")]
 		Cleared = 7,
 
-		[Description("Returning")]
+		/// <summary>
+		/// The resource is returning to quarters, station or base. Classified as Committed.
+		/// </summary>
+		[Description("The unit or responder is returning to quarters, station or base.")]
 		[Display(Name = "Returning")]
 		Returning = 8,
 
-		[Description("Staging")]
+		/// <summary>
+		/// The resource is staged at a safe location awaiting assignment or orders. Classified as Committed.
+		/// </summary>
+		[Description("The unit or responder is staged at a safe location awaiting assignment or orders.")]
 		[Display(Name = "Staging")]
 		Staging = 9,
 
-		[Description("Unavailable")]
+		/// <summary>
+		/// The resource is out of service and unavailable for assignment. Classified as Unavailable.
+		/// </summary>
+		[Description("The unit or responder is out of service and unavailable for assignment.")]
 		[Display(Name = "Unavailable")]
-		Unavailable = 10
+		Unavailable = 10,
+
+		/// <summary>
+		/// The resource is traveling to an assignment, destination or location on a routine
+		/// (non-emergency) basis, as opposed to an emergency <see cref="Responding"/>. Classified as Committed.
+		/// Useful for logistics, security, industrial and commodity-delivery operations.
+		/// </summary>
+		[Description("The unit or responder is traveling to an assignment, destination or location on a routine (non-emergency) basis.")]
+		[Display(Name = "En Route")]
+		Enroute = 11,
+
+		/// <summary>
+		/// The resource is actively transporting a patient, subject, prisoner or cargo to a destination.
+		/// Classified as Committed. Covers EMS transport to a hospital, law-enforcement prisoner
+		/// transport, search-and-rescue subject transport and in-transit freight.
+		/// </summary>
+		[Description("The unit or responder is actively transporting a patient, subject, prisoner or cargo to a destination.")]
+		[Display(Name = "Transporting")]
+		Transporting = 12,
+
+		/// <summary>
+		/// The resource is actively delivering goods, supplies, equipment or commodities to a recipient
+		/// or drop-off point. Classified as Committed. Primarily for commodity delivery and logistics.
+		/// </summary>
+		[Description("The unit or responder is actively delivering goods, supplies, equipment or commodities to a recipient or drop-off point.")]
+		[Display(Name = "Delivering")]
+		Delivering = 13,
+
+		/// <summary>
+		/// The resource has reached and is providing care to, or is in contact with, a patient or the
+		/// subject of a search. Classified as Committed. Common in EMS and search-and-rescue operations.
+		/// </summary>
+		[Description("The unit or responder has reached and is providing care to, or is in contact with, a patient or search subject.")]
+		[Display(Name = "At Patient")]
+		AtPatient = 14,
+
+		/// <summary>
+		/// The resource has arrived at a hospital or receiving facility to transfer patient care.
+		/// Classified as Committed. Common in EMS operations.
+		/// </summary>
+		[Description("The unit or responder has arrived at a hospital or receiving facility to transfer patient care.")]
+		[Display(Name = "At Hospital")]
+		AtHospital = 15,
+
+		/// <summary>
+		/// The resource is conducting an active search of an assigned area, sector or grid. Classified as
+		/// Committed. Common in search-and-rescue and law-enforcement operations.
+		/// </summary>
+		[Description("The unit or responder is conducting an active search of an assigned area, sector or grid.")]
+		[Display(Name = "Searching")]
+		Searching = 16,
+
+		/// <summary>
+		/// The resource is loading or picking up cargo, supplies, equipment or a subject prior to
+		/// transport. Classified as Committed. Useful for logistics, industrial and commodity-delivery
+		/// operations.
+		/// </summary>
+		[Description("The unit or responder is loading or picking up cargo, supplies, equipment or a subject prior to transport.")]
+		[Display(Name = "Loading")]
+		Loading = 17,
+
+		/// <summary>
+		/// The resource is held in reserve, on standby or on-call and ready to be assigned. Classified as
+		/// Committed. Common in disaster response and planned-event operations.
+		/// </summary>
+		[Description("The unit or responder is held in reserve, on standby or on-call and ready to be assigned.")]
+		[Display(Name = "Standby")]
+		Standby = 18,
+
+		/// <summary>
+		/// The resource is actively patrolling an assigned area or beat while remaining available for
+		/// dispatch. Classified as Available. Common in security and law-enforcement operations.
+		/// </summary>
+		[Description("The unit or responder is actively patrolling an assigned area or beat while remaining available for dispatch.")]
+		[Display(Name = "On Patrol")]
+		OnPatrol = 19,
+
+		/// <summary>
+		/// The resource is out of service for maintenance, refueling, restocking, cleaning or servicing.
+		/// Classified as Unavailable. Common in industrial management and fleet operations.
+		/// </summary>
+		[Description("The unit or responder is out of service for maintenance, refueling, restocking, cleaning or servicing.")]
+		[Display(Name = "Maintenance")]
+		Maintenance = 20,
+
+		/// <summary>
+		/// The resource is on a rest, meal or crew-rest break and is temporarily unavailable. Classified
+		/// as Delayed (expected to return to service). Common in industrial management and extended operations.
+		/// </summary>
+		[Description("The unit or responder is on a rest, meal or crew-rest break and is temporarily unavailable.")]
+		[Display(Name = "On Break")]
+		OnBreak = 21,
+
+		/// <summary>
+		/// The assignment, task or delivery is complete; the resource is wrapping up and becoming
+		/// available again. Classified as Available. Useful for industrial, logistics and
+		/// commodity-delivery operations.
+		/// </summary>
+		[Description("The assignment, task or delivery is complete; the unit or responder is wrapping up and becoming available.")]
+		[Display(Name = "Completed")]
+		Completed = 22
 	}
 }

--- a/Core/Resgrid.Model/CustomStates/CustomStateTemplate.cs
+++ b/Core/Resgrid.Model/CustomStates/CustomStateTemplate.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Resgrid.Model.CustomStates
+{
+	/// <summary>
+	/// A predefined, code-defined set of custom statuses (a "starter pack") that a department can pick
+	/// from instead of building a set from a blank slate. Templates are defined entirely in code (see
+	/// <see cref="CustomStateTemplateCatalog"/>) and are never stored in the database. When selected, a
+	/// template is projected into a real, unsaved <see cref="CustomState"/> that the user edits (rename
+	/// verbiage, recolor, delete options) and then saves through the normal create pipeline.
+	/// </summary>
+	public class CustomStateTemplate
+	{
+		/// <summary>Stable, unique identifier/slug for the template (e.g. "unit-ems-ambulance").</summary>
+		public string Id { get; set; }
+
+		/// <summary>The kind of custom state this template applies to (Unit, Personnel or Staffing).</summary>
+		public CustomStateTypes Type { get; set; }
+
+		/// <summary>Short, human friendly name (e.g. "EMS / Ambulance").</summary>
+		public string Name { get; set; }
+
+		/// <summary>The discipline/category used for grouping and filtering (e.g. "EMS", "Fire").</summary>
+		public string Category { get; set; }
+
+		/// <summary>A one or two sentence explanation of what the set is for and who should use it.</summary>
+		public string Description { get; set; }
+
+		/// <summary>Extra synonyms/keywords to make the template easier to find via search.</summary>
+		public string[] Keywords { get; set; } = new string[0];
+
+		/// <summary>The ordered buttons/options that make up the set.</summary>
+		public List<CustomStateTemplateDetail> Details { get; set; } = new List<CustomStateTemplateDetail>();
+
+		/// <summary>Number of buttons/options in the set.</summary>
+		public int ButtonCount => Details?.Count ?? 0;
+
+		/// <summary>
+		/// A single lowercased blob of all searchable text (name, category, description, keywords and
+		/// every button label). Used to power client-side search/filtering in the template gallery.
+		/// </summary>
+		public string SearchText
+		{
+			get
+			{
+				var parts = new List<string> { Name, Category, Description };
+
+				if (Keywords != null)
+					parts.AddRange(Keywords);
+
+				if (Details != null)
+					parts.AddRange(Details.Select(d => d.ButtonText));
+
+				return string.Join(" ", parts.Where(p => !string.IsNullOrWhiteSpace(p))).ToLowerInvariant();
+			}
+		}
+	}
+}

--- a/Core/Resgrid.Model/CustomStates/CustomStateTemplate.cs
+++ b/Core/Resgrid.Model/CustomStates/CustomStateTemplate.cs
@@ -28,10 +28,10 @@ namespace Resgrid.Model.CustomStates
 		public string Description { get; set; }
 
 		/// <summary>Extra synonyms/keywords to make the template easier to find via search.</summary>
-		public string[] Keywords { get; set; } = new string[0];
+		public IReadOnlyList<string> Keywords { get; init; } = new string[0];
 
 		/// <summary>The ordered buttons/options that make up the set.</summary>
-		public List<CustomStateTemplateDetail> Details { get; set; } = new List<CustomStateTemplateDetail>();
+		public IReadOnlyList<CustomStateTemplateDetail> Details { get; init; } = new List<CustomStateTemplateDetail>();
 
 		/// <summary>Number of buttons/options in the set.</summary>
 		public int ButtonCount => Details?.Count ?? 0;

--- a/Core/Resgrid.Model/CustomStates/CustomStateTemplateCatalog.cs
+++ b/Core/Resgrid.Model/CustomStates/CustomStateTemplateCatalog.cs
@@ -1,0 +1,500 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Resgrid.Model.CustomStates
+{
+	/// <summary>
+	/// The code-defined catalog of predefined custom-state templates ("starter packs") that departments
+	/// can pick from when setting up Unit, Personnel or Staffing custom statuses. Everything here lives in
+	/// code (NOT the database) by design, mirroring the pattern used by other static reference data such
+	/// as <see cref="Resgrid.Model.Reporting.AvailabilityMatrix"/>.
+	///
+	/// To add a template, add it to the relevant builder below. Each template projects into an unsaved
+	/// <see cref="CustomState"/> the user can edit before saving, so button text/colors are just sensible
+	/// starting points. Base types come from <see cref="ActionBaseTypes"/> so the platform understands
+	/// what each status means operationally.
+	/// </summary>
+	public static class CustomStateTemplateCatalog
+	{
+		#region Palette
+
+		// A small, consistent palette so templates look good out of the box. Backgrounds pair with a
+		// readable text color (white on dark, black on light).
+		private const string Green = "#5CB85C";     // available / in service
+		private const string DarkGreen = "#449D44"; // cleared / completed / at hospital
+		private const string Blue = "#428BCA";      // dispatched / en route / returning
+		private const string Orange = "#F0AD4E";    // responding (light -> black text)
+		private const string Red = "#D9534F";       // on scene / deployed
+		private const string DarkRed = "#C9302C";   // not responding / recall
+		private const string Purple = "#8E44AD";    // transporting
+		private const string Teal = "#17A2B8";      // patient contact / delivering
+		private const string Indigo = "#6F42C1";    // investigating / searching
+		private const string Yellow = "#FFC107";    // staging / partial (light -> black text)
+		private const string Cyan = "#5BC0DE";      // loading / standby (light -> black text)
+		private const string Slate = "#34495E";     // on patrol
+		private const string Brown = "#8A6D3B";     // maintenance
+		private const string Gray = "#777777";      // unavailable / out of service
+		private const string LightGray = "#ADADAD"; // on break (light -> black text)
+		private const string White = "#FFFFFF";
+		private const string Black = "#000000";
+
+		#endregion Palette
+
+		/// <summary>All templates across every type, in display order.</summary>
+		public static IReadOnlyList<CustomStateTemplate> All { get; } = BuildAll();
+
+		/// <summary>Returns the templates for a given custom state type (Unit, Personnel or Staffing).</summary>
+		public static IReadOnlyList<CustomStateTemplate> GetByType(CustomStateTypes type)
+		{
+			return All.Where(t => t.Type == type).ToList();
+		}
+
+		/// <summary>Returns a single template by its stable id, or null if it does not exist.</summary>
+		public static CustomStateTemplate GetById(string id)
+		{
+			if (string.IsNullOrWhiteSpace(id))
+				return null;
+
+			return All.FirstOrDefault(t => string.Equals(t.Id, id, StringComparison.OrdinalIgnoreCase));
+		}
+
+		/// <summary>
+		/// Returns templates filtered by type and an optional free-text query (matched against the name,
+		/// category, description, keywords and button labels). Provided for server-side/API use; the
+		/// gallery UI also filters client-side for instant results.
+		/// </summary>
+		public static IReadOnlyList<CustomStateTemplate> Search(CustomStateTypes type, string query)
+		{
+			var results = All.Where(t => t.Type == type);
+
+			if (!string.IsNullOrWhiteSpace(query))
+			{
+				var terms = query.ToLowerInvariant().Split(new[] { ' ', ',' }, StringSplitOptions.RemoveEmptyEntries);
+				results = results.Where(t => terms.All(term => t.SearchText.Contains(term)));
+			}
+
+			return results.ToList();
+		}
+
+		#region Builders
+
+		private static IReadOnlyList<CustomStateTemplate> BuildAll()
+		{
+			var templates = new List<CustomStateTemplate>();
+			templates.AddRange(BuildUnitTemplates());
+			templates.AddRange(BuildPersonnelTemplates());
+			templates.AddRange(BuildStaffingTemplates());
+			return templates;
+		}
+
+		private static IReadOnlyList<CustomStateTemplate> BuildUnitTemplates()
+		{
+			return new List<CustomStateTemplate>
+			{
+				new CustomStateTemplate
+				{
+					Id = "unit-ems-ambulance",
+					Type = CustomStateTypes.Unit,
+					Name = "EMS / Ambulance",
+					Category = "EMS",
+					Description = "Patient-transport lifecycle for ambulances and medic units: dispatch, response, patient care, transport to hospital and return to service.",
+					Keywords = new[] { "ambulance", "medic", "paramedic", "als", "bls", "medical", "rescue" },
+					Details = new List<CustomStateTemplateDetail>
+					{
+						D(0, "Available", ActionBaseTypes.Available, Green),
+						D(1, "Dispatched", ActionBaseTypes.Dispatched, Blue),
+						D(2, "Responding", ActionBaseTypes.Responding, Orange, Black, gps: true),
+						D(3, "On Scene", ActionBaseTypes.OnScene, Red, gps: true),
+						D(4, "At Patient", ActionBaseTypes.AtPatient, Teal, gps: true),
+						D(5, "Transporting", ActionBaseTypes.Transporting, Purple, gps: true, note: CustomStateNoteTypes.Optional),
+						D(6, "At Hospital", ActionBaseTypes.AtHospital, DarkGreen, gps: true),
+						D(7, "Returning", ActionBaseTypes.Returning, Blue, gps: true),
+						D(8, "Out of Service", ActionBaseTypes.Unavailable, Gray, note: CustomStateNoteTypes.Optional)
+					}
+				},
+				new CustomStateTemplate
+				{
+					Id = "unit-fire-engine",
+					Type = CustomStateTypes.Unit,
+					Name = "Fire Apparatus / Engine",
+					Category = "Fire",
+					Description = "Fire apparatus response cycle: dispatch, response, on scene, staging and return to quarters.",
+					Keywords = new[] { "engine", "truck", "ladder", "apparatus", "rescue", "brush", "tanker" },
+					Details = new List<CustomStateTemplateDetail>
+					{
+						D(0, "Available", ActionBaseTypes.Available, Green),
+						D(1, "Dispatched", ActionBaseTypes.Dispatched, Blue),
+						D(2, "Responding", ActionBaseTypes.Responding, Orange, Black, gps: true),
+						D(3, "On Scene", ActionBaseTypes.OnScene, Red, gps: true),
+						D(4, "Staging", ActionBaseTypes.Staging, Yellow, Black, gps: true),
+						D(5, "Returning", ActionBaseTypes.Returning, Blue, gps: true),
+						D(6, "Out of Service", ActionBaseTypes.Unavailable, Gray, note: CustomStateNoteTypes.Optional)
+					}
+				},
+				new CustomStateTemplate
+				{
+					Id = "unit-law-enforcement",
+					Type = CustomStateTypes.Unit,
+					Name = "Law Enforcement",
+					Category = "Law Enforcement",
+					Description = "Patrol and response cycle for law-enforcement units, including patrol, investigation, subject contact and prisoner transport.",
+					Keywords = new[] { "police", "sheriff", "patrol", "officer", "deputy", "cruiser", "prisoner" },
+					Details = new List<CustomStateTemplateDetail>
+					{
+						D(0, "Available", ActionBaseTypes.Available, Green),
+						D(1, "On Patrol", ActionBaseTypes.OnPatrol, Slate, gps: true),
+						D(2, "Dispatched", ActionBaseTypes.Dispatched, Blue),
+						D(3, "En Route", ActionBaseTypes.Enroute, Orange, Black, gps: true),
+						D(4, "On Scene", ActionBaseTypes.OnScene, Red, gps: true),
+						D(5, "Investigating", ActionBaseTypes.Investigating, Indigo, gps: true),
+						D(6, "Made Contact", ActionBaseTypes.MadeContact, Teal, gps: true),
+						D(7, "Transporting", ActionBaseTypes.Transporting, Purple, gps: true, note: CustomStateNoteTypes.Optional),
+						D(8, "Out of Service", ActionBaseTypes.Unavailable, Gray, note: CustomStateNoteTypes.Optional)
+					}
+				},
+				new CustomStateTemplate
+				{
+					Id = "unit-sar",
+					Type = CustomStateTypes.Unit,
+					Name = "Search & Rescue",
+					Category = "Search and Rescue",
+					Description = "Field team lifecycle for search-and-rescue units: response, staging, active search, subject contact and transport.",
+					Keywords = new[] { "sar", "search", "rescue", "team", "ground", "wilderness", "subject" },
+					Details = new List<CustomStateTemplateDetail>
+					{
+						D(0, "Available", ActionBaseTypes.Available, Green),
+						D(1, "Responding", ActionBaseTypes.Responding, Orange, Black, gps: true),
+						D(2, "Staging", ActionBaseTypes.Staging, Yellow, Black, gps: true),
+						D(3, "Searching", ActionBaseTypes.Searching, Indigo, gps: true),
+						D(4, "Subject Contact", ActionBaseTypes.MadeContact, Teal, gps: true),
+						D(5, "Transporting", ActionBaseTypes.Transporting, Purple, gps: true, note: CustomStateNoteTypes.Optional),
+						D(6, "Returning", ActionBaseTypes.Returning, Blue, gps: true),
+						D(7, "Out of Service", ActionBaseTypes.Unavailable, Gray)
+					}
+				},
+				new CustomStateTemplate
+				{
+					Id = "unit-emergency-response",
+					Type = CustomStateTypes.Unit,
+					Name = "Emergency Response (General)",
+					Category = "Emergency Response",
+					Description = "A general-purpose response cycle suitable for most emergency-response units when a discipline-specific set is not needed.",
+					Keywords = new[] { "general", "response", "generic", "standard", "basic" },
+					Details = new List<CustomStateTemplateDetail>
+					{
+						D(0, "Available", ActionBaseTypes.Available, Green),
+						D(1, "Dispatched", ActionBaseTypes.Dispatched, Blue),
+						D(2, "Responding", ActionBaseTypes.Responding, Orange, Black, gps: true),
+						D(3, "On Scene", ActionBaseTypes.OnScene, Red, gps: true),
+						D(4, "Staging", ActionBaseTypes.Staging, Yellow, Black, gps: true),
+						D(5, "Cleared", ActionBaseTypes.Cleared, DarkGreen),
+						D(6, "Out of Service", ActionBaseTypes.Unavailable, Gray)
+					}
+				},
+				new CustomStateTemplate
+				{
+					Id = "unit-disaster-response",
+					Type = CustomStateTypes.Unit,
+					Name = "Disaster Response",
+					Category = "Disaster Response",
+					Description = "Deployment cycle for disaster and large-scale incident resources: mobilizing, staging, standby, deployment and demobilization.",
+					Keywords = new[] { "disaster", "deployment", "mobilize", "task force", "ems", "fema", "strike team" },
+					Details = new List<CustomStateTemplateDetail>
+					{
+						D(0, "Available", ActionBaseTypes.Available, Green),
+						D(1, "Mobilizing", ActionBaseTypes.Enroute, Blue, gps: true),
+						D(2, "Staging", ActionBaseTypes.Staging, Yellow, Black, gps: true),
+						D(3, "Standby", ActionBaseTypes.Standby, Cyan, Black),
+						D(4, "Deployed", ActionBaseTypes.OnScene, Red, gps: true),
+						D(5, "Returning", ActionBaseTypes.Returning, Blue, gps: true),
+						D(6, "Out of Service", ActionBaseTypes.Unavailable, Gray)
+					}
+				},
+				new CustomStateTemplate
+				{
+					Id = "unit-security",
+					Type = CustomStateTypes.Unit,
+					Name = "Security",
+					Category = "Security",
+					Description = "Patrol and response cycle for security units and mobile patrols, including investigation and contact.",
+					Keywords = new[] { "guard", "patrol", "site", "facility", "campus", "officer" },
+					Details = new List<CustomStateTemplateDetail>
+					{
+						D(0, "In Service", ActionBaseTypes.Available, Green),
+						D(1, "On Patrol", ActionBaseTypes.OnPatrol, Slate, gps: true),
+						D(2, "Responding", ActionBaseTypes.Responding, Orange, Black, gps: true),
+						D(3, "On Scene", ActionBaseTypes.OnScene, Red, gps: true),
+						D(4, "Investigating", ActionBaseTypes.Investigating, Indigo, gps: true),
+						D(5, "Made Contact", ActionBaseTypes.MadeContact, Teal, gps: true),
+						D(6, "Out of Service", ActionBaseTypes.Unavailable, Gray, note: CustomStateNoteTypes.Optional)
+					}
+				},
+				new CustomStateTemplate
+				{
+					Id = "unit-industrial-fleet",
+					Type = CustomStateTypes.Unit,
+					Name = "Industrial / Fleet",
+					Category = "Industrial Management",
+					Description = "Work and availability cycle for industrial vehicles, plant equipment and fleet assets, including loading, breaks and maintenance.",
+					Keywords = new[] { "fleet", "vehicle", "equipment", "plant", "asset", "operator", "utility" },
+					Details = new List<CustomStateTemplateDetail>
+					{
+						D(0, "Available", ActionBaseTypes.Available, Green),
+						D(1, "En Route", ActionBaseTypes.Enroute, Blue, gps: true),
+						D(2, "On Site", ActionBaseTypes.OnScene, Red, gps: true),
+						D(3, "Loading", ActionBaseTypes.Loading, Cyan, Black, gps: true),
+						D(4, "On Break", ActionBaseTypes.OnBreak, LightGray, Black),
+						D(5, "Maintenance", ActionBaseTypes.Maintenance, Brown, note: CustomStateNoteTypes.Optional),
+						D(6, "Out of Service", ActionBaseTypes.Unavailable, Gray, note: CustomStateNoteTypes.Optional)
+					}
+				},
+				new CustomStateTemplate
+				{
+					Id = "unit-commodity-delivery",
+					Type = CustomStateTypes.Unit,
+					Name = "Commodity Delivery / Logistics",
+					Category = "Commodity Delivery",
+					Description = "End-to-end delivery cycle for logistics and commodity-delivery vehicles: loading, transit, delivery and return.",
+					Keywords = new[] { "delivery", "logistics", "freight", "cargo", "supply", "transport", "courier", "goods" },
+					Details = new List<CustomStateTemplateDetail>
+					{
+						D(0, "Available", ActionBaseTypes.Available, Green),
+						D(1, "Loading", ActionBaseTypes.Loading, Cyan, Black, gps: true),
+						D(2, "En Route", ActionBaseTypes.Enroute, Blue, gps: true),
+						D(3, "Transporting", ActionBaseTypes.Transporting, Purple, gps: true),
+						D(4, "Delivering", ActionBaseTypes.Delivering, Teal, gps: true, note: CustomStateNoteTypes.Optional),
+						D(5, "Delivered", ActionBaseTypes.Completed, DarkGreen),
+						D(6, "Returning", ActionBaseTypes.Returning, Blue, gps: true),
+						D(7, "Out of Service", ActionBaseTypes.Unavailable, Gray)
+					}
+				}
+			};
+		}
+
+		private static IReadOnlyList<CustomStateTemplate> BuildPersonnelTemplates()
+		{
+			return new List<CustomStateTemplate>
+			{
+				new CustomStateTemplate
+				{
+					Id = "personnel-firefighter",
+					Type = CustomStateTypes.Personnel,
+					Name = "Firefighter",
+					Category = "Fire",
+					Description = "Actions a firefighter taps to signal their response, including responding to the station or directly to the scene.",
+					Keywords = new[] { "fire", "ff", "responder", "station", "scene" },
+					Details = new List<CustomStateTemplateDetail>
+					{
+						D(0, "Responding", ActionBaseTypes.Responding, Orange, Black, gps: true),
+						D(1, "Responding to Station", ActionBaseTypes.Responding, Blue, gps: true),
+						D(2, "On Scene", ActionBaseTypes.OnScene, Red, gps: true),
+						D(3, "Available", ActionBaseTypes.Available, Green),
+						D(4, "Not Responding", ActionBaseTypes.NotResponding, DarkRed, note: CustomStateNoteTypes.Optional),
+						D(5, "Unavailable", ActionBaseTypes.Unavailable, Gray)
+					}
+				},
+				new CustomStateTemplate
+				{
+					Id = "personnel-ems",
+					Type = CustomStateTypes.Personnel,
+					Name = "EMS Responder",
+					Category = "EMS",
+					Description = "Actions an EMS provider taps through a patient-care and transport call.",
+					Keywords = new[] { "medic", "paramedic", "emt", "ambulance", "medical" },
+					Details = new List<CustomStateTemplateDetail>
+					{
+						D(0, "Available", ActionBaseTypes.Available, Green),
+						D(1, "Responding", ActionBaseTypes.Responding, Orange, Black, gps: true),
+						D(2, "On Scene", ActionBaseTypes.OnScene, Red, gps: true),
+						D(3, "At Patient", ActionBaseTypes.AtPatient, Teal, gps: true),
+						D(4, "Transporting", ActionBaseTypes.Transporting, Purple, gps: true),
+						D(5, "Unavailable", ActionBaseTypes.Unavailable, Gray)
+					}
+				},
+				new CustomStateTemplate
+				{
+					Id = "personnel-law-enforcement",
+					Type = CustomStateTypes.Personnel,
+					Name = "Law Enforcement Officer",
+					Category = "Law Enforcement",
+					Description = "Actions an officer taps while on patrol and responding to calls.",
+					Keywords = new[] { "police", "deputy", "officer", "patrol", "sheriff" },
+					Details = new List<CustomStateTemplateDetail>
+					{
+						D(0, "Available", ActionBaseTypes.Available, Green),
+						D(1, "On Patrol", ActionBaseTypes.OnPatrol, Slate, gps: true),
+						D(2, "En Route", ActionBaseTypes.Enroute, Orange, Black, gps: true),
+						D(3, "On Scene", ActionBaseTypes.OnScene, Red, gps: true),
+						D(4, "Investigating", ActionBaseTypes.Investigating, Indigo, gps: true),
+						D(5, "Off Duty", ActionBaseTypes.Unavailable, Gray)
+					}
+				},
+				new CustomStateTemplate
+				{
+					Id = "personnel-sar",
+					Type = CustomStateTypes.Personnel,
+					Name = "Search & Rescue Member",
+					Category = "Search and Rescue",
+					Description = "Actions a search-and-rescue team member taps through a callout and active search.",
+					Keywords = new[] { "sar", "search", "rescue", "team", "ground" },
+					Details = new List<CustomStateTemplateDetail>
+					{
+						D(0, "Available", ActionBaseTypes.Available, Green),
+						D(1, "Responding", ActionBaseTypes.Responding, Orange, Black, gps: true),
+						D(2, "Staging", ActionBaseTypes.Staging, Yellow, Black, gps: true),
+						D(3, "Searching", ActionBaseTypes.Searching, Indigo, gps: true),
+						D(4, "Made Contact", ActionBaseTypes.MadeContact, Teal, gps: true),
+						D(5, "Unavailable", ActionBaseTypes.Unavailable, Gray)
+					}
+				},
+				new CustomStateTemplate
+				{
+					Id = "personnel-volunteer",
+					Type = CustomStateTypes.Personnel,
+					Name = "Volunteer Responder",
+					Category = "Emergency Response",
+					Description = "A simple response set for volunteers who respond either to the station or directly to the scene.",
+					Keywords = new[] { "volunteer", "pov", "station", "scene", "poc" },
+					Details = new List<CustomStateTemplateDetail>
+					{
+						D(0, "Responding to Scene", ActionBaseTypes.Responding, Orange, Black, gps: true),
+						D(1, "Responding to Station", ActionBaseTypes.Responding, Blue, gps: true),
+						D(2, "Available", ActionBaseTypes.Available, Green),
+						D(3, "Not Responding", ActionBaseTypes.NotResponding, DarkRed, note: CustomStateNoteTypes.Optional),
+						D(4, "Unavailable", ActionBaseTypes.Unavailable, Gray)
+					}
+				},
+				new CustomStateTemplate
+				{
+					Id = "personnel-security",
+					Type = CustomStateTypes.Personnel,
+					Name = "Security Officer",
+					Category = "Security",
+					Description = "Shift and patrol actions for a security officer, including patrol, response and breaks.",
+					Keywords = new[] { "guard", "patrol", "shift", "site", "officer" },
+					Details = new List<CustomStateTemplateDetail>
+					{
+						D(0, "On Duty", ActionBaseTypes.Available, Green),
+						D(1, "On Patrol", ActionBaseTypes.OnPatrol, Slate, gps: true),
+						D(2, "Responding", ActionBaseTypes.Responding, Orange, Black, gps: true),
+						D(3, "On Break", ActionBaseTypes.OnBreak, LightGray, Black),
+						D(4, "Off Duty", ActionBaseTypes.Unavailable, Gray)
+					}
+				},
+				new CustomStateTemplate
+				{
+					Id = "personnel-industrial",
+					Type = CustomStateTypes.Personnel,
+					Name = "Industrial Worker",
+					Category = "Industrial Management",
+					Description = "Shift and task actions for plant, utility and industrial workers, including tasks, breaks and maintenance.",
+					Keywords = new[] { "worker", "operator", "plant", "shift", "crew", "utility" },
+					Details = new List<CustomStateTemplateDetail>
+					{
+						D(0, "On Shift", ActionBaseTypes.Available, Green),
+						D(1, "On Task", ActionBaseTypes.OnScene, Orange, Black, gps: true),
+						D(2, "On Break", ActionBaseTypes.OnBreak, LightGray, Black),
+						D(3, "Maintenance", ActionBaseTypes.Maintenance, Brown),
+						D(4, "Off Shift", ActionBaseTypes.Unavailable, Gray)
+					}
+				}
+			};
+		}
+
+		private static IReadOnlyList<CustomStateTemplate> BuildStaffingTemplates()
+		{
+			// Personnel "staffing" is an INDIVIDUAL person's availability/staffing status (e.g. "I'm
+			// available for calls" or "I'm away") -- NOT the group/crew staffing of a unit (that is computed
+			// from unit roles, see UnitRoleStaffingResult). These are personal availability sets, so they do
+			// not carry an operational base type, GPS or call/station detail association.
+			return new List<CustomStateTemplate>
+			{
+				new CustomStateTemplate
+				{
+					Id = "staffing-standard",
+					Type = CustomStateTypes.Staffing,
+					Name = "Standard Availability",
+					Category = "General",
+					Description = "A simple personal availability set: whether you are available to be assigned to calls or not.",
+					Keywords = new[] { "general", "standard", "available", "availability", "basic" },
+					Details = new List<CustomStateTemplateDetail>
+					{
+						D(0, "Available", ActionBaseTypes.None, Green),
+						D(1, "Delayed", ActionBaseTypes.None, Yellow, Black),
+						D(2, "Unavailable", ActionBaseTypes.None, Gray)
+					}
+				},
+				new CustomStateTemplate
+				{
+					Id = "staffing-detailed",
+					Type = CustomStateTypes.Staffing,
+					Name = "Detailed Availability",
+					Category = "General",
+					Description = "A more granular personal availability set for members who want to signal delayed, committed or away in addition to available.",
+					Keywords = new[] { "detailed", "available", "committed", "delayed", "away", "availability" },
+					Details = new List<CustomStateTemplateDetail>
+					{
+						D(0, "Available", ActionBaseTypes.None, Green),
+						D(1, "Delayed", ActionBaseTypes.None, Yellow, Black),
+						D(2, "Committed", ActionBaseTypes.None, Orange, Black),
+						D(3, "Away", ActionBaseTypes.None, LightGray, Black),
+						D(4, "Unavailable", ActionBaseTypes.None, Gray)
+					}
+				},
+				new CustomStateTemplate
+				{
+					Id = "staffing-duty",
+					Type = CustomStateTypes.Staffing,
+					Name = "On / Off Duty",
+					Category = "Security",
+					Description = "A shift-oriented personal availability set for members who work scheduled duty, including on-call and breaks.",
+					Keywords = new[] { "duty", "shift", "on call", "off duty", "break", "security", "industrial" },
+					Details = new List<CustomStateTemplateDetail>
+					{
+						D(0, "On Duty", ActionBaseTypes.None, Green),
+						D(1, "On Call", ActionBaseTypes.None, Blue),
+						D(2, "On Break", ActionBaseTypes.None, LightGray, Black),
+						D(3, "Off Duty", ActionBaseTypes.None, Gray)
+					}
+				},
+				new CustomStateTemplate
+				{
+					Id = "staffing-volunteer",
+					Type = CustomStateTypes.Staffing,
+					Name = "Volunteer Availability",
+					Category = "Emergency Response",
+					Description = "A personal availability set for volunteer members to indicate whether they can take calls right now.",
+					Keywords = new[] { "volunteer", "available", "committed", "not available", "availability" },
+					Details = new List<CustomStateTemplateDetail>
+					{
+						D(0, "Available", ActionBaseTypes.None, Green),
+						D(1, "Delayed", ActionBaseTypes.None, Yellow, Black),
+						D(2, "Committed", ActionBaseTypes.None, Orange, Black),
+						D(3, "Not Available", ActionBaseTypes.None, Gray)
+					}
+				}
+			};
+		}
+
+		/// <summary>Compact factory for a template button with sensible defaults.</summary>
+		private static CustomStateTemplateDetail D(int order, string text, ActionBaseTypes baseType, string bg,
+			string fg = White, bool gps = false, CustomStateNoteTypes note = CustomStateNoteTypes.None,
+			CustomStateDetailTypes detail = CustomStateDetailTypes.None)
+		{
+			return new CustomStateTemplateDetail
+			{
+				Order = order,
+				ButtonText = text,
+				BaseType = baseType,
+				ButtonColor = bg,
+				TextColor = fg,
+				GpsRequired = gps,
+				NoteType = note,
+				DetailType = detail
+			};
+		}
+
+		#endregion Builders
+	}
+}

--- a/Core/Resgrid.Model/CustomStates/CustomStateTemplateDetail.cs
+++ b/Core/Resgrid.Model/CustomStates/CustomStateTemplateDetail.cs
@@ -1,0 +1,62 @@
+namespace Resgrid.Model.CustomStates
+{
+	/// <summary>
+	/// A single predefined button/option within a <see cref="CustomStateTemplate"/>. This is a pure
+	/// code-defined shape (never persisted). When a user picks a template it is projected into a real
+	/// <see cref="CustomStateDetail"/> that the user can then rename, recolor, reorder or delete before
+	/// saving to their department.
+	/// </summary>
+	public class CustomStateTemplateDetail
+	{
+		/// <summary>Display order of the button within the set (0 based).</summary>
+		public int Order { get; set; }
+
+		/// <summary>The text shown inside the button (e.g. "Responding", "Transporting").</summary>
+		public string ButtonText { get; set; }
+
+		/// <summary>Background color of the button as a hex string (e.g. "#5CB85C").</summary>
+		public string ButtonColor { get; set; }
+
+		/// <summary>Text color of the button as a hex string (e.g. "#FFFFFF").</summary>
+		public string TextColor { get; set; }
+
+		/// <summary>
+		/// The canonical system meaning of the status (drives availability/reporting/automations).
+		/// See <see cref="ActionBaseTypes"/>.
+		/// </summary>
+		public ActionBaseTypes BaseType { get; set; } = ActionBaseTypes.None;
+
+		/// <summary>Whether pressing the button prompts for / captures a note.</summary>
+		public CustomStateNoteTypes NoteType { get; set; } = CustomStateNoteTypes.None;
+
+		/// <summary>Whether the status can be associated with a Call, Station and/or POI.</summary>
+		public CustomStateDetailTypes DetailType { get; set; } = CustomStateDetailTypes.None;
+
+		/// <summary>Whether pressing the button requires/captures the device GPS location.</summary>
+		public bool GpsRequired { get; set; }
+
+		/// <summary>Optional time-to-live (minutes) for the status; 0 means none.</summary>
+		public int Ttl { get; set; }
+
+		/// <summary>
+		/// Projects this template button into a real, unsaved <see cref="CustomStateDetail"/> entity so
+		/// it can be edited and then persisted through the normal create pipeline.
+		/// </summary>
+		public CustomStateDetail ToCustomStateDetail()
+		{
+			return new CustomStateDetail
+			{
+				ButtonText = ButtonText,
+				ButtonColor = ButtonColor,
+				TextColor = TextColor,
+				BaseType = (int)BaseType,
+				NoteType = (int)NoteType,
+				DetailType = (int)DetailType,
+				GpsRequired = GpsRequired,
+				Order = Order,
+				TTL = Ttl,
+				IsDeleted = false
+			};
+		}
+	}
+}

--- a/Core/Resgrid.Model/Reporting/AvailabilityMatrix.cs
+++ b/Core/Resgrid.Model/Reporting/AvailabilityMatrix.cs
@@ -46,6 +46,18 @@ namespace Resgrid.Model.Reporting
 			{ (int)ActionBaseTypes.Returning,     AvailabilityClass.Committed },
 			{ (int)ActionBaseTypes.Staging,       AvailabilityClass.Committed },
 			{ (int)ActionBaseTypes.Unavailable,   AvailabilityClass.Unavailable },
+			{ (int)ActionBaseTypes.Enroute,       AvailabilityClass.Committed },
+			{ (int)ActionBaseTypes.Transporting,  AvailabilityClass.Committed },
+			{ (int)ActionBaseTypes.Delivering,    AvailabilityClass.Committed },
+			{ (int)ActionBaseTypes.AtPatient,     AvailabilityClass.Committed },
+			{ (int)ActionBaseTypes.AtHospital,    AvailabilityClass.Committed },
+			{ (int)ActionBaseTypes.Searching,     AvailabilityClass.Committed },
+			{ (int)ActionBaseTypes.Loading,       AvailabilityClass.Committed },
+			{ (int)ActionBaseTypes.Standby,       AvailabilityClass.Committed },
+			{ (int)ActionBaseTypes.OnPatrol,      AvailabilityClass.Available },
+			{ (int)ActionBaseTypes.Maintenance,   AvailabilityClass.Unavailable },
+			{ (int)ActionBaseTypes.OnBreak,       AvailabilityClass.Delayed },
+			{ (int)ActionBaseTypes.Completed,     AvailabilityClass.Available },
 		};
 
 		// Built-in personnel status (ActionTypes) -> availability.

--- a/Core/Resgrid.Model/Repositories/IUnitRolesRepository.cs
+++ b/Core/Resgrid.Model/Repositories/IUnitRolesRepository.cs
@@ -16,5 +16,12 @@ namespace Resgrid.Model.Repositories
 		/// <param name="unitId">The unit identifier.</param>
 		/// <returns>Task&lt;IEnumerable&lt;UnitRole&gt;&gt;.</returns>
 		Task<IEnumerable<UnitRole>> GetAllRolesByUnitIdAsync(int unitId);
+
+		/// <summary>
+		/// Gets all unit roles for every unit in a department in a single query.
+		/// </summary>
+		/// <param name="departmentId">The department identifier.</param>
+		/// <returns>Task&lt;IEnumerable&lt;UnitRole&gt;&gt;.</returns>
+		Task<IEnumerable<UnitRole>> GetAllRolesByDepartmentIdAsync(int departmentId);
 	}
 }

--- a/Core/Resgrid.Model/Services/IUnitsService.cs
+++ b/Core/Resgrid.Model/Services/IUnitsService.cs
@@ -329,6 +329,23 @@ namespace Resgrid.Model.Services
 
 		Task<List<UnitActiveRole>> GetAllActiveRolesForUnitsByDepartmentIdAsync(int departmentId);
 
+		/// <summary>
+		/// Determines whether the user holds the personnel role (qualification) required by the given
+		/// unit role. Returns true when the role has no qualification requirement.
+		/// </summary>
+		Task<bool> IsUserQualifiedForUnitRoleAsync(UnitRole role, string userId, int departmentId);
+
+		/// <summary>
+		/// Computes the staffing level of a unit from its defined roles, current assignments and any
+		/// required personnel qualifications.
+		/// </summary>
+		Task<UnitRoleStaffingResult> GetUnitStaffingAsync(int unitId);
+
+		/// <summary>
+		/// Computes the staffing level for every unit in a department, keyed by unit id.
+		/// </summary>
+		Task<Dictionary<int, UnitRoleStaffingResult>> GetUnitStaffingForDepartmentAsync(int departmentId);
+
 		Task<List<UnitsLocation>> GetLatestUnitLocationsAsync(int departmentId);
 	}
 }

--- a/Core/Resgrid.Model/Services/IUnitsService.cs
+++ b/Core/Resgrid.Model/Services/IUnitsService.cs
@@ -210,6 +210,13 @@ namespace Resgrid.Model.Services
 		Task<UnitRole> GetRoleByIdAsync(int unitRoleId);
 
 		/// <summary>
+		/// Gets all unit roles for every unit in a department in a single query.
+		/// </summary>
+		/// <param name="departmentId">The department identifier.</param>
+		/// <returns>Task&lt;List&lt;UnitRole&gt;&gt;.</returns>
+		Task<List<UnitRole>> GetAllRolesForDepartmentAsync(int departmentId);
+
+		/// <summary>
 		/// Sets the roles for unit asynchronous.
 		/// </summary>
 		/// <param name="unitId">The unit identifier.</param>

--- a/Core/Resgrid.Model/UnitRole.cs
+++ b/Core/Resgrid.Model/UnitRole.cs
@@ -23,6 +23,19 @@ namespace Resgrid.Model
 		[MaxLength(250)]
 		public string Name { get; set; }
 
+		/// <summary>
+		/// Optional <see cref="PersonnelRole"/> (a personnel qualification such as "Paramedic") that the
+		/// person filling this unit role must hold. Null means the seat has no qualification requirement.
+		/// </summary>
+		public int? PersonnelRoleId { get; set; }
+
+		/// <summary>
+		/// When true and <see cref="PersonnelRoleId"/> is set, a user lacking that personnel role is
+		/// blocked from being assigned to this unit role (a hard requirement). When false the requirement
+		/// is "preferred": the assignment is allowed but the unit is reported as degraded.
+		/// </summary>
+		public bool PersonnelRoleRequired { get; set; }
+
 		[NotMapped]
 		[JsonIgnore]
 		public object IdValue

--- a/Core/Resgrid.Model/UnitRoleStaffingResult.cs
+++ b/Core/Resgrid.Model/UnitRoleStaffingResult.cs
@@ -88,6 +88,11 @@ namespace Resgrid.Model
 					continue;
 				}
 
+				// Consume the matched assignment so it cannot fill more than one seat. Without this,
+				// duplicate defined roles sharing the same Name would all match the same active role
+				// (FirstOrDefault) and overcount FilledRoleCount.
+				active.Remove(assignment);
+
 				result.FilledRoleCount++;
 
 				if (role.PersonnelRoleId.HasValue && isUserQualified != null

--- a/Core/Resgrid.Model/UnitRoleStaffingResult.cs
+++ b/Core/Resgrid.Model/UnitRoleStaffingResult.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Resgrid.Model
+{
+	/// <summary>
+	/// The computed staffing picture for a single unit: how many of its defined roles are filled and
+	/// whether the assignees hold any required personnel qualification. Produced by
+	/// <see cref="Calculate"/> and by <c>IUnitsService.GetUnitStaffingAsync</c>.
+	/// </summary>
+	public class UnitRoleStaffingResult
+	{
+		public int UnitId { get; set; }
+
+		public UnitStaffingLevel Level { get; set; } = UnitStaffingLevel.Unknown;
+
+		/// <summary>Number of roles defined on the unit.</summary>
+		public int DefinedRoleCount { get; set; }
+
+		/// <summary>Number of defined roles that currently have someone assigned.</summary>
+		public int FilledRoleCount { get; set; }
+
+		/// <summary>Names of defined roles that have no one assigned.</summary>
+		public List<string> UnfilledRoleNames { get; set; } = new List<string>();
+
+		/// <summary>Filled roles whose assignee does not hold the required/preferred personnel role.</summary>
+		public List<UnitRoleStaffingIssue> QualificationIssues { get; set; } = new List<UnitRoleStaffingIssue>();
+
+		/// <summary>True when the unit has at least one defined role.</summary>
+		public bool HasDefinedRoles => DefinedRoleCount > 0;
+
+		/// <summary>True when the unit is anything other than fully staffed (and has roles defined).</summary>
+		public bool IsDegraded => HasDefinedRoles && Level != UnitStaffingLevel.FullyStaffed;
+
+		/// <summary>A short, human-friendly summary suitable for a badge tooltip.</summary>
+		public string Summary
+		{
+			get
+			{
+				if (!HasDefinedRoles)
+					return "No roles defined for this unit.";
+
+				var parts = new List<string> { $"{FilledRoleCount} of {DefinedRoleCount} roles filled" };
+
+				if (QualificationIssues.Any())
+					parts.Add($"{QualificationIssues.Count} unqualified");
+
+				return string.Join(", ", parts) + ".";
+			}
+		}
+
+		/// <summary>
+		/// Computes a unit's staffing from its defined roles, the current active-role assignments and a
+		/// qualification predicate. Kept as a pure function (no I/O) so it is easy to test and reuse.
+		/// </summary>
+		/// <param name="unitId">The unit being assessed.</param>
+		/// <param name="definedRoles">The unit's defined <see cref="UnitRole"/> seats.</param>
+		/// <param name="activeRoles">The current <see cref="UnitActiveRole"/> assignments (matched to a
+		/// defined role by <c>Role</c> name).</param>
+		/// <param name="isUserQualified">Predicate: does the given user hold the given personnel role id?</param>
+		/// <param name="personnelRoleNameLookup">Optional map of personnel role id -> display name.</param>
+		public static UnitRoleStaffingResult Calculate(int unitId, IEnumerable<UnitRole> definedRoles,
+			IEnumerable<UnitActiveRole> activeRoles, Func<string, int, bool> isUserQualified,
+			IReadOnlyDictionary<int, string> personnelRoleNameLookup = null)
+		{
+			var result = new UnitRoleStaffingResult { UnitId = unitId };
+
+			var roles = definedRoles?.ToList() ?? new List<UnitRole>();
+			var active = activeRoles?.Where(x => x.UnitId == unitId).ToList() ?? new List<UnitActiveRole>();
+
+			result.DefinedRoleCount = roles.Count;
+
+			if (result.DefinedRoleCount == 0)
+			{
+				result.Level = UnitStaffingLevel.Unknown;
+				return result;
+			}
+
+			foreach (var role in roles)
+			{
+				var assignment = active.FirstOrDefault(x => string.Equals(x.Role, role.Name, StringComparison.OrdinalIgnoreCase)
+					&& !string.IsNullOrWhiteSpace(x.UserId));
+
+				if (assignment == null)
+				{
+					result.UnfilledRoleNames.Add(role.Name);
+					continue;
+				}
+
+				result.FilledRoleCount++;
+
+				if (role.PersonnelRoleId.HasValue && isUserQualified != null
+					&& !isUserQualified(assignment.UserId, role.PersonnelRoleId.Value))
+				{
+					string roleName = null;
+					personnelRoleNameLookup?.TryGetValue(role.PersonnelRoleId.Value, out roleName);
+
+					result.QualificationIssues.Add(new UnitRoleStaffingIssue
+					{
+						RoleName = role.Name,
+						UserId = assignment.UserId,
+						RequiredPersonnelRoleId = role.PersonnelRoleId.Value,
+						RequiredPersonnelRoleName = roleName,
+						Required = role.PersonnelRoleRequired
+					});
+				}
+			}
+
+			if (result.FilledRoleCount == 0)
+				result.Level = UnitStaffingLevel.NotStaffed;
+			else if (result.FilledRoleCount < result.DefinedRoleCount)
+				result.Level = UnitStaffingLevel.PartiallyStaffed;
+			else if (result.QualificationIssues.Count > 0)
+				result.Level = UnitStaffingLevel.Degraded;
+			else
+				result.Level = UnitStaffingLevel.FullyStaffed;
+
+			return result;
+		}
+	}
+
+	/// <summary>A single filled seat whose assignee lacks the required/preferred personnel role.</summary>
+	public class UnitRoleStaffingIssue
+	{
+		public string RoleName { get; set; }
+		public string UserId { get; set; }
+		public int RequiredPersonnelRoleId { get; set; }
+		public string RequiredPersonnelRoleName { get; set; }
+
+		/// <summary>True if the qualification was a hard requirement (block) vs. a preference (warn).</summary>
+		public bool Required { get; set; }
+	}
+}

--- a/Core/Resgrid.Model/UnitRoles/UnitRoleTemplate.cs
+++ b/Core/Resgrid.Model/UnitRoles/UnitRoleTemplate.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Resgrid.Model.UnitRoles
+{
+	/// <summary>
+	/// A predefined, code-defined set of unit accountability roles (a "crew template") that a department
+	/// can pick from instead of typing role names from scratch. Templates are defined entirely in code
+	/// (see <see cref="UnitRoleTemplateCatalog"/>) and are never stored in the database. When selected, the
+	/// roles are added as editable rows on the unit form so the department can rename them, change the
+	/// required personnel role, add or remove seats, and then save.
+	/// </summary>
+	public class UnitRoleTemplate
+	{
+		/// <summary>Stable, unique identifier/slug (e.g. "fire-engine-company").</summary>
+		public string Id { get; set; }
+
+		/// <summary>Short, human friendly name (e.g. "Fire Engine Company").</summary>
+		public string Name { get; set; }
+
+		/// <summary>The discipline/category used for grouping and filtering (e.g. "Fire", "EMS").</summary>
+		public string Category { get; set; }
+
+		/// <summary>A one or two sentence explanation of what the crew set is and who should use it.</summary>
+		public string Description { get; set; }
+
+		/// <summary>Extra synonyms/keywords to make the template easier to find via search.</summary>
+		public string[] Keywords { get; set; } = new string[0];
+
+		/// <summary>The ordered seats/positions that make up the crew.</summary>
+		public List<UnitRoleTemplateRole> Roles { get; set; } = new List<UnitRoleTemplateRole>();
+
+		/// <summary>Number of seats in the crew.</summary>
+		public int RoleCount => Roles?.Count ?? 0;
+
+		/// <summary>
+		/// A single lowercased blob of all searchable text (name, category, description, keywords and every
+		/// role/seat name). Powers client-side search/filtering in the template picker.
+		/// </summary>
+		public string SearchText
+		{
+			get
+			{
+				var parts = new List<string> { Name, Category, Description };
+
+				if (Keywords != null)
+					parts.AddRange(Keywords);
+
+				if (Roles != null)
+				{
+					parts.AddRange(Roles.Select(r => r.Name));
+					parts.AddRange(Roles.Where(r => !string.IsNullOrWhiteSpace(r.SuggestedPersonnelRole)).Select(r => r.SuggestedPersonnelRole));
+				}
+
+				return string.Join(" ", parts.Where(p => !string.IsNullOrWhiteSpace(p))).ToLowerInvariant();
+			}
+		}
+	}
+}

--- a/Core/Resgrid.Model/UnitRoles/UnitRoleTemplateCatalog.cs
+++ b/Core/Resgrid.Model/UnitRoles/UnitRoleTemplateCatalog.cs
@@ -1,0 +1,205 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Resgrid.Model.UnitRoles
+{
+	/// <summary>
+	/// The code-defined catalog of predefined unit accountability-role sets ("crew templates") that
+	/// departments can pick from when defining the roles on a unit. Everything here lives in code (NOT the
+	/// database) by design, mirroring <see cref="Resgrid.Model.CustomStates.CustomStateTemplateCatalog"/>.
+	///
+	/// Suggested personnel roles are expressed by NAME (e.g. "Paramedic") because personnel roles are
+	/// per-department; they are matched to the department's existing personnel roles when a template is
+	/// applied. To add a template, add it to the relevant builder below.
+	/// </summary>
+	public static class UnitRoleTemplateCatalog
+	{
+		/// <summary>All crew templates across every discipline, in display order.</summary>
+		public static IReadOnlyList<UnitRoleTemplate> All { get; } = BuildAll();
+
+		/// <summary>Returns a single template by its stable id, or null if it does not exist.</summary>
+		public static UnitRoleTemplate GetById(string id)
+		{
+			if (string.IsNullOrWhiteSpace(id))
+				return null;
+
+			return All.FirstOrDefault(t => string.Equals(t.Id, id, StringComparison.OrdinalIgnoreCase));
+		}
+
+		/// <summary>Returns the templates for a given discipline/category.</summary>
+		public static IReadOnlyList<UnitRoleTemplate> GetByCategory(string category)
+		{
+			return All.Where(t => string.Equals(t.Category, category, StringComparison.OrdinalIgnoreCase)).ToList();
+		}
+
+		/// <summary>
+		/// Returns templates filtered by an optional free-text query (matched against the name, category,
+		/// description, keywords and role names). The picker UI also filters client-side for instant results.
+		/// </summary>
+		public static IReadOnlyList<UnitRoleTemplate> Search(string query)
+		{
+			if (string.IsNullOrWhiteSpace(query))
+				return All;
+
+			var terms = query.ToLowerInvariant().Split(new[] { ' ', ',' }, StringSplitOptions.RemoveEmptyEntries);
+
+			return All.Where(t => terms.All(term => t.SearchText.Contains(term))).ToList();
+		}
+
+		#region Builders
+
+		private static UnitRoleTemplateRole R(string name, string suggestedPersonnelRole = null, bool required = false)
+			=> new UnitRoleTemplateRole(name, suggestedPersonnelRole, required);
+
+		private static UnitRoleTemplate T(string id, string name, string category, string description, string[] keywords, params UnitRoleTemplateRole[] roles)
+			=> new UnitRoleTemplate { Id = id, Name = name, Category = category, Description = description, Keywords = keywords, Roles = roles.ToList() };
+
+		private static IReadOnlyList<UnitRoleTemplate> BuildAll()
+		{
+			return new List<UnitRoleTemplate>
+			{
+				// ---- Fire ----
+				T("fire-engine-company", "Fire Engine Company", "Fire",
+					"A standard engine (pumper) company: company officer, apparatus driver/engineer and firefighters.",
+					new[] { "engine", "pumper", "company", "suppression", "crew" },
+					R("Company Officer", "Officer"), R("Driver/Engineer", "Driver/Operator"), R("Firefighter"), R("Firefighter")),
+
+				T("fire-truck-company", "Fire Truck / Ladder Company", "Fire",
+					"A truck (ladder/aerial) company focused on search, ventilation and rescue.",
+					new[] { "ladder", "truck", "aerial", "tiller", "rescue", "ventilation" },
+					R("Company Officer", "Officer"), R("Driver/Operator", "Driver/Operator"), R("Firefighter"), R("Firefighter"), R("Firefighter")),
+
+				T("fire-rescue-squad", "Rescue / Squad Company", "Fire",
+					"A heavy rescue or squad company for technical rescue and extrication work.",
+					new[] { "rescue", "squad", "extrication", "technical", "heavy" },
+					R("Rescue Officer", "Officer"), R("Driver/Operator", "Driver/Operator"), R("Rescue Technician", "Rescue Technician"), R("Rescue Technician", "Rescue Technician")),
+
+				T("fire-brush-unit", "Brush / Wildland Unit", "Fire",
+					"A wildland/brush unit for vegetation and wildland-urban interface fires.",
+					new[] { "brush", "wildland", "grass", "wui", "interface" },
+					R("Crew Boss", "Wildland"), R("Operator", "Driver/Operator"), R("Firefighter", "Wildland"), R("Firefighter", "Wildland")),
+
+				T("fire-command", "Fire Command Staff", "Fire",
+					"An incident command team for structure fires and larger incidents.",
+					new[] { "command", "ics", "incident", "chief", "accountability" },
+					R("Incident Commander", "Command Officer"), R("Safety Officer", "Safety Officer"), R("Operations"), R("Accountability")),
+
+				// ---- EMS ----
+				T("ems-ambulance-als", "Ambulance (ALS)", "EMS",
+					"An advanced life support ambulance staffed with a paramedic and a driver.",
+					new[] { "ambulance", "medic", "als", "paramedic", "transport" },
+					R("Lead Medic", "Paramedic", required: true), R("Driver / EMT", "EMT")),
+
+				T("ems-ambulance-bls", "Ambulance (BLS)", "EMS",
+					"A basic life support ambulance staffed with EMTs.",
+					new[] { "ambulance", "bls", "emt", "basic", "transport" },
+					R("Attendant", "EMT", required: true), R("Driver", "EMT")),
+
+				T("ems-supervisor", "EMS Supervisor / Chase", "EMS",
+					"A single-role EMS supervisor or chase/fly car unit.",
+					new[] { "supervisor", "chase", "fly car", "qrv", "field" },
+					R("Supervisor", "Paramedic")),
+
+				// ---- Law Enforcement ----
+				T("le-patrol-unit", "Patrol Unit", "Law Enforcement",
+					"A patrol vehicle staffed by one or two officers.",
+					new[] { "police", "patrol", "cruiser", "officer", "deputy" },
+					R("Primary Officer", "Officer"), R("Secondary Officer", "Officer")),
+
+				T("le-k9-unit", "K9 Unit", "Law Enforcement",
+					"A K9 unit with a certified handler.",
+					new[] { "k9", "canine", "handler", "dog" },
+					R("K9 Handler", "K9 Handler", required: true), R("Cover Officer", "Officer")),
+
+				T("le-swat-team", "SWAT / Tactical Team", "Law Enforcement",
+					"A tactical team for high-risk operations, including a tactical medic.",
+					new[] { "swat", "tactical", "sert", "entry", "sniper" },
+					R("Team Leader", "Officer"), R("Entry"), R("Entry"), R("Sniper/Observer", "Marksman"), R("Tactical Medic", "Paramedic", required: true)),
+
+				// ---- Search and Rescue ----
+				T("sar-ground-team", "SAR Ground Team", "Search and Rescue",
+					"A ground search-and-rescue team with a leader, navigator and medic.",
+					new[] { "sar", "ground", "search", "field team", "hasty" },
+					R("Team Leader", "Team Leader"), R("Navigator"), R("Medic", "First Aid"), R("Searcher"), R("Searcher")),
+
+				T("sar-k9-team", "SAR K9 Team", "Search and Rescue",
+					"A search dog team with handler, flanker and radio operator.",
+					new[] { "sar", "k9", "canine", "air scent", "trailing", "cadaver" },
+					R("K9 Handler", "K9 Handler", required: true), R("Flanker"), R("Radio Operator")),
+
+				T("sar-swiftwater-team", "Swiftwater Rescue Team", "Search and Rescue",
+					"A swiftwater/flood rescue team with certified rescue swimmers.",
+					new[] { "swiftwater", "water rescue", "flood", "boat", "river" },
+					R("Team Leader", "Swiftwater Technician"), R("Rescue Swimmer", "Swiftwater Technician", required: true), R("Rope Tender"), R("Spotter")),
+
+				// ---- Emergency / Disaster Response ----
+				T("er-incident-command", "Incident Command Team", "Emergency Response",
+					"A general ICS command and general staff structure for any incident type.",
+					new[] { "ics", "command", "general staff", "nims", "unified command" },
+					R("Incident Commander"), R("Operations Section Chief"), R("Planning Section Chief"), R("Logistics Section Chief"), R("Finance/Admin Section Chief")),
+
+				T("dr-usar-squad", "USAR Squad", "Disaster Response",
+					"An urban search-and-rescue squad for structural collapse operations.",
+					new[] { "usar", "collapse", "task force", "disaster", "shoring" },
+					R("Squad Leader", "Rescue Technician"), R("Rescue Specialist", "Rescue Technician", required: true), R("Medical Specialist", "Paramedic", required: true), R("Hazmat Specialist", "Hazmat Technician")),
+
+				T("dr-eoc-team", "Emergency Operations Center", "Disaster Response",
+					"An EOC staffing template for coordinating a large-scale response.",
+					new[] { "eoc", "operations center", "coordination", "activation" },
+					R("EOC Director"), R("Operations"), R("Planning"), R("Logistics"), R("Public Information Officer", "PIO")),
+
+				// ---- Security ----
+				T("sec-patrol", "Security Patrol", "Security",
+					"A mobile security patrol with a supervisor and officers.",
+					new[] { "security", "guard", "patrol", "site", "campus" },
+					R("Shift Supervisor", "Supervisor"), R("Patrol Officer", "Security Officer"), R("Patrol Officer", "Security Officer")),
+
+				T("sec-event-team", "Event Security Team", "Security",
+					"A security detail for events and venues.",
+					new[] { "event", "venue", "crowd", "detail", "guard" },
+					R("Team Lead", "Supervisor"), R("Officer", "Security Officer"), R("Officer", "Security Officer"), R("Officer", "Security Officer")),
+
+				// ---- Industrial Management ----
+				T("ind-fire-brigade", "Industrial Fire Brigade", "Industrial Management",
+					"A plant/industrial fire brigade crew for on-site emergency response.",
+					new[] { "industrial", "brigade", "plant", "refinery", "on-site" },
+					R("Brigade Leader", "Fire Brigade Leader"), R("Nozzle", "Fire Brigade Member"), R("Backup", "Fire Brigade Member"), R("Pump Operator", "Driver/Operator")),
+
+				T("ind-hazmat-team", "Hazmat Team", "Industrial Management",
+					"A hazardous materials response team with certified technicians.",
+					new[] { "hazmat", "hazardous materials", "decon", "spill", "cbrne" },
+					R("Team Leader", "Hazmat Technician"), R("Entry Team", "Hazmat Technician", required: true), R("Entry Team", "Hazmat Technician", required: true), R("Decon"), R("Safety Officer", "Safety Officer")),
+
+				T("ind-work-crew", "Utility / Work Crew", "Industrial Management",
+					"A general industrial or utility work crew.",
+					new[] { "utility", "work crew", "maintenance", "operator", "labor" },
+					R("Crew Lead", "Supervisor"), R("Operator", "Equipment Operator"), R("Laborer"), R("Laborer")),
+
+				// ---- Commodity Delivery / Logistics ----
+				T("log-delivery-vehicle", "Delivery Vehicle", "Commodity Delivery",
+					"A delivery vehicle crew with a driver and helper.",
+					new[] { "delivery", "courier", "driver", "logistics", "route" },
+					R("Driver", "CDL", required: true), R("Helper")),
+
+				T("log-logistics-truck", "Logistics Truck Crew", "Commodity Delivery",
+					"A freight/logistics truck crew for loading and hauling.",
+					new[] { "logistics", "freight", "cargo", "haul", "supply" },
+					R("Driver", "CDL", required: true), R("Loader"), R("Loader")),
+
+				// ---- General ----
+				T("gen-two-person", "Two-Person Crew", "General",
+					"A simple two-person crew for any small unit.",
+					new[] { "general", "basic", "two person", "pair" },
+					R("Lead"), R("Assistant")),
+
+				T("gen-four-person", "Four-Person Crew", "General",
+					"A general four-person crew with a lead, driver and two members.",
+					new[] { "general", "standard", "four person", "crew" },
+					R("Officer / Lead"), R("Driver"), R("Crew"), R("Crew"))
+			};
+		}
+
+		#endregion Builders
+	}
+}

--- a/Core/Resgrid.Model/UnitRoles/UnitRoleTemplateRole.cs
+++ b/Core/Resgrid.Model/UnitRoles/UnitRoleTemplateRole.cs
@@ -1,0 +1,38 @@
+namespace Resgrid.Model.UnitRoles
+{
+	/// <summary>
+	/// A single seat/position within a <see cref="UnitRoleTemplate"/> (e.g. "Driver/Engineer",
+	/// "Lead Medic"). Pure code-defined data; never persisted. When a template is applied the seat becomes
+	/// an editable <see cref="UnitRole"/> row on the unit form.
+	/// </summary>
+	public class UnitRoleTemplateRole
+	{
+		/// <summary>The name of the role/seat (e.g. "Officer", "Firefighter").</summary>
+		public string Name { get; set; }
+
+		/// <summary>
+		/// Optional suggested personnel qualification (by name, e.g. "Paramedic") for this seat. Because
+		/// personnel roles are per-department, this is matched to the department's existing personnel roles
+		/// by name when the template is applied; if no match exists the seat is added without a requirement.
+		/// </summary>
+		public string SuggestedPersonnelRole { get; set; }
+
+		/// <summary>
+		/// Whether the suggested personnel role should default to a hard requirement (blocks unqualified
+		/// members) rather than a preference (allowed but degraded). Only meaningful when
+		/// <see cref="SuggestedPersonnelRole"/> is set and matches an existing personnel role.
+		/// </summary>
+		public bool Required { get; set; }
+
+		public UnitRoleTemplateRole()
+		{
+		}
+
+		public UnitRoleTemplateRole(string name, string suggestedPersonnelRole = null, bool required = false)
+		{
+			Name = name;
+			SuggestedPersonnelRole = suggestedPersonnelRole;
+			Required = required;
+		}
+	}
+}

--- a/Core/Resgrid.Model/UnitStaffingLevel.cs
+++ b/Core/Resgrid.Model/UnitStaffingLevel.cs
@@ -1,0 +1,42 @@
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+
+namespace Resgrid.Model
+{
+	/// <summary>
+	/// The computed staffing level of a unit, derived from how many of the unit's defined roles
+	/// (<see cref="UnitRole"/>) are currently filled (<see cref="UnitActiveRole"/>) and whether the
+	/// people filling them hold any required personnel qualification (<see cref="PersonnelRole"/>).
+	/// This is NOT a stored value — it is calculated on demand (see <see cref="UnitRoleStaffingResult"/>).
+	/// </summary>
+	public enum UnitStaffingLevel
+	{
+		/// <summary>The unit has no defined roles, so staffing cannot be assessed.</summary>
+		[Description("No Roles")]
+		[Display(Name = "No Roles")]
+		Unknown = 0,
+
+		/// <summary>The unit has defined roles but none of them are currently filled.</summary>
+		[Description("Not Staffed")]
+		[Display(Name = "Not Staffed")]
+		NotStaffed = 1,
+
+		/// <summary>Some, but not all, of the unit's defined roles are filled.</summary>
+		[Description("Partially Staffed")]
+		[Display(Name = "Partially Staffed")]
+		PartiallyStaffed = 2,
+
+		/// <summary>
+		/// Every defined role is filled, but at least one assignee does not hold the personnel role
+		/// required (or preferred) for their seat, so the unit is operating in a degraded capacity.
+		/// </summary>
+		[Description("Degraded")]
+		[Display(Name = "Degraded")]
+		Degraded = 3,
+
+		/// <summary>Every defined role is filled and every qualification requirement is met.</summary>
+		[Description("Fully Staffed")]
+		[Display(Name = "Fully Staffed")]
+		FullyStaffed = 4
+	}
+}

--- a/Core/Resgrid.Services/UnitsService.cs
+++ b/Core/Resgrid.Services/UnitsService.cs
@@ -722,9 +722,16 @@ namespace Resgrid.Services
 			var roleNames = await BuildPersonnelRoleNameLookupAsync(departmentId);
 			var userRoleMap = await _personnelRolesService.GetAllRolesForUsersInDepartmentAsync(departmentId);
 
+			// Load every unit's defined roles for the whole department in a single query and group them
+			// by unit, instead of querying roles per unit inside the loop (avoids an N+1).
+			var allRoles = await _unitRolesRepository.GetAllRolesByDepartmentIdAsync(departmentId);
+			var rolesByUnit = (allRoles ?? Enumerable.Empty<UnitRole>())
+				.GroupBy(r => r.UnitId)
+				.ToDictionary(g => g.Key, g => g.ToList());
+
 			foreach (var unit in units)
 			{
-				var definedRoles = await GetRolesForUnitAsync(unit.UnitId);
+				var definedRoles = rolesByUnit.TryGetValue(unit.UnitId, out var unitRoles) ? unitRoles : new List<UnitRole>();
 
 				results[unit.UnitId] = UnitRoleStaffingResult.Calculate(unit.UnitId, definedRoles, activeRoles,
 					(uId, personnelRoleId) => UserHoldsPersonnelRole(userRoleMap, uId, personnelRoleId), roleNames);

--- a/Core/Resgrid.Services/UnitsService.cs
+++ b/Core/Resgrid.Services/UnitsService.cs
@@ -29,13 +29,14 @@ namespace Resgrid.Services
 		private readonly IUnitActiveRolesRepository _unitActiveRolesRepository;
 		private readonly IDepartmentGroupsService _departmentGroupsService;
 		private readonly ILimitsService _limitsService;
+		private readonly IPersonnelRolesService _personnelRolesService;
 
 		public UnitsService(IUnitsRepository unitsRepository, IUnitStatesRepository unitStatesRepository,
 			IUnitLogsRepository unitLogsRepository, IUnitTypesRepository unitTypesRepository, ISubscriptionsService subscriptionsService,
 			IUnitRolesRepository unitRolesRepository, IUnitStateRoleRepository unitStateRoleRepository, IUserStateService userStateService,
 			IEventAggregator eventAggregator, ICustomStateService customStateService, Lazy<IMongoRepository<UnitsLocation>> unitLocationRepository,
 			IUnitLocationsDocRepository unitLocationsDocRepository, IUnitActiveRolesRepository unitActiveRolesRepository,
-			IDepartmentGroupsService departmentGroupsService, ILimitsService limitsService)
+			IDepartmentGroupsService departmentGroupsService, ILimitsService limitsService, IPersonnelRolesService personnelRolesService)
 		{
 			_unitsRepository = unitsRepository;
 			_unitStatesRepository = unitStatesRepository;
@@ -52,6 +53,7 @@ namespace Resgrid.Services
 			_unitActiveRolesRepository = unitActiveRolesRepository;
 			_departmentGroupsService = departmentGroupsService;
 			_limitsService = limitsService;
+			_personnelRolesService = personnelRolesService;
 		}
 
 		public async Task<List<Unit>> GetAllAsync()
@@ -674,6 +676,87 @@ namespace Resgrid.Services
 		public async Task<bool> DeleteActiveRolesForUnitAsync(int unitId, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			return await _unitActiveRolesRepository.DeleteActiveRolesByUnitIdAsync(unitId, cancellationToken);
+		}
+
+		public async Task<bool> IsUserQualifiedForUnitRoleAsync(UnitRole role, string userId, int departmentId)
+		{
+			// No qualification configured for the seat -> anyone may fill it.
+			if (role == null || !role.PersonnelRoleId.HasValue)
+				return true;
+
+			if (String.IsNullOrWhiteSpace(userId))
+				return false;
+
+			var userRoles = await _personnelRolesService.GetRolesForUserAsync(userId, departmentId);
+
+			return userRoles != null && userRoles.Any(x => x != null && x.PersonnelRoleId == role.PersonnelRoleId.Value);
+		}
+
+		public async Task<UnitRoleStaffingResult> GetUnitStaffingAsync(int unitId)
+		{
+			var unit = await GetUnitByIdAsync(unitId);
+
+			if (unit == null)
+				return new UnitRoleStaffingResult { UnitId = unitId };
+
+			var definedRoles = await GetRolesForUnitAsync(unitId);
+			var activeRoles = await GetActiveRolesForUnitAsync(unitId);
+
+			var roleNames = await BuildPersonnelRoleNameLookupAsync(unit.DepartmentId);
+			var userRoleMap = await _personnelRolesService.GetAllRolesForUsersInDepartmentAsync(unit.DepartmentId);
+
+			return UnitRoleStaffingResult.Calculate(unitId, definedRoles, activeRoles,
+				(uId, personnelRoleId) => UserHoldsPersonnelRole(userRoleMap, uId, personnelRoleId), roleNames);
+		}
+
+		public async Task<Dictionary<int, UnitRoleStaffingResult>> GetUnitStaffingForDepartmentAsync(int departmentId)
+		{
+			var results = new Dictionary<int, UnitRoleStaffingResult>();
+
+			var units = await GetUnitsForDepartmentAsync(departmentId);
+
+			if (units == null || !units.Any())
+				return results;
+
+			var activeRoles = await GetAllActiveRolesForUnitsByDepartmentIdAsync(departmentId);
+			var roleNames = await BuildPersonnelRoleNameLookupAsync(departmentId);
+			var userRoleMap = await _personnelRolesService.GetAllRolesForUsersInDepartmentAsync(departmentId);
+
+			foreach (var unit in units)
+			{
+				var definedRoles = await GetRolesForUnitAsync(unit.UnitId);
+
+				results[unit.UnitId] = UnitRoleStaffingResult.Calculate(unit.UnitId, definedRoles, activeRoles,
+					(uId, personnelRoleId) => UserHoldsPersonnelRole(userRoleMap, uId, personnelRoleId), roleNames);
+			}
+
+			return results;
+		}
+
+		private async Task<Dictionary<int, string>> BuildPersonnelRoleNameLookupAsync(int departmentId)
+		{
+			var lookup = new Dictionary<int, string>();
+			var allRoles = await _personnelRolesService.GetAllRolesForDepartmentAsync(departmentId);
+
+			if (allRoles != null)
+			{
+				foreach (var role in allRoles)
+				{
+					if (role != null && !lookup.ContainsKey(role.PersonnelRoleId))
+						lookup[role.PersonnelRoleId] = role.Name;
+				}
+			}
+
+			return lookup;
+		}
+
+		private static bool UserHoldsPersonnelRole(Dictionary<string, List<PersonnelRole>> userRoleMap, string userId, int personnelRoleId)
+		{
+			return !String.IsNullOrWhiteSpace(userId)
+				&& userRoleMap != null
+				&& userRoleMap.TryGetValue(userId, out var roles)
+				&& roles != null
+				&& roles.Any(r => r != null && r.PersonnelRoleId == personnelRoleId);
 		}
 	}
 }

--- a/Core/Resgrid.Services/UnitsService.cs
+++ b/Core/Resgrid.Services/UnitsService.cs
@@ -375,6 +375,16 @@ namespace Resgrid.Services
 			return await _unitRolesRepository.GetByIdAsync(unitRoleId);
 		}
 
+		public async Task<List<UnitRole>> GetAllRolesForDepartmentAsync(int departmentId)
+		{
+			var roles = await _unitRolesRepository.GetAllRolesByDepartmentIdAsync(departmentId);
+
+			if (roles != null && roles.Any())
+				return roles.ToList();
+			else
+				return new List<UnitRole>();
+		}
+
 		public async Task<List<UnitRole>> SetRolesForUnitAsync(int unitId, List<UnitRole> roles, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			if (unitId <= 0)

--- a/Providers/Resgrid.Providers.Migrations/Migrations/M0086_AddUnitRolePersonnelRole.cs
+++ b/Providers/Resgrid.Providers.Migrations/Migrations/M0086_AddUnitRolePersonnelRole.cs
@@ -1,0 +1,32 @@
+using FluentMigrator;
+
+namespace Resgrid.Providers.Migrations.Migrations
+{
+	/// <summary>
+	/// Adds an optional required personnel qualification to a unit role. PersonnelRoleId points at the
+	/// PersonnelRole (e.g. "Paramedic") the person filling the seat must hold; PersonnelRoleRequired marks
+	/// whether that qualification is a hard requirement (blocks assignment) or a preference (allowed but
+	/// reports the unit as degraded). Drives unit staffing computation.
+	/// </summary>
+	[Migration(86)]
+	public class M0086_AddUnitRolePersonnelRole : Migration
+	{
+		public override void Up()
+		{
+			if (Schema.Table("UnitRoles").Exists() && !Schema.Table("UnitRoles").Column("PersonnelRoleId").Exists())
+				Alter.Table("UnitRoles").AddColumn("PersonnelRoleId").AsInt32().Nullable();
+
+			if (Schema.Table("UnitRoles").Exists() && !Schema.Table("UnitRoles").Column("PersonnelRoleRequired").Exists())
+				Alter.Table("UnitRoles").AddColumn("PersonnelRoleRequired").AsBoolean().NotNullable().WithDefaultValue(false);
+		}
+
+		public override void Down()
+		{
+			if (Schema.Table("UnitRoles").Exists() && Schema.Table("UnitRoles").Column("PersonnelRoleRequired").Exists())
+				Delete.Column("PersonnelRoleRequired").FromTable("UnitRoles");
+
+			if (Schema.Table("UnitRoles").Exists() && Schema.Table("UnitRoles").Column("PersonnelRoleId").Exists())
+				Delete.Column("PersonnelRoleId").FromTable("UnitRoles");
+		}
+	}
+}

--- a/Providers/Resgrid.Providers.MigrationsPg/Migrations/M0086_AddUnitRolePersonnelRolePg.cs
+++ b/Providers/Resgrid.Providers.MigrationsPg/Migrations/M0086_AddUnitRolePersonnelRolePg.cs
@@ -1,0 +1,32 @@
+using FluentMigrator;
+
+namespace Resgrid.Providers.MigrationsPg.Migrations
+{
+	/// <summary>
+	/// Adds an optional required personnel qualification to a unit role (PostgreSQL). PersonnelRoleId points
+	/// at the PersonnelRole (e.g. "Paramedic") the person filling the seat must hold; PersonnelRoleRequired
+	/// marks whether that qualification is a hard requirement (blocks assignment) or a preference (allowed
+	/// but reports the unit as degraded). Drives unit staffing computation.
+	/// </summary>
+	[Migration(86)]
+	public class M0086_AddUnitRolePersonnelRolePg : Migration
+	{
+		public override void Up()
+		{
+			if (Schema.Table("UnitRoles".ToLower()).Exists() && !Schema.Table("UnitRoles".ToLower()).Column("PersonnelRoleId".ToLower()).Exists())
+				Alter.Table("UnitRoles".ToLower()).AddColumn("PersonnelRoleId".ToLower()).AsInt32().Nullable();
+
+			if (Schema.Table("UnitRoles".ToLower()).Exists() && !Schema.Table("UnitRoles".ToLower()).Column("PersonnelRoleRequired".ToLower()).Exists())
+				Alter.Table("UnitRoles".ToLower()).AddColumn("PersonnelRoleRequired".ToLower()).AsBoolean().NotNullable().WithDefaultValue(false);
+		}
+
+		public override void Down()
+		{
+			if (Schema.Table("UnitRoles".ToLower()).Exists() && Schema.Table("UnitRoles".ToLower()).Column("PersonnelRoleRequired".ToLower()).Exists())
+				Delete.Column("PersonnelRoleRequired".ToLower()).FromTable("UnitRoles".ToLower());
+
+			if (Schema.Table("UnitRoles".ToLower()).Exists() && Schema.Table("UnitRoles".ToLower()).Column("PersonnelRoleId".ToLower()).Exists())
+				Delete.Column("PersonnelRoleId".ToLower()).FromTable("UnitRoles".ToLower());
+		}
+	}
+}

--- a/Repositories/Resgrid.Repositories.DataRepository/Configs/SqlConfiguration.cs
+++ b/Repositories/Resgrid.Repositories.DataRepository/Configs/SqlConfiguration.cs
@@ -241,6 +241,7 @@ namespace Resgrid.Repositories.DataRepository.Configs
 		public string SelectUnitTypeByDIdNameQuery { get; set; }
 		public string SelectUnitLogsByUnitIdQuery { get; set; }
 		public string SelectUnitRolesByUnitIdQuery { get; set; }
+		public string SelectUnitRolesByDepartmentIdQuery { get; set; }
 		public string SelectUnitsByGroupIdQuery { get; set; }
 		public string SelectCurrentRolesByUnitIdQuery { get; set; }
 		public string SelectLatestUnitLocationByUnitId { get; set; }

--- a/Repositories/Resgrid.Repositories.DataRepository/Queries/Units/SelectUnitRolesByDepartmentIdQuery.cs
+++ b/Repositories/Resgrid.Repositories.DataRepository/Queries/Units/SelectUnitRolesByDepartmentIdQuery.cs
@@ -1,0 +1,35 @@
+using Resgrid.Model;
+using Resgrid.Model.Repositories.Queries.Contracts;
+using Resgrid.Repositories.DataRepository.Configs;
+using Resgrid.Repositories.DataRepository.Extensions;
+
+namespace Resgrid.Repositories.DataRepository.Queries.Units
+{
+	public class SelectUnitRolesByDepartmentIdQuery : ISelectQuery
+	{
+		private readonly SqlConfiguration _sqlConfiguration;
+		public SelectUnitRolesByDepartmentIdQuery(SqlConfiguration sqlConfiguration)
+		{
+			_sqlConfiguration = sqlConfiguration;
+		}
+
+		public string GetQuery()
+		{
+			var query = _sqlConfiguration.SelectUnitRolesByDepartmentIdQuery
+				.ReplaceQueryParameters(_sqlConfiguration, _sqlConfiguration.SchemaName,
+					_sqlConfiguration.UnitRolesTable,
+					_sqlConfiguration.ParameterNotation,
+					new string[] { "%DID%" },
+					new string[] { "DepartmentId" },
+					new string[] { "%UNITSTABLE%" },
+					new string[] { _sqlConfiguration.UnitsTable });
+
+			return query;
+		}
+
+		public string GetQuery<TEntity>() where TEntity : class, IEntity
+		{
+			throw new System.NotImplementedException();
+		}
+	}
+}

--- a/Repositories/Resgrid.Repositories.DataRepository/Servers/PostgreSql/PostgreSqlConfiguration.cs
+++ b/Repositories/Resgrid.Repositories.DataRepository/Servers/PostgreSql/PostgreSqlConfiguration.cs
@@ -662,6 +662,11 @@ namespace Resgrid.Repositories.DataRepository.Servers.SqlServer
 			SelectUnitLogsByUnitIdQuery =
 				"SELECT * FROM %SCHEMA%.%TABLENAME% WHERE UnitId = %UNITID% ORDER BY Timestamp DESC";
 			SelectUnitRolesByUnitIdQuery = "SELECT * FROM %SCHEMA%.%TABLENAME% WHERE UnitId = %UNITID%";
+			SelectUnitRolesByDepartmentIdQuery = @"
+					SELECT ur.*
+					FROM %SCHEMA%.%TABLENAME% ur
+					INNER JOIN %SCHEMA%.%UNITSTABLE% u ON u.UnitId = ur.UnitId
+					WHERE u.DepartmentId = %DID%";
 			SelectUnitsByGroupIdQuery = @"
 					SELECT u.*, dg.*
 					FROM %SCHEMA%.%UNITSTABLE% u

--- a/Repositories/Resgrid.Repositories.DataRepository/Servers/SqlServer/SqlServerConfiguration.cs
+++ b/Repositories/Resgrid.Repositories.DataRepository/Servers/SqlServer/SqlServerConfiguration.cs
@@ -659,6 +659,11 @@ namespace Resgrid.Repositories.DataRepository.Servers.SqlServer
 			SelectUnitLogsByUnitIdQuery =
 				"SELECT * FROM %SCHEMA%.%TABLENAME% WHERE [UnitId] = %UNITID% ORDER BY Timestamp DESC";
 			SelectUnitRolesByUnitIdQuery = "SELECT * FROM %SCHEMA%.%TABLENAME% WHERE [UnitId] = %UNITID%";
+			SelectUnitRolesByDepartmentIdQuery = @"
+					SELECT ur.*
+					FROM %SCHEMA%.%TABLENAME% ur
+					INNER JOIN %SCHEMA%.%UNITSTABLE% u ON u.[UnitId] = ur.[UnitId]
+					WHERE u.[DepartmentId] = %DID%";
 			SelectUnitsByGroupIdQuery = @"
 					SELECT u.*, dg.*
 					FROM [dbo].[Units] u

--- a/Repositories/Resgrid.Repositories.DataRepository/UnitRolesRepository.cs
+++ b/Repositories/Resgrid.Repositories.DataRepository/UnitRolesRepository.cs
@@ -69,5 +69,46 @@ namespace Resgrid.Repositories.DataRepository
 				throw;
 			}
 		}
+
+		public async Task<IEnumerable<UnitRole>> GetAllRolesByDepartmentIdAsync(int departmentId)
+		{
+			try
+			{
+				var selectFunction = new Func<DbConnection, Task<IEnumerable<UnitRole>>>(async x =>
+				{
+					var dynamicParameters = new DynamicParametersExtension();
+					dynamicParameters.Add("DepartmentId", departmentId);
+
+					var query = _queryFactory.GetQuery<SelectUnitRolesByDepartmentIdQuery>();
+
+					return await x.QueryAsync<UnitRole>(sql: query,
+						param: dynamicParameters,
+						transaction: _unitOfWork.Transaction);
+				});
+
+				DbConnection conn = null;
+				if (_unitOfWork?.Connection == null)
+				{
+					using (conn = _connectionProvider.Create())
+					{
+						await conn.OpenAsync();
+
+						return await selectFunction(conn);
+					}
+				}
+				else
+				{
+					conn = _unitOfWork.CreateOrGetConnection();
+
+					return await selectFunction(conn);
+				}
+			}
+			catch (Exception ex)
+			{
+				Logging.LogException(ex);
+
+				throw;
+			}
+		}
 	}
 }

--- a/Tests/Resgrid.Tests/Services/DocumentDatabaseProviderSelectionTests.cs
+++ b/Tests/Resgrid.Tests/Services/DocumentDatabaseProviderSelectionTests.cs
@@ -198,7 +198,8 @@ namespace Resgrid.Tests.Services
 				unitLocationsDocRepository,
 				new Mock<IUnitActiveRolesRepository>().Object,
 				new Mock<IDepartmentGroupsService>().Object,
-				new Mock<ILimitsService>().Object);
+				new Mock<ILimitsService>().Object,
+				new Mock<IPersonnelRolesService>().Object);
 		}
 
 		private static UsersService CreateUsersService(IEventAggregator eventAggregator, Lazy<IMongoRepository<PersonnelLocation>> mongoRepository, IPersonnelLocationsDocRepository personnelLocationsDocRepository)

--- a/Tests/Resgrid.Tests/Services/UnitRoleStaffingResultTests.cs
+++ b/Tests/Resgrid.Tests/Services/UnitRoleStaffingResultTests.cs
@@ -1,0 +1,67 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using NUnit.Framework;
+using Resgrid.Model;
+
+namespace Resgrid.Tests.Services
+{
+	[TestFixture]
+	public class UnitRoleStaffingResultTests
+	{
+		private const int UnitId = 42;
+
+		/// <summary>
+		/// Regression: two defined seats sharing the same Name must not both be satisfied by a single
+		/// active assignment. Before the fix, active.FirstOrDefault matched the same UnitActiveRole for
+		/// every duplicate seat and overcounted FilledRoleCount (reporting the unit as fully staffed).
+		/// </summary>
+		[Test]
+		public void Calculate_DuplicateRoleNames_SingleActiveAssignmentFillsOnlyOneSeat()
+		{
+			var definedRoles = new List<UnitRole>
+			{
+				new UnitRole { UnitId = UnitId, Name = "Firefighter" },
+				new UnitRole { UnitId = UnitId, Name = "Firefighter" }
+			};
+
+			var activeRoles = new List<UnitActiveRole>
+			{
+				new UnitActiveRole { UnitId = UnitId, Role = "Firefighter", UserId = "user-1" }
+			};
+
+			var result = UnitRoleStaffingResult.Calculate(UnitId, definedRoles, activeRoles, (userId, personnelRoleId) => true);
+
+			result.DefinedRoleCount.Should().Be(2);
+			result.FilledRoleCount.Should().Be(1, "one active assignment must not fill two identically-named seats");
+			result.UnfilledRoleNames.Should().ContainSingle().Which.Should().Be("Firefighter");
+			result.Level.Should().Be(UnitStaffingLevel.PartiallyStaffed);
+		}
+
+		/// <summary>
+		/// Companion happy-path: consuming a matched assignment must not prevent a second, distinct
+		/// assignment from filling the other duplicate seat.
+		/// </summary>
+		[Test]
+		public void Calculate_DuplicateRoleNames_TwoActiveAssignmentsFillBothSeats()
+		{
+			var definedRoles = new List<UnitRole>
+			{
+				new UnitRole { UnitId = UnitId, Name = "Firefighter" },
+				new UnitRole { UnitId = UnitId, Name = "Firefighter" }
+			};
+
+			var activeRoles = new List<UnitActiveRole>
+			{
+				new UnitActiveRole { UnitId = UnitId, Role = "Firefighter", UserId = "user-1" },
+				new UnitActiveRole { UnitId = UnitId, Role = "Firefighter", UserId = "user-2" }
+			};
+
+			var result = UnitRoleStaffingResult.Calculate(UnitId, definedRoles, activeRoles, (userId, personnelRoleId) => true);
+
+			result.DefinedRoleCount.Should().Be(2);
+			result.FilledRoleCount.Should().Be(2);
+			result.UnfilledRoleNames.Should().BeEmpty();
+			result.Level.Should().Be(UnitStaffingLevel.FullyStaffed);
+		}
+	}
+}

--- a/Web/Resgrid.Web.Services/Controllers/v4/UnitRolesController.cs
+++ b/Web/Resgrid.Web.Services/Controllers/v4/UnitRolesController.cs
@@ -28,13 +28,32 @@ namespace Resgrid.Web.Services.Controllers.v4
 		#region Members and Constructors
 		private readonly IUnitsService _unitsService;
 		private readonly IDepartmentsService _departmentsService;
+		private readonly IPersonnelRolesService _personnelRolesService;
 
-		public UnitRolesController(IUnitsService unitsService, IDepartmentsService departmentsService)
+		public UnitRolesController(IUnitsService unitsService, IDepartmentsService departmentsService, IPersonnelRolesService personnelRolesService)
 		{
 			_unitsService = unitsService;
 			_departmentsService = departmentsService;
+			_personnelRolesService = personnelRolesService;
 		}
 		#endregion Members and Constructors
+
+		private async Task<Dictionary<int, string>> GetPersonnelRoleNamesAsync()
+		{
+			var map = new Dictionary<int, string>();
+			var roles = await _personnelRolesService.GetAllRolesForDepartmentAsync(DepartmentId);
+
+			if (roles != null)
+			{
+				foreach (var role in roles)
+				{
+					if (role != null && !map.ContainsKey(role.PersonnelRoleId))
+						map[role.PersonnelRoleId] = role.Name;
+				}
+			}
+
+			return map;
+		}
 
 		/// <summary>
 		/// Gets the accountability roles for a unit
@@ -71,10 +90,11 @@ namespace Resgrid.Web.Services.Controllers.v4
 
 			if (roles != null && roles.Any())
 			{
+				var personnelRoleNames = await GetPersonnelRoleNamesAsync();
 
 				foreach (var role in roles)
 				{
-					result.Data.Add(ConvertUnitRoleData(role));
+					result.Data.Add(ConvertUnitRoleData(role, personnelRoleNames));
 				}
 
 				result.PageSize = result.Data.Count;
@@ -84,7 +104,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 			{
 				result.PageSize = 0;
 				result.Status = ResponseHelper.NotFound;
-			}	
+			}
 
 			ResponseHelper.PopulateV4ResponseData(result);
 
@@ -127,11 +147,13 @@ namespace Resgrid.Web.Services.Controllers.v4
 
 			if (roles != null && roles.Any())
 			{
+				var personnelRoleNames = await GetPersonnelRoleNamesAsync();
 
 				foreach (var role in roles)
 				{
 					var activeRole = allActiveRoles.FirstOrDefault(x => x.UnitId == role.UnitId && x.Role == role.Name);
-					result.Data.Add(ConvertActiveUnitRoleData(role, activeRole, personnelNames));
+					bool isQualified = activeRole == null || await _unitsService.IsUserQualifiedForUnitRoleAsync(role, activeRole.UserId, DepartmentId);
+					result.Data.Add(ConvertActiveUnitRoleData(role, activeRole, personnelNames, personnelRoleNames, isQualified));
 				}
 
 				result.PageSize = result.Data.Count;
@@ -183,6 +205,27 @@ namespace Resgrid.Web.Services.Controllers.v4
 
 			if (setRolesInput.Roles != null && setRolesInput.Roles.Any())
 			{
+				// Enforce "Required" personnel-role qualifications before mutating anything (the save path
+				// deletes existing assignments first). A seat marked Required blocks an unqualified member;
+				// "Preferred" seats are allowed and reported as degraded.
+				foreach (var roleInput in setRolesInput.Roles)
+				{
+					if (string.IsNullOrWhiteSpace(roleInput.UserId) || string.IsNullOrWhiteSpace(roleInput.RoleId)
+						|| !int.TryParse(roleInput.RoleId, out var roleIdToCheck))
+						continue;
+
+					var roleToCheck = await _unitsService.GetRoleByIdAsync(roleIdToCheck);
+
+					if (roleToCheck != null && roleToCheck.PersonnelRoleId.HasValue && roleToCheck.PersonnelRoleRequired
+						&& !await _unitsService.IsUserQualifiedForUnitRoleAsync(roleToCheck, roleInput.UserId, DepartmentId))
+					{
+						result.Status = ResponseHelper.Failure;
+						ResponseHelper.PopulateV4ResponseData(result);
+
+						return BadRequest(result);
+					}
+				}
+
 				await _unitsService.DeleteActiveRolesForUnitAsync(unit.UnitId, cancellationToken);
 
 				foreach (var unitRole in setRolesInput.Roles)
@@ -228,6 +271,8 @@ namespace Resgrid.Web.Services.Controllers.v4
 
 			if (units != null && units.Any())
 			{
+				var personnelRoleNames = await GetPersonnelRoleNamesAsync();
+
 				foreach (var unit in units)
 				{
 					if (unit.Roles != null && unit.Roles.Any())
@@ -235,13 +280,14 @@ namespace Resgrid.Web.Services.Controllers.v4
 						foreach (var unitRole in unit.Roles)
 						{
 							var activeRole = activeRoles.FirstOrDefault(x => x.UnitId == unitRole.UnitId && x.Role == unitRole.Name);
-							var role = new ActiveUnitRoleResultData(ConvertUnitRoleData(unitRole));
+							var role = new ActiveUnitRoleResultData(ConvertUnitRoleData(unitRole, personnelRoleNames));
 
 							if (activeRole != null)
 							{
 								role.UserId = activeRole.UserId;
 								role.UpdatedOn = activeRole.UpdatedOn.ToString();
 								role.FullName = await UserHelper.GetFullNameForUser(activeRole.UserId); //TODO: Perf issue here most likely, temp add for Unit app Cap conversion. -SJ
+								role.IsQualified = await _unitsService.IsUserQualifiedForUnitRoleAsync(unitRole, activeRole.UserId, DepartmentId);
 							}
 
 							result.Data.Add(role);
@@ -263,22 +309,30 @@ namespace Resgrid.Web.Services.Controllers.v4
 			return Ok(result);
 		}
 
-		public static UnitRoleResultData ConvertUnitRoleData(UnitRole role)
+		public static UnitRoleResultData ConvertUnitRoleData(UnitRole role, IReadOnlyDictionary<int, string> personnelRoleNames = null)
 		{
 			var data = new UnitRoleResultData();
 			data.Name = role.Name;
 			data.UnitId = role.UnitId.ToString();
 			data.UnitRoleId = role.UnitRoleId.ToString();
 
+			if (role.PersonnelRoleId.HasValue)
+			{
+				data.PersonnelRoleId = role.PersonnelRoleId.Value.ToString();
+				data.PersonnelRoleRequired = role.PersonnelRoleRequired;
+
+				if (personnelRoleNames != null && personnelRoleNames.TryGetValue(role.PersonnelRoleId.Value, out var name))
+					data.PersonnelRoleName = name;
+			}
+
 			return data;
 		}
 
-		public static ActiveUnitRoleResultData ConvertActiveUnitRoleData(UnitRole role, UnitActiveRole activeRole, List<PersonName> names)
+		public static ActiveUnitRoleResultData ConvertActiveUnitRoleData(UnitRole role, UnitActiveRole activeRole, List<PersonName> names,
+			IReadOnlyDictionary<int, string> personnelRoleNames = null, bool isQualified = true)
 		{
-			var data = new ActiveUnitRoleResultData();
-			data.Name = role.Name;
-			data.UnitId = role.UnitId.ToString();
-			data.UnitRoleId = role.UnitRoleId.ToString();
+			var data = new ActiveUnitRoleResultData(ConvertUnitRoleData(role, personnelRoleNames));
+			data.IsQualified = isQualified;
 
 			if (activeRole != null)
 			{
@@ -292,7 +346,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 					data.FullName = name.Name;
 				}
 			}
-			
+
 			return data;
 		}
 	}

--- a/Web/Resgrid.Web.Services/Controllers/v4/UnitRolesController.cs
+++ b/Web/Resgrid.Web.Services/Controllers/v4/UnitRolesController.cs
@@ -273,6 +273,10 @@ namespace Resgrid.Web.Services.Controllers.v4
 			{
 				var personnelRoleNames = await GetPersonnelRoleNamesAsync();
 
+				// Load all user-personnel-role mappings in a single query before the loop to avoid an N+1
+				// (mirrors the pattern in UnitsService.GetUnitStaffingForDepartmentAsync).
+				var userRoleMap = await _personnelRolesService.GetAllRolesForUsersInDepartmentAsync(DepartmentId);
+
 				foreach (var unit in units)
 				{
 					if (unit.Roles != null && unit.Roles.Any())
@@ -287,7 +291,14 @@ namespace Resgrid.Web.Services.Controllers.v4
 								role.UserId = activeRole.UserId;
 								role.UpdatedOn = activeRole.UpdatedOn.ToString();
 								role.FullName = await UserHelper.GetFullNameForUser(activeRole.UserId); //TODO: Perf issue here most likely, temp add for Unit app Cap conversion. -SJ
-								role.IsQualified = await _unitsService.IsUserQualifiedForUnitRoleAsync(unitRole, activeRole.UserId, DepartmentId);
+								// No qualification configured for the seat -> anyone may fill it. Otherwise check the pre-loaded
+								// map in-memory instead of hitting the DB per role (matches IsUserQualifiedForUnitRoleAsync / UserHoldsPersonnelRole).
+								role.IsQualified = !unitRole.PersonnelRoleId.HasValue
+									|| (!string.IsNullOrWhiteSpace(activeRole.UserId)
+										&& userRoleMap != null
+										&& userRoleMap.TryGetValue(activeRole.UserId, out var userRoles)
+										&& userRoles != null
+										&& userRoles.Any(r => r != null && r.PersonnelRoleId == unitRole.PersonnelRoleId.Value));
 							}
 
 							result.Data.Add(role);

--- a/Web/Resgrid.Web.Services/Controllers/v4/UnitRolesController.cs
+++ b/Web/Resgrid.Web.Services/Controllers/v4/UnitRolesController.cs
@@ -230,23 +230,27 @@ namespace Resgrid.Web.Services.Controllers.v4
 
 				foreach (var unitRole in setRolesInput.Roles)
 				{
-					if (!string.IsNullOrWhiteSpace(unitRole.UserId) && !string.IsNullOrWhiteSpace(unitRole.RoleId))
-					{
-						var role = await _unitsService.GetRoleByIdAsync(int.Parse(unitRole.RoleId));
+					if (string.IsNullOrWhiteSpace(unitRole.UserId) || string.IsNullOrWhiteSpace(unitRole.RoleId)
+						|| !int.TryParse(unitRole.RoleId, out var roleId))
+						continue;
 
-						if (role != null)
-						{
-							UnitActiveRole activeRole = new UnitActiveRole();
-							activeRole.UnitId = role.UnitId;
-							activeRole.Role = role.Name;
-							activeRole.UserId = unitRole.UserId;
-							activeRole.DepartmentId = DepartmentId;
-							activeRole.UpdatedBy = UserId;
-							activeRole.UpdatedOn = DateTime.UtcNow;
+					var role = await _unitsService.GetRoleByIdAsync(roleId);
 
-							await _unitsService.SaveActiveRoleAsync(activeRole, cancellationToken);
-						}
-					}
+					// GetRoleByIdAsync is a global primary-key lookup with no ownership filter. The role MUST
+					// belong to the validated unit for this department; otherwise a caller can inject an active-role
+					// assignment onto another department's unit by supplying that unit's RoleId.
+					if (role == null || role.UnitId != unit.UnitId)
+						continue;
+
+					UnitActiveRole activeRole = new UnitActiveRole();
+					activeRole.UnitId = unit.UnitId;
+					activeRole.Role = role.Name;
+					activeRole.UserId = unitRole.UserId;
+					activeRole.DepartmentId = DepartmentId;
+					activeRole.UpdatedBy = UserId;
+					activeRole.UpdatedOn = DateTime.UtcNow;
+
+					await _unitsService.SaveActiveRoleAsync(activeRole, cancellationToken);
 				}
 			}
 

--- a/Web/Resgrid.Web.Services/Models/v4/UnitRoles/ActiveUnitRolesResult.cs
+++ b/Web/Resgrid.Web.Services/Models/v4/UnitRoles/ActiveUnitRolesResult.cs
@@ -41,6 +41,12 @@ namespace Resgrid.Web.Services.Models.v4.UnitRoles
 		/// </summary>
 		public string UpdatedOn { get; set; }
 
+		/// <summary>
+		/// Whether the assigned user holds the personnel role required by this seat. True when the seat has
+		/// no requirement or no one is assigned.
+		/// </summary>
+		public bool IsQualified { get; set; } = true;
+
 		public ActiveUnitRoleResultData()
 		{
 		}
@@ -50,6 +56,9 @@ namespace Resgrid.Web.Services.Models.v4.UnitRoles
 			UnitId = baseData.UnitId;
 			UnitRoleId = baseData.UnitRoleId;
 			Name = baseData.Name;
+			PersonnelRoleId = baseData.PersonnelRoleId;
+			PersonnelRoleName = baseData.PersonnelRoleName;
+			PersonnelRoleRequired = baseData.PersonnelRoleRequired;
 		}
 	}
 }

--- a/Web/Resgrid.Web.Services/Models/v4/UnitRoles/UnitRoleResult.cs
+++ b/Web/Resgrid.Web.Services/Models/v4/UnitRoles/UnitRoleResult.cs
@@ -30,5 +30,21 @@
 		/// Name of the Unit Role
 		/// </summary>
 		public string Name { get; set; }
+
+		/// <summary>
+		/// Optional personnel role (qualification) required to fill this unit role. Null/empty if none.
+		/// </summary>
+		public string PersonnelRoleId { get; set; }
+
+		/// <summary>
+		/// Display name of the required personnel role, if any.
+		/// </summary>
+		public string PersonnelRoleName { get; set; }
+
+		/// <summary>
+		/// When true the personnel role is a hard requirement (unqualified members are blocked from being
+		/// assigned). When false it is preferred (allowed, but the unit is reported as degraded).
+		/// </summary>
+		public bool PersonnelRoleRequired { get; set; }
 	}
 }

--- a/Web/Resgrid.Web.Services/Resgrid.Web.Services.xml
+++ b/Web/Resgrid.Web.Services/Resgrid.Web.Services.xml
@@ -9964,6 +9964,12 @@
             When the user was assigned to the role
             </summary>
         </member>
+        <member name="P:Resgrid.Web.Services.Models.v4.UnitRoles.ActiveUnitRoleResultData.IsQualified">
+            <summary>
+            Whether the assigned user holds the personnel role required by this seat. True when the seat has
+            no requirement or no one is assigned.
+            </summary>
+        </member>
         <member name="T:Resgrid.Web.Services.Models.v4.UnitRoles.SetUnitRolesInput">
             <summary>
             Object inputs for setting a users Status/Action. If this object is used in an operation that sets
@@ -10028,6 +10034,22 @@
         <member name="P:Resgrid.Web.Services.Models.v4.UnitRoles.UnitRoleResultData.Name">
             <summary>
             Name of the Unit Role
+            </summary>
+        </member>
+        <member name="P:Resgrid.Web.Services.Models.v4.UnitRoles.UnitRoleResultData.PersonnelRoleId">
+            <summary>
+            Optional personnel role (qualification) required to fill this unit role. Null/empty if none.
+            </summary>
+        </member>
+        <member name="P:Resgrid.Web.Services.Models.v4.UnitRoles.UnitRoleResultData.PersonnelRoleName">
+            <summary>
+            Display name of the required personnel role, if any.
+            </summary>
+        </member>
+        <member name="P:Resgrid.Web.Services.Models.v4.UnitRoles.UnitRoleResultData.PersonnelRoleRequired">
+            <summary>
+            When true the personnel role is a hard requirement (unqualified members are blocked from being
+            assigned). When false it is preferred (allowed, but the unit is reported as degraded).
             </summary>
         </member>
         <member name="T:Resgrid.Web.Services.Models.v4.UnitRoles.UnitRolesResult">

--- a/Web/Resgrid.Web/Areas/User/Controllers/CustomStatusesController.cs
+++ b/Web/Resgrid.Web/Areas/User/Controllers/CustomStatusesController.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Resgrid.Framework;
 using Resgrid.Model;
+using Resgrid.Model.CustomStates;
 using Resgrid.Model.Events;
 using Resgrid.Model.Providers;
 using Resgrid.Model.Services;
@@ -57,12 +58,38 @@ namespace Resgrid.Web.Areas.User.Controllers
 		}
 
 		[Authorize(Policy = ResgridResources.CustomStates_Create)]
-		public async Task<IActionResult> New(int type)
+		public IActionResult Templates(int type)
+		{
+			var model = new CustomStateTemplatesView();
+			model.Type = (CustomStateTypes)type;
+			model.Templates = CustomStateTemplateCatalog.GetByType(model.Type);
+
+			return View(model);
+		}
+
+		[Authorize(Policy = ResgridResources.CustomStates_Create)]
+		public async Task<IActionResult> New(int type, string templateId = null)
 		{
 			var model = new NewCustomStateView();
 			model.Type = (CustomStateTypes)type;
 			model.State = new CustomState();
 			model.State.Details = new Collection<CustomStateDetail>();
+
+			// If the user chose a predefined template, seed the (still unsaved) state with its options so
+			// they can rename/recolor/delete them before saving. A blank/fresh slate is used otherwise.
+			if (!String.IsNullOrWhiteSpace(templateId))
+			{
+				var template = CustomStateTemplateCatalog.GetById(templateId);
+
+				if (template != null && template.Type == model.Type)
+				{
+					model.State.Name = template.Name;
+					model.State.Description = template.Description;
+
+					foreach (var templateDetail in template.Details.OrderBy(d => d.Order))
+						model.State.Details.Add(templateDetail.ToCustomStateDetail());
+				}
+			}
 
 			return View(model);
 		}

--- a/Web/Resgrid.Web/Areas/User/Controllers/UnitsController.cs
+++ b/Web/Resgrid.Web/Areas/User/Controllers/UnitsController.cs
@@ -200,6 +200,14 @@ namespace Resgrid.Web.Areas.User.Controllers
 									   where key.ToString().StartsWith("Role_")
 									   select int.Parse(key.ToString().Replace("Role_", ""))).ToList();
 
+				// Batch-load all unit roles for the department and every user's personnel roles up front so the
+				// qualification checks below run in-memory instead of issuing DB round-trips per submitted role
+				// (the previous per-iteration GetRoleByIdAsync / IsUserQualifiedForUnitRoleAsync / GetRoleByIdAsync
+				// calls were an N+1 across all Role_* form entries). Personnel role names come from the already
+				// loaded model.PersonnelRoles.
+				var roleMap = (await _unitsService.GetAllRolesForDepartmentAsync(DepartmentId)).ToDictionary(r => r.UnitRoleId);
+				var userRoleMap = await _personnelRolesService.GetAllRolesForUsersInDepartmentAsync(DepartmentId);
+
 				// Validate required qualifications BEFORE mutating anything -- the save path deletes existing
 				// assignments first, so blocking part-way through would lose data. A seat whose personnel role
 				// is "Required" blocks an unqualified member; a "Preferred" seat is allowed (the unit is then
@@ -211,13 +219,19 @@ namespace Resgrid.Web.Areas.User.Controllers
 					if (String.IsNullOrWhiteSpace(candidateUserId))
 						continue;
 
-					var roleToCheck = await _unitsService.GetRoleByIdAsync(unitRoleId);
+					if (!roleMap.TryGetValue(unitRoleId, out var roleToCheck) || roleToCheck == null
+						|| !roleToCheck.PersonnelRoleId.HasValue || !roleToCheck.PersonnelRoleRequired)
+						continue;
 
-					if (roleToCheck != null && roleToCheck.PersonnelRoleId.HasValue && roleToCheck.PersonnelRoleRequired
-						&& !await _unitsService.IsUserQualifiedForUnitRoleAsync(roleToCheck, candidateUserId, DepartmentId))
+					var candidateHoldsRole = userRoleMap != null
+						&& userRoleMap.TryGetValue(candidateUserId, out var candidateRoles)
+						&& candidateRoles != null
+						&& candidateRoles.Any(r => r != null && r.PersonnelRoleId == roleToCheck.PersonnelRoleId.Value);
+
+					if (!candidateHoldsRole)
 					{
 						var member = model.Users?.FirstOrDefault(u => u.UserId == candidateUserId);
-						var requiredRole = await _personnelRolesService.GetRoleByIdAsync(roleToCheck.PersonnelRoleId.Value);
+						var requiredRole = model.PersonnelRoles?.FirstOrDefault(p => p.PersonnelRoleId == roleToCheck.PersonnelRoleId.Value);
 						var unitName = model.Units?.FirstOrDefault(x => x.UnitId == roleToCheck.UnitId)?.Name;
 
 						ModelState.AddModelError("", $"{(member != null ? member.Name : "The selected member")} cannot be assigned to the \"{roleToCheck.Name}\" role on {unitName} because it requires the {(requiredRole != null ? requiredRole.Name : "required")} personnel role.");
@@ -238,9 +252,12 @@ namespace Resgrid.Web.Areas.User.Controllers
 
 					if (!String.IsNullOrWhiteSpace(unitRoleStaffingUserId))
 					{
-						var role = await _unitsService.GetRoleByIdAsync(unitRole);
-
-						if (role != null)
+						// Reuse the department-scoped roleMap loaded above instead of a per-role DB lookup. The map
+						// only contains this department's unit roles, and the Role_ form keys are caller-supplied,
+						// so a role absent from the map (or belonging to a unit outside this department) is rejected;
+						// otherwise a caller could inject an active-role assignment onto another department's unit.
+						if (roleMap.TryGetValue(unitRole, out var role) && role != null
+							&& model.Units != null && model.Units.Any(u => u.UnitId == role.UnitId))
 						{
 							UnitActiveRole activeRole = new UnitActiveRole();
 							activeRole.UnitId = role.UnitId;

--- a/Web/Resgrid.Web/Areas/User/Controllers/UnitsController.cs
+++ b/Web/Resgrid.Web/Areas/User/Controllers/UnitsController.cs
@@ -49,11 +49,13 @@ namespace Resgrid.Web.Areas.User.Controllers
 		private readonly IUserDefinedFieldsService _userDefinedFieldsService;
 		private readonly IUdfRenderingService _udfRenderingService;
 		private readonly IStringLocalizer<Resgrid.Localization.Common> _localizer;
+		private readonly IPersonnelRolesService _personnelRolesService;
 
 		public UnitsController(IDepartmentsService departmentsService, IUsersService usersService, IUnitsService unitsService, Model.Services.IAuthorizationService authorizationService,
 			ILimitsService limitsService, IDepartmentGroupsService departmentGroupsService, ICallsService callsService, IEventAggregator eventAggregator, ICustomStateService customStateService,
 			IGeoService geoService, IDepartmentSettingsService departmentSettingsService, IGeoLocationProvider geoLocationProvider, INovuProvider novuProvider, IMappingService mappingService,
-			IUserDefinedFieldsService userDefinedFieldsService, IUdfRenderingService udfRenderingService, IStringLocalizer<Resgrid.Localization.Common> localizer)
+			IUserDefinedFieldsService userDefinedFieldsService, IUdfRenderingService udfRenderingService, IStringLocalizer<Resgrid.Localization.Common> localizer,
+			IPersonnelRolesService personnelRolesService)
 		{
 			_departmentsService = departmentsService;
 			_usersService = usersService;
@@ -72,6 +74,7 @@ namespace Resgrid.Web.Areas.User.Controllers
 			_userDefinedFieldsService = userDefinedFieldsService;
 			_udfRenderingService = udfRenderingService;
 			_localizer = localizer;
+			_personnelRolesService = personnelRolesService;
 		}
 		#endregion Private Members and Constructors
 
@@ -174,6 +177,8 @@ namespace Resgrid.Web.Areas.User.Controllers
 			model.Units = await _unitsService.GetUnitsForDepartmentAsync(DepartmentId);
 			model.Users = await _usersService.GetUserGroupAndRolesByDepartmentIdInLimitAsync(DepartmentId, false, false, false);
 			model.ActiveRoles = await _unitsService.GetAllActiveRolesForUnitsByDepartmentIdAsync(DepartmentId);
+			model.PersonnelRoles = await _personnelRolesService.GetAllRolesForDepartmentAsync(DepartmentId);
+			model.UnitStaffing = await _unitsService.GetUnitStaffingForDepartmentAsync(DepartmentId);
 
 			return View(model);
 		}
@@ -185,6 +190,8 @@ namespace Resgrid.Web.Areas.User.Controllers
 			model.Units = await _unitsService.GetUnitsForDepartmentAsync(DepartmentId);
 			model.Users = await _usersService.GetUserGroupAndRolesByDepartmentIdInLimitAsync(DepartmentId, false, false, false);
 			model.ActiveRoles = await _unitsService.GetAllActiveRolesForUnitsByDepartmentIdAsync(DepartmentId);
+			model.PersonnelRoles = await _personnelRolesService.GetAllRolesForDepartmentAsync(DepartmentId);
+			model.UnitStaffing = await _unitsService.GetUnitStaffingForDepartmentAsync(DepartmentId);
 
 
 			if (ModelState.IsValid)
@@ -192,6 +199,33 @@ namespace Resgrid.Web.Areas.User.Controllers
 				List<int> unitRoles = (from object key in form.Keys
 									   where key.ToString().StartsWith("Role_")
 									   select int.Parse(key.ToString().Replace("Role_", ""))).ToList();
+
+				// Validate required qualifications BEFORE mutating anything -- the save path deletes existing
+				// assignments first, so blocking part-way through would lose data. A seat whose personnel role
+				// is "Required" blocks an unqualified member; a "Preferred" seat is allowed (the unit is then
+				// reported as degraded rather than blocked).
+				foreach (var unitRoleId in unitRoles)
+				{
+					var candidateUserId = form[$"Role_{unitRoleId}"];
+
+					if (String.IsNullOrWhiteSpace(candidateUserId))
+						continue;
+
+					var roleToCheck = await _unitsService.GetRoleByIdAsync(unitRoleId);
+
+					if (roleToCheck != null && roleToCheck.PersonnelRoleId.HasValue && roleToCheck.PersonnelRoleRequired
+						&& !await _unitsService.IsUserQualifiedForUnitRoleAsync(roleToCheck, candidateUserId, DepartmentId))
+					{
+						var member = model.Users?.FirstOrDefault(u => u.UserId == candidateUserId);
+						var requiredRole = await _personnelRolesService.GetRoleByIdAsync(roleToCheck.PersonnelRoleId.Value);
+						var unitName = model.Units?.FirstOrDefault(x => x.UnitId == roleToCheck.UnitId)?.Name;
+
+						ModelState.AddModelError("", $"{(member != null ? member.Name : "The selected member")} cannot be assigned to the \"{roleToCheck.Name}\" role on {unitName} because it requires the {(requiredRole != null ? requiredRole.Name : "required")} personnel role.");
+					}
+				}
+
+				if (!ModelState.IsValid)
+					return View(model);
 
 				foreach (var unit in model.Units)
 				{
@@ -227,6 +261,44 @@ namespace Resgrid.Web.Areas.User.Controllers
 			return View(model);
 		}
 
+		/// <summary>
+		/// Builds the list of unit roles from the New/Edit unit form, including each role's optional required
+		/// personnel qualification (unitRolePersonnelRole_N) and whether it is a hard requirement
+		/// (unitRoleRequired_N). Roles are keyed by the "unitRole_N" suffix so each role stays paired with
+		/// its qualification fields.
+		/// </summary>
+		private List<UnitRole> ParseUnitRolesFromForm(IFormCollection form, int unitId)
+		{
+			var roles = new List<UnitRole>();
+
+			foreach (var key in form.Keys.Where(k => k.StartsWith("unitRole_")))
+			{
+				var roleName = form[key].ToString();
+
+				if (String.IsNullOrWhiteSpace(roleName))
+					continue;
+
+				var suffix = key.Substring("unitRole_".Length);
+
+				var role = new UnitRole();
+				role.Name = roleName;
+				role.UnitId = unitId;
+
+				var personnelRoleValue = form[$"unitRolePersonnelRole_{suffix}"].ToString();
+				if (!String.IsNullOrWhiteSpace(personnelRoleValue) && int.TryParse(personnelRoleValue, out var personnelRoleId) && personnelRoleId > 0)
+				{
+					role.PersonnelRoleId = personnelRoleId;
+
+					var requiredValue = form[$"unitRoleRequired_{suffix}"].ToString();
+					role.PersonnelRoleRequired = requiredValue == "on" || requiredValue == "true";
+				}
+
+				roles.Add(role);
+			}
+
+			return roles;
+		}
+
 		[HttpGet]
 		[Authorize(Policy = ResgridResources.Unit_Create)]
 		public async Task<IActionResult> NewUnit()
@@ -242,6 +314,8 @@ namespace Resgrid.Web.Areas.User.Controllers
 			});
 			states.AddRange(await _customStateService.GetAllActiveUnitStatesForDepartmentAsync(DepartmentId));
 			model.States = states;
+
+			model.PersonnelRoles = await _personnelRolesService.GetAllRolesForDepartmentAsync(DepartmentId);
 
 			var groups = new List<DepartmentGroup>();
 			groups.Add(new DepartmentGroup
@@ -296,18 +370,7 @@ namespace Resgrid.Web.Areas.User.Controllers
 
 				model.Unit = await _unitsService.SaveUnitAsync(model.Unit, cancellationToken);
 
-				var roles = new List<UnitRole>();
-				if (unitRoleNames.Count > 0)
-				{
-					foreach (var roleName in unitRoleNames)
-					{
-						var role = new UnitRole();
-						role.Name = roleName;
-						role.UnitId = model.Unit.UnitId;
-
-						roles.Add(role);
-					}
-				}
+				var roles = ParseUnitRolesFromForm(form, model.Unit.UnitId);
 
 				if (roles.Count > 0)
 					await _unitsService.SetRolesForUnitAsync(model.Unit.UnitId, roles, cancellationToken);
@@ -423,6 +486,7 @@ namespace Resgrid.Web.Areas.User.Controllers
 			model.Stations = groups;
 
 			model.UnitRoles = await _unitsService.GetRolesForUnitAsync(unitId);
+			model.PersonnelRoles = await _personnelRolesService.GetAllRolesForDepartmentAsync(DepartmentId);
 
 			var department = await _departmentsService.GetDepartmentByIdAsync(DepartmentId);
 			await _novuProvider.CreateUnitSubscriber(model.Unit.UnitId, department.Code, DepartmentId, model.Unit.Name, null);
@@ -494,18 +558,7 @@ namespace Resgrid.Web.Areas.User.Controllers
 			{
 				await _unitsService.SaveUnitAsync(unit, cancellationToken);
 
-				var roles = new List<UnitRole>();
-				if (unitRoleNames.Count > 0)
-				{
-					foreach (var roleName in unitRoleNames)
-					{
-						var role = new UnitRole();
-						role.Name = roleName;
-						role.UnitId = unit.UnitId;
-
-						roles.Add(role);
-					}
-				}
+				var roles = ParseUnitRolesFromForm(form, unit.UnitId);
 
 				if (roles.Count > 0)
 					await _unitsService.SetRolesForUnitAsync(unit.UnitId, roles, cancellationToken);

--- a/Web/Resgrid.Web/Areas/User/Models/CustomStatuses/CustomStateTemplatesView.cs
+++ b/Web/Resgrid.Web/Areas/User/Models/CustomStatuses/CustomStateTemplatesView.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using Resgrid.Model;
+using Resgrid.Model.CustomStates;
+
+namespace Resgrid.Web.Areas.User.Models.CustomStatuses
+{
+	public class CustomStateTemplatesView
+	{
+		public CustomStateTypes Type { get; set; }
+
+		public IReadOnlyList<CustomStateTemplate> Templates { get; set; } = new List<CustomStateTemplate>();
+	}
+}

--- a/Web/Resgrid.Web/Areas/User/Models/Units/NewUnitView.cs
+++ b/Web/Resgrid.Web/Areas/User/Models/Units/NewUnitView.cs
@@ -12,5 +12,6 @@ namespace Resgrid.Web.Areas.User.Models.Units
 		public List<DepartmentGroup> Stations { get; set; }
 		public List<UnitRole> UnitRoles { get; set; }
 		public List<CustomState> States { get; set; }
+		public List<PersonnelRole> PersonnelRoles { get; set; }
 	}
 }

--- a/Web/Resgrid.Web/Areas/User/Models/Units/UnitStaffingView.cs
+++ b/Web/Resgrid.Web/Areas/User/Models/Units/UnitStaffingView.cs
@@ -13,6 +13,37 @@ namespace Resgrid.WebCore.Areas.User.Models.Units
 		public List<Unit> Units { get; set; }
 		public List<UserGroupRole> Users { get; set; }
 		public List<UnitActiveRole> ActiveRoles { get; set; }
+		public List<PersonnelRole> PersonnelRoles { get; set; }
+		public Dictionary<int, UnitRoleStaffingResult> UnitStaffing { get; set; }
+
+		/// <summary>Returns the display name of a personnel role by id, or null.</summary>
+		public string GetPersonnelRoleName(int? personnelRoleId)
+		{
+			if (!personnelRoleId.HasValue || PersonnelRoles == null)
+				return null;
+
+			return PersonnelRoles.FirstOrDefault(x => x.PersonnelRoleId == personnelRoleId.Value)?.Name;
+		}
+
+		/// <summary>Returns the computed staffing result for a unit, or null if not available.</summary>
+		public UnitRoleStaffingResult GetStaffingForUnit(int unitId)
+		{
+			if (UnitStaffing != null && UnitStaffing.TryGetValue(unitId, out var result))
+				return result;
+
+			return null;
+		}
+
+		/// <summary>Does the given member currently hold the given personnel role? (drives the UI warning)</summary>
+		public bool DoesUserHoldPersonnelRole(string userId, int personnelRoleId)
+		{
+			if (string.IsNullOrWhiteSpace(userId) || Users == null)
+				return false;
+
+			var user = Users.FirstOrDefault(x => x.UserId == userId);
+
+			return user != null && user.RoleList != null && user.RoleList.Contains(personnelRoleId);
+		}
 
 		public int GetTotalRoles()
 		{

--- a/Web/Resgrid.Web/Areas/User/Views/CustomStatuses/Edit.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/CustomStatuses/Edit.cshtml
@@ -180,7 +180,20 @@
                                 <option value="8">@localizer["Returning"]</option>
                                 <option value="9">@localizer["Staging"]</option>
                                 <option value="10">@localizer["Unavailable"]</option>
+                                <option value="11">@localizer["Enroute"]</option>
+                                <option value="12">@localizer["Transporting"]</option>
+                                <option value="13">@localizer["Delivering"]</option>
+                                <option value="14">@localizer["AtPatient"]</option>
+                                <option value="15">@localizer["AtHospital"]</option>
+                                <option value="16">@localizer["Searching"]</option>
+                                <option value="17">@localizer["Loading"]</option>
+                                <option value="18">@localizer["Standby"]</option>
+                                <option value="19">@localizer["OnPatrol"]</option>
+                                <option value="20">@localizer["Maintenance"]</option>
+                                <option value="21">@localizer["OnBreak"]</option>
+                                <option value="22">@localizer["Completed"]</option>
                             </select>
+                            @await Html.PartialAsync("_BaseTypeDescription", "baseType")
                         </div>
                     }
 

--- a/Web/Resgrid.Web/Areas/User/Views/CustomStatuses/EditDetail.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/CustomStatuses/EditDetail.cshtml
@@ -61,7 +61,10 @@
 						{
 							<div class="form-group">
 								<label class="col-sm-2 control-label">@localizer["BaseType"]</label>
-								<div class="col-sm-10">@Html.DropDownListFor(m => m.BaseType, Model.DetailTypes)</div>
+								<div class="col-sm-10">
+									@Html.DropDownListFor(m => m.BaseType, Model.BaseTypes)
+									@await Html.PartialAsync("_BaseTypeDescription", "BaseType")
+								</div>
 							</div>
 						}
 

--- a/Web/Resgrid.Web/Areas/User/Views/CustomStatuses/Index.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/CustomStatuses/Index.cshtml
@@ -28,7 +28,7 @@
           <h5>@localizer["CurrentUnitStatusesHeader"]</h5>
           <div class="ibox-tools">
             <div class="buttons-actions">
-              <a title="Add a new Custom Unit Statuses" class="btn btn-success" asp-controller="CustomStatuses" asp-action="New" asp-route-area="User" asp-route-type="2">Add Unit Statuses</a>
+              <a title="Add a new Custom Unit Statuses" class="btn btn-success" asp-controller="CustomStatuses" asp-action="Templates" asp-route-area="User" asp-route-type="2">Add Unit Statuses</a>
             </div>
           </div>
         </div>
@@ -119,7 +119,7 @@
               <div class="col-sm-4 col-sm-offset-2">
                 @if (Model.PersonnelStatuses == null)
                 {
-                  <a class="btn btn-success" asp-controller="CustomStatuses" asp-action="New" asp-route-area="User" asp-route-type="1">@localizer["SetCustomStatuses"]</a>
+                  <a class="btn btn-success" asp-controller="CustomStatuses" asp-action="Templates" asp-route-area="User" asp-route-type="1">@localizer["SetCustomStatuses"]</a>
                 }
                 else
                 {
@@ -159,7 +159,7 @@
               <div class="col-sm-4 col-sm-offset-2">
                 @if (Model.PersonellStaffing == null)
                 {
-                  <a class="btn btn-success" asp-controller="CustomStatuses" asp-action="New" asp-route-area="User" asp-route-type="3">@localizer["SetCustomStaffingLevels"]</a>
+                  <a class="btn btn-success" asp-controller="CustomStatuses" asp-action="Templates" asp-route-area="User" asp-route-type="3">@localizer["SetCustomStaffingLevels"]</a>
                 }
                 else
                 {

--- a/Web/Resgrid.Web/Areas/User/Views/CustomStatuses/New.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/CustomStatuses/New.cshtml
@@ -78,6 +78,16 @@
                                 <div class="row">
                                     <div class="col-xs-10">@localizer["ButtonsHelp"]<br /></div>
                                 </div>
+                                @if (Model.State.GetActiveDetails().Count > 0)
+                                {
+                                    <div class="row">
+                                        <div class="col-xs-10">
+                                            <div class="alert alert-info" style="margin-top: 8px;">
+                                                These options were pre-filled from a template. Rename the text, change colors, remove any you don't need, or add your own &mdash; nothing is saved until you click Add.
+                                            </div>
+                                        </div>
+                                    </div>
+                                }
                                 <div class="row">
                                     <div class="col-xs-12">
                                         <table id="options" class="table table-striped table-bordered">
@@ -89,7 +99,31 @@
                                                     <th style="max-width: 90px; font-size: 16px;"><a id="addButton" class="btn btn-success btn-xs" data-original-title="@localizer["AddOption"]" data-toggle="modal" data-target="#newStatusModal">@localizer["AddOption"]</a></th>
                                                 </tr>
                                             </thead>
-                                            <tbody></tbody>
+                                            <tbody>
+                                                @{
+                                                    int count = 0;
+                                                }
+                                                @foreach (var detail in Model.State.GetActiveDetails())
+                                                {
+                                                    count++;
+                                                    <tr>
+                                                        <td><input type='number' min='0' id='order_@count' name='order_@count' value='@detail.Order' onkeypress='return resgrid.statuses.newstatus.isNumber(event)'></td>
+                                                        <td><input type='text' class='form-control' id='buttonText_@count' name='buttonText_@count' value='@detail.ButtonText' maxlength='50'></td>
+                                                        <td>
+                                                            <a class="btn btn-default rowPreview" role="button" style="color: @detail.TextColor; background: @detail.ButtonColor;">@detail.ButtonText</a>
+                                                            <label style="font-weight: normal; margin: 0 6px;">Bg <input type='color' id='buttonColor_@count' name='buttonColor_@count' value='@detail.ButtonColor'></label>
+                                                            <label style="font-weight: normal; margin: 0 6px;">Text <input type='color' id='textColor_@count' name='textColor_@count' value='@detail.TextColor'></label>
+                                                            <input type='hidden' id='detailType_@count' name='detailType_@count' value='@detail.DetailType'>
+                                                            <input type='hidden' id='noteType_@count' name='noteType_@count' value='@detail.NoteType'>
+                                                            <input type='hidden' id='requireGps_@count' name='requireGps_@count' value='@(detail.GpsRequired ? "on" : "false")'>
+                                                            <input type='hidden' id='baseType_@count' name='baseType_@count' value='@detail.BaseType'>
+                                                        </td>
+                                                        <td style='text-align: center;'>
+                                                            <a onclick='$(this).closest("tr").remove();' class="btn btn-xs btn-danger" data-original-title='Remove this option'>@commonLocalizer["Delete"]</a>
+                                                        </td>
+                                                    </tr>
+                                                }
+                                            </tbody>
                                         </table>
                                     </div>
                                 </div>
@@ -153,7 +187,20 @@
                                 <option value="8">@localizer["Returning"]</option>
                                 <option value="9">@localizer["Staging"]</option>
                                 <option value="10">@localizer["Unavailable"]</option>
+                                <option value="11">@localizer["Enroute"]</option>
+                                <option value="12">@localizer["Transporting"]</option>
+                                <option value="13">@localizer["Delivering"]</option>
+                                <option value="14">@localizer["AtPatient"]</option>
+                                <option value="15">@localizer["AtHospital"]</option>
+                                <option value="16">@localizer["Searching"]</option>
+                                <option value="17">@localizer["Loading"]</option>
+                                <option value="18">@localizer["Standby"]</option>
+                                <option value="19">@localizer["OnPatrol"]</option>
+                                <option value="20">@localizer["Maintenance"]</option>
+                                <option value="21">@localizer["OnBreak"]</option>
+                                <option value="22">@localizer["Completed"]</option>
                             </select>
+                            @await Html.PartialAsync("_BaseTypeDescription", "baseType")
                         </div>
                     }
 
@@ -223,4 +270,23 @@
 @section Scripts
 {
     <script src="~/js/app/internal/statuses/resgrid.statuses.newstatus.js"></script>
+    <script>
+        // When pre-filled from a template the option rows are rendered server-side; start the option
+        // counter after them so newly added options don't collide with the seeded rows.
+        resgrid.statuses.newstatus.optionsCount = '@Model.State.GetActiveDetails().Count';
+
+        // Live-preview editing of pre-filled (template) rows: renaming the text or picking new colors
+        // updates that row's preview button in place.
+        $(function () {
+            $('#options').on('input', 'input[name^="buttonText_"]', function () {
+                $(this).closest('tr').find('.rowPreview').text($(this).val());
+            });
+            $('#options').on('input', 'input[name^="buttonColor_"]', function () {
+                $(this).closest('tr').find('.rowPreview').css('background', $(this).val());
+            });
+            $('#options').on('input', 'input[name^="textColor_"]', function () {
+                $(this).closest('tr').find('.rowPreview').css('color', $(this).val());
+            });
+        });
+    </script>
 }

--- a/Web/Resgrid.Web/Areas/User/Views/CustomStatuses/Templates.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/CustomStatuses/Templates.cshtml
@@ -1,0 +1,123 @@
+@using Resgrid.Model
+@model Resgrid.Web.Areas.User.Models.CustomStatuses.CustomStateTemplatesView
+@inject IStringLocalizer<Resgrid.Localization.Areas.User.CustomStatuses.CustomStatuses> localizer
+@{
+	ViewBag.Title = "Resgrid | Custom Status Templates";
+
+	string typeName = Model.Type == CustomStateTypes.Unit
+		? "Unit"
+		: Model.Type == CustomStateTypes.Personnel ? "Personnel" : "Staffing";
+}
+
+<div class="row wrapper border-bottom white-bg page-heading">
+	<div class="col-sm-8">
+		<h2>@typeName Status Templates</h2>
+		<ol class="breadcrumb">
+			<li>
+				<a asp-controller="Home" asp-action="Dashboard" asp-route-area="User">@commonLocalizer["HomeModule"]</a>
+			</li>
+			<li>
+				<a asp-controller="CustomStatuses" asp-action="Index" asp-route-area="User">@localizer["CustomStatusesHeader"]</a>
+			</li>
+			<li class="active">
+				<strong>@typeName Templates</strong>
+			</li>
+		</ol>
+	</div>
+</div>
+
+<div class="wrapper wrapper-content">
+	<div class="row">
+		<div class="col-lg-12">
+			<div class="ibox float-e-margins">
+				<div class="ibox-title">
+					<h5>Choose a starting point for your @typeName.ToLower() statuses</h5>
+					<div class="ibox-tools">
+						<a class="btn btn-white btn-sm" asp-controller="CustomStatuses" asp-action="New" asp-route-area="User" asp-route-type="@((int)Model.Type)">
+							<i class="fa fa-file-o"></i> Start from Blank
+						</a>
+					</div>
+				</div>
+				<div class="ibox-content">
+					<p>
+						Pick a predefined set below and we'll pre-fill the options for you. You can rename the text, change colors,
+						remove options you don't need or add your own before saving &mdash; nothing is saved until you click Add.
+						Prefer to build your own? Use <strong>Start from Blank</strong>.
+					</p>
+
+					<div class="input-group" style="max-width: 420px; margin-bottom: 18px;">
+						<span class="input-group-addon"><i class="fa fa-search"></i></span>
+						<input type="text" id="templateSearch" class="form-control" placeholder="Search templates (e.g. EMS, patrol, delivery)..." autocomplete="off" />
+					</div>
+
+					<div class="row" id="templateGrid">
+						@foreach (var template in Model.Templates)
+						{
+							<div class="col-md-6 col-lg-4 template-card" data-search="@template.SearchText">
+								<div class="ibox">
+									<div class="ibox-content" style="min-height: 260px;">
+										<div class="clearfix" style="margin-bottom: 6px;">
+											<h3 style="display: inline-block; margin: 0;">@template.Name</h3>
+											<span class="label label-primary pull-right">@template.Category</span>
+										</div>
+										<p class="text-muted" style="min-height: 54px;">@template.Description</p>
+
+										<div style="margin-bottom: 12px;">
+											@foreach (var detail in template.Details)
+											{
+												<span class="btn btn-xs" style="margin: 0 4px 6px 0; cursor: default; color: @detail.TextColor; background: @detail.ButtonColor;">@detail.ButtonText</span>
+											}
+										</div>
+
+										<div class="clearfix">
+											<small class="text-muted pull-left" style="line-height: 30px;">@template.ButtonCount options</small>
+											<a class="btn btn-primary btn-sm pull-right"
+											   asp-controller="CustomStatuses" asp-action="New" asp-route-area="User"
+											   asp-route-type="@((int)Model.Type)" asp-route-templateId="@template.Id">
+												Use this template
+											</a>
+										</div>
+									</div>
+								</div>
+							</div>
+						}
+					</div>
+
+					<div id="noTemplateResults" class="alert alert-warning" style="display: none;">
+						No templates match your search. Try a different term, or <a asp-controller="CustomStatuses" asp-action="New" asp-route-area="User" asp-route-type="@((int)Model.Type)">start from blank</a>.
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+
+@section Scripts
+{
+	<script>
+		(function () {
+			var input = document.getElementById('templateSearch');
+			var cards = Array.prototype.slice.call(document.querySelectorAll('#templateGrid .template-card'));
+			var noResults = document.getElementById('noTemplateResults');
+
+			function applyFilter() {
+				var q = (input.value || '').toLowerCase().trim();
+				var terms = q.length ? q.split(/[\s,]+/) : [];
+				var visible = 0;
+
+				cards.forEach(function (card) {
+					var haystack = card.getAttribute('data-search') || '';
+					var match = terms.every(function (t) { return haystack.indexOf(t) !== -1; });
+					card.style.display = match ? '' : 'none';
+					if (match) { visible++; }
+				});
+
+				noResults.style.display = visible === 0 ? '' : 'none';
+			}
+
+			if (input) {
+				input.addEventListener('input', applyFilter);
+			}
+		})();
+	</script>
+}

--- a/Web/Resgrid.Web/Areas/User/Views/CustomStatuses/_BaseTypeDescription.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/CustomStatuses/_BaseTypeDescription.cshtml
@@ -18,7 +18,7 @@
 <script>
 	(function () {
 		window.resgridBaseTypeDescriptions = window.resgridBaseTypeDescriptions || (function () {
-			var d = {
+			const d = {
 				none: "No system meaning. The status is informational only and does not affect availability, reporting or automations.",
 				available: "The unit or responder is in service and available to be assigned or dispatched to a call or task.",
 				notresponding: "The responder has acknowledged but is declining or is unable to respond to the current assignment.",
@@ -46,21 +46,21 @@
 			};
 
 			// Add numeric aliases that match the ActionBaseTypes enum values (None = -1, Available = 0, ...).
-			var order = ["none", "available", "notresponding", "responding", "onscene", "madecontact",
+			const order = ["none", "available", "notresponding", "responding", "onscene", "madecontact",
 				"investigating", "dispatched", "cleared", "returning", "staging", "unavailable",
 				"enroute", "transporting", "delivering", "atpatient", "athospital", "searching",
 				"loading", "standby", "onpatrol", "maintenance", "onbreak", "completed"];
-			for (var i = 0; i < order.length; i++) {
+			for (let i = 0; i < order.length; i++) {
 				d[String(i - 1)] = d[order[i]];
 			}
 			return d;
 		})();
 
-		var sel = document.getElementById("@selectId");
-		var out = document.getElementById("@descId");
+		const sel = document.getElementById("@selectId");
+		const out = document.getElementById("@descId");
 		if (sel && out) {
-			var render = function () {
-				var key = String(sel.value == null ? "" : sel.value).toLowerCase();
+			const render = function () {
+				const key = String(sel.value == null ? "" : sel.value).toLowerCase();
 				out.textContent = window.resgridBaseTypeDescriptions[key] || "";
 			};
 			sel.addEventListener("change", render);

--- a/Web/Resgrid.Web/Areas/User/Views/CustomStatuses/_BaseTypeDescription.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/CustomStatuses/_BaseTypeDescription.cshtml
@@ -1,0 +1,70 @@
+@*
+	Renders a live, user-facing description of the currently selected Custom State "Base Type".
+	The Base Type is how Resgrid understands what a custom status means at a system level (availability,
+	reporting, automations). Keep the descriptions below in sync with the [Description] attributes on
+	Resgrid.Model.ActionBaseTypes.
+
+	Usage: @await Html.PartialAsync("_BaseTypeDescription", "baseType")
+	where the model is the DOM id of the <select> element that holds the base type value. The select
+	options may be keyed either by the numeric enum value (-1..22) or by the enum member name
+	(e.g. "Transporting"); both are supported.
+*@
+@model string
+@{
+	var selectId = string.IsNullOrWhiteSpace(Model) ? "baseType" : Model;
+	var descId = selectId + "_baseTypeDescription";
+}
+<div id="@descId" class="help-block base-type-description" style="margin-top: 6px; font-style: italic;"></div>
+<script>
+	(function () {
+		window.resgridBaseTypeDescriptions = window.resgridBaseTypeDescriptions || (function () {
+			var d = {
+				none: "No system meaning. The status is informational only and does not affect availability, reporting or automations.",
+				available: "The unit or responder is in service and available to be assigned or dispatched to a call or task.",
+				notresponding: "The responder has acknowledged but is declining or is unable to respond to the current assignment.",
+				responding: "The unit or responder is actively responding (en route) to an assigned call or incident.",
+				onscene: "The unit or responder has arrived and is operating at the scene of a call or incident.",
+				madecontact: "The unit or responder has made contact with the subject, patient, party or point of interest.",
+				investigating: "The unit or responder is investigating, assessing or sizing up the situation.",
+				dispatched: "The unit or responder has been dispatched or assigned but has not yet begun responding.",
+				cleared: "The unit or responder has cleared the call or incident and is returning to an available state.",
+				returning: "The unit or responder is returning to quarters, station or base.",
+				staging: "The unit or responder is staged at a safe location awaiting assignment or orders.",
+				unavailable: "The unit or responder is out of service and unavailable for assignment.",
+				enroute: "The unit or responder is traveling to an assignment, destination or location on a routine (non-emergency) basis.",
+				transporting: "The unit or responder is actively transporting a patient, subject, prisoner or cargo to a destination.",
+				delivering: "The unit or responder is actively delivering goods, supplies, equipment or commodities to a recipient or drop-off point.",
+				atpatient: "The unit or responder has reached and is providing care to, or is in contact with, a patient or search subject.",
+				athospital: "The unit or responder has arrived at a hospital or receiving facility to transfer patient care.",
+				searching: "The unit or responder is conducting an active search of an assigned area, sector or grid.",
+				loading: "The unit or responder is loading or picking up cargo, supplies, equipment or a subject prior to transport.",
+				standby: "The unit or responder is held in reserve, on standby or on-call and ready to be assigned.",
+				onpatrol: "The unit or responder is actively patrolling an assigned area or beat while remaining available for dispatch.",
+				maintenance: "The unit or responder is out of service for maintenance, refueling, restocking, cleaning or servicing.",
+				onbreak: "The unit or responder is on a rest, meal or crew-rest break and is temporarily unavailable.",
+				completed: "The assignment, task or delivery is complete; the unit or responder is wrapping up and becoming available."
+			};
+
+			// Add numeric aliases that match the ActionBaseTypes enum values (None = -1, Available = 0, ...).
+			var order = ["none", "available", "notresponding", "responding", "onscene", "madecontact",
+				"investigating", "dispatched", "cleared", "returning", "staging", "unavailable",
+				"enroute", "transporting", "delivering", "atpatient", "athospital", "searching",
+				"loading", "standby", "onpatrol", "maintenance", "onbreak", "completed"];
+			for (var i = 0; i < order.length; i++) {
+				d[String(i - 1)] = d[order[i]];
+			}
+			return d;
+		})();
+
+		var sel = document.getElementById("@selectId");
+		var out = document.getElementById("@descId");
+		if (sel && out) {
+			var render = function () {
+				var key = String(sel.value == null ? "" : sel.value).toLowerCase();
+				out.textContent = window.resgridBaseTypeDescriptions[key] || "";
+			};
+			sel.addEventListener("change", render);
+			render();
+		}
+	})();
+</script>

--- a/Web/Resgrid.Web/Areas/User/Views/Units/EditUnit.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Units/EditUnit.cshtml
@@ -73,7 +73,9 @@
                                     <thead style="font-size: 14px;">
                                         <tr>
                                             <th style="font-size: 14px;">@localizer["RoleNameHeader"]</th>
-                                            <th style="font-size: 16px;"><a id="addRoleButton" onclick="resgrid.units.editunit.addRole();" class="btn btn-xs btn-success" style="float:right;" data-original-title="@localizer["AddRole"]">@localizer["AddRole"]</a></th>
+                                            <th style="font-size: 14px;">Required Personnel Role</th>
+                                            <th style="font-size: 14px; text-align:center;">Required?</th>
+                                            <th style="font-size: 16px;"><a id="addRoleButton" onclick="resgrid.units.editunit.addRole();" class="btn btn-xs btn-success" style="float:right;" data-original-title="@localizer["AddRole"]">@localizer["AddRole"]</a><a class="btn btn-xs btn-info" style="float:right; margin-right: 6px;" data-toggle="modal" data-target="#unitRoleTemplatesModal"><i class="fa fa-list-alt"></i> Browse Templates</a></th>
                                         </tr>
                                     </thead>
                                     <tbody>
@@ -82,7 +84,33 @@
                                             unitCount++;
                                             <tr>
                                                 <td><input id='unitRole_@unitCount' name='unitRole_@unitCount' style='width:100%;' value="@role.Name"></td>
-                                                <td style='text-align:center;'><a onclick='$(this).parent().parent().remove();' class='btn btn-xs btn-danger' data-original-title='@localizer["RemoveThisRole"]'>@commonLocalizer["Remove"]</a></td>
+                                                <td>
+                                                    <select id='unitRolePersonnelRole_@unitCount' name='unitRolePersonnelRole_@unitCount' style='width:100%;'>
+                                                        <option value="">-- None --</option>
+                                                        @foreach (var pr in Model.PersonnelRoles ?? new List<Resgrid.Model.PersonnelRole>())
+                                                        {
+                                                            if (role.PersonnelRoleId == pr.PersonnelRoleId)
+                                                            {
+                                                                <option value="@pr.PersonnelRoleId" selected>@pr.Name</option>
+                                                            }
+                                                            else
+                                                            {
+                                                                <option value="@pr.PersonnelRoleId">@pr.Name</option>
+                                                            }
+                                                        }
+                                                    </select>
+                                                </td>
+                                                <td style='text-align:center;'>
+                                                    @if (role.PersonnelRoleRequired)
+                                                    {
+                                                        <input type='checkbox' id='unitRoleRequired_@unitCount' name='unitRoleRequired_@unitCount' checked>
+                                                    }
+                                                    else
+                                                    {
+                                                        <input type='checkbox' id='unitRoleRequired_@unitCount' name='unitRoleRequired_@unitCount'>
+                                                    }
+                                                </td>
+                                                <td style='text-align:center;'><a onclick='$(this).closest("tr").remove();' class='btn btn-xs btn-danger' data-original-title='@localizer["RemoveThisRole"]'>@commonLocalizer["Remove"]</a></td>
                                             </tr>
                                         }
                                     </tbody>
@@ -111,10 +139,16 @@
     </div>
 </div>
 
+@await Html.PartialAsync("_UnitRoleTemplatesModal", Model.PersonnelRoles)
+
 @section Scripts
     {
     <script>
         var count = @(unitCount);
     </script>
     <script src="~/js/app/internal/units/resgrid.units.editunit.js"></script>
+    <script>
+        // Personnel roles (qualifications) available to require on a unit role.
+        resgrid.units.editunit.personnelRoles = @Json.Serialize((Model.PersonnelRoles ?? new List<Resgrid.Model.PersonnelRole>()).Select(x => new { id = x.PersonnelRoleId, name = x.Name }));
+    </script>
 }

--- a/Web/Resgrid.Web/Areas/User/Views/Units/EditUnit.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Units/EditUnit.cshtml
@@ -73,8 +73,8 @@
                                     <thead style="font-size: 14px;">
                                         <tr>
                                             <th style="font-size: 14px;">@localizer["RoleNameHeader"]</th>
-                                            <th style="font-size: 14px;">Required Personnel Role</th>
-                                            <th style="font-size: 14px; text-align:center;">Required?</th>
+                                            <th style="font-size: 14px;">@localizer["RequiredPersonnelRoleHeader"]</th>
+                                            <th style="font-size: 14px; text-align:center;">@localizer["RequiredHeader"]</th>
                                             <th style="font-size: 16px;"><a id="addRoleButton" onclick="resgrid.units.editunit.addRole();" class="btn btn-xs btn-success" style="float:right;" data-original-title="@localizer["AddRole"]">@localizer["AddRole"]</a><a class="btn btn-xs btn-info" style="float:right; margin-right: 6px;" data-toggle="modal" data-target="#unitRoleTemplatesModal"><i class="fa fa-list-alt"></i> Browse Templates</a></th>
                                         </tr>
                                     </thead>
@@ -144,7 +144,7 @@
 @section Scripts
     {
     <script>
-        var count = @(unitCount);
+        resgrid.units.roleCounter.seed(@(unitCount));
     </script>
     <script src="~/js/app/internal/units/resgrid.units.editunit.js"></script>
     <script>

--- a/Web/Resgrid.Web/Areas/User/Views/Units/NewUnit.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Units/NewUnit.cshtml
@@ -68,8 +68,8 @@
 									<thead style="font-size: 14px;">
 										<tr>
 											<th style="font-size: 14px;">@localizer["RoleName"]</th>
-											<th style="font-size: 14px;">Required Personnel Role</th>
-											<th style="font-size: 14px; text-align:center;">Required?</th>
+											<th style="font-size: 14px;">@localizer["RequiredPersonnelRoleHeader"]</th>
+											<th style="font-size: 14px; text-align:center;">@localizer["RequiredHeader"]</th>
 											<th style="font-size: 16px;"><a id="addRoleButton" onclick="resgrid.units.newunit.addRole();" class="btn btn-xs btn-success" style="float:right;" data-original-title="@localizer["AddRole"]">@localizer["AddRole"]</a><a class="btn btn-xs btn-info" style="float:right; margin-right: 6px;" data-toggle="modal" data-target="#unitRoleTemplatesModal"><i class="fa fa-list-alt"></i> Browse Templates</a></th>
 										</tr>
 									</thead>

--- a/Web/Resgrid.Web/Areas/User/Views/Units/NewUnit.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Units/NewUnit.cshtml
@@ -68,7 +68,9 @@
 									<thead style="font-size: 14px;">
 										<tr>
 											<th style="font-size: 14px;">@localizer["RoleName"]</th>
-											<th style="font-size: 16px;"><a id="addRoleButton" onclick="resgrid.units.newunit.addRole();" class="btn btn-xs btn-success" style="float:right;" data-original-title="@localizer["AddRole"]">@localizer["AddRole"]</a></th>
+											<th style="font-size: 14px;">Required Personnel Role</th>
+											<th style="font-size: 14px; text-align:center;">Required?</th>
+											<th style="font-size: 16px;"><a id="addRoleButton" onclick="resgrid.units.newunit.addRole();" class="btn btn-xs btn-success" style="float:right;" data-original-title="@localizer["AddRole"]">@localizer["AddRole"]</a><a class="btn btn-xs btn-info" style="float:right; margin-right: 6px;" data-toggle="modal" data-target="#unitRoleTemplatesModal"><i class="fa fa-list-alt"></i> Browse Templates</a></th>
 										</tr>
 									</thead>
 									<tbody></tbody>
@@ -97,7 +99,13 @@
 	</div>
 </div>
 
+@await Html.PartialAsync("_UnitRoleTemplatesModal", Model.PersonnelRoles)
+
 @section Scripts
 {
 	<script src="~/js/app/internal/units/resgrid.units.newunit.js"></script>
+	<script>
+		// Personnel roles (qualifications) available to require on a unit role.
+		resgrid.units.newunit.personnelRoles = @Json.Serialize((Model.PersonnelRoles ?? new List<Resgrid.Model.PersonnelRole>()).Select(x => new { id = x.PersonnelRoleId, name = x.Name }));
+	</script>
 }

--- a/Web/Resgrid.Web/Areas/User/Views/Units/UnitStaffing.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Units/UnitStaffing.cshtml
@@ -261,7 +261,10 @@
                     try {
                         var roles = (JSON.parse(data).Roles || '').split(',').map(function (s) { return s.trim(); });
                         qualified = roles.indexOf(required) !== -1;
-                    } catch (e) { }
+                    } catch (e) {
+                        // Malformed option data -- leave qualified as false (safe default) so the warning shows.
+                        if (window.console) console.warn('Failed to parse personnel role data for qualification check', e);
+                    }
                 }
 
                 if (qualified) {

--- a/Web/Resgrid.Web/Areas/User/Views/Units/UnitStaffing.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Units/UnitStaffing.cshtml
@@ -5,6 +5,31 @@
     ViewBag.Title = "Resgrid | " + @localizer["UnitStaffingHeader"];
     Layout = "~/Areas/User/Views/Shared/_UserLayout.cshtml";
 }
+@functions {
+    static string StaffingLabelClass(Resgrid.Model.UnitStaffingLevel level)
+    {
+        switch (level)
+        {
+            case Resgrid.Model.UnitStaffingLevel.FullyStaffed: return "label-success";
+            case Resgrid.Model.UnitStaffingLevel.Degraded: return "label-warning";
+            case Resgrid.Model.UnitStaffingLevel.PartiallyStaffed: return "label-warning";
+            case Resgrid.Model.UnitStaffingLevel.NotStaffed: return "label-danger";
+            default: return "label-default";
+        }
+    }
+
+    static string StaffingLabelText(Resgrid.Model.UnitStaffingLevel level)
+    {
+        switch (level)
+        {
+            case Resgrid.Model.UnitStaffingLevel.FullyStaffed: return "Fully Staffed";
+            case Resgrid.Model.UnitStaffingLevel.Degraded: return "Degraded";
+            case Resgrid.Model.UnitStaffingLevel.PartiallyStaffed: return "Partially Staffed";
+            case Resgrid.Model.UnitStaffingLevel.NotStaffed: return "Not Staffed";
+            default: return "No Roles";
+        }
+    }
+}
 @section Styles
 {
     <style type="text/css">
@@ -114,17 +139,34 @@
                             {
                                 if (unit.Roles.Any())
                                 {
+                                    var staffing = Model.GetStaffingForUnit(unit.UnitId);
                                     <div class="form-group">
-                                        <label class="col-sm-2 control-label">@unit.Name</label>
+                                        <label class="col-sm-2 control-label">
+                                            @unit.Name
+                                            @if (staffing != null && staffing.HasDefinedRoles)
+                                            {
+                                                <br />
+                                                <span class="label @StaffingLabelClass(staffing.Level)" title="@staffing.Summary">@StaffingLabelText(staffing.Level)</span>
+                                            }
+                                        </label>
                                         <div class="col-sm-10" id="unitAssignments">
                                             @foreach (var role in unit.Roles)
                                             {
                                                 var activeRole = Model.ActiveRoles.FirstOrDefault(x => x.UnitId == role.UnitId && x.Role == role.Name);
+                                                var requiredRoleName = Model.GetPersonnelRoleName(role.PersonnelRoleId);
+                                                var currentUserQualified = activeRole == null || !role.PersonnelRoleId.HasValue || Model.DoesUserHoldPersonnelRole(activeRole.UserId, role.PersonnelRoleId.Value);
 
-                                                <div class="row">
-                                                    <div class="col-md-5">@role.Name</div>
+                                                <div class="row" style="margin-bottom: 6px;">
+                                                    <div class="col-md-5">
+                                                        @role.Name
+                                                        @if (!string.IsNullOrWhiteSpace(requiredRoleName))
+                                                        {
+                                                            <br />
+                                                            <small class="text-muted">Requires: @requiredRoleName @(role.PersonnelRoleRequired ? "(Required)" : "(Preferred)")</small>
+                                                        }
+                                                    </div>
                                                     <div class="col-md-7">
-                                                        <select id="Role_@role.UnitRoleId" name="Role_@role.UnitRoleId" class="selectize personnelDropdown" style="width:100%;">
+                                                        <select id="Role_@role.UnitRoleId" name="Role_@role.UnitRoleId" class="selectize personnelDropdown" style="width:100%;" data-required-role="@requiredRoleName" data-required="@(role.PersonnelRoleRequired ? "true" : "false")">
                                                             @if (activeRole == null)
                                                             {
                                                                 <option value="" selected>@localizer["NotOccupied"]</option>
@@ -145,6 +187,12 @@
                                                                 }
                                                             }
                                                         </select>
+                                                        <span class="help-block role-warning" style="@(currentUserQualified ? "display:none;" : "")color: @(role.PersonnelRoleRequired ? "#a94442" : "#8a6d3b");">
+                                                            @if (!currentUserQualified)
+                                                            {
+                                                                <text>Assigned member does not hold the @requiredRoleName role.</text>
+                                                            }
+                                                        </span>
                                                     </div>
                                                 </div>
                                             }
@@ -191,4 +239,47 @@
     }
 
     <script src="~/js/app/internal/units/resgrid.units.setstaffing.js" asp-append-version="true"></script>
+    <script>
+        // Live qualification warning: when a member is chosen for a seat that requires a personnel role
+        // they don't hold, surface a warning. Hard "required" seats are also blocked server-side on save.
+        $(function () {
+            function checkRoleQualification(el) {
+                var $sel = $(el);
+                var required = $sel.attr('data-required-role');
+                if (!required) return;
+
+                var isHard = $sel.attr('data-required') === 'true';
+                var $warning = $sel.closest('.col-md-7').find('.role-warning');
+                var val = $sel.val();
+
+                if (!val) { $warning.hide(); return; }
+
+                var qualified = false;
+                var opt = $sel.find('option[value="' + val + '"]');
+                var data = opt.attr('data-data');
+                if (data) {
+                    try {
+                        var roles = (JSON.parse(data).Roles || '').split(',').map(function (s) { return s.trim(); });
+                        qualified = roles.indexOf(required) !== -1;
+                    } catch (e) { }
+                }
+
+                if (qualified) {
+                    $warning.hide();
+                } else {
+                    $warning.css('color', isHard ? '#a94442' : '#8a6d3b')
+                        .text('Assigned member does not hold the ' + required + (isHard ? ' role (required).' : ' role (preferred).'))
+                        .show();
+                }
+            }
+
+            $(document).on('change', 'select.personnelDropdown[data-required-role]', function () {
+                checkRoleQualification(this);
+            });
+
+            $('select.personnelDropdown[data-required-role]').each(function () {
+                checkRoleQualification(this);
+            });
+        });
+    </script>
 }

--- a/Web/Resgrid.Web/Areas/User/Views/Units/_UnitRoleTemplatesModal.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Units/_UnitRoleTemplatesModal.cshtml
@@ -73,15 +73,27 @@
     resgrid.units = resgrid.units || {};
     resgrid.units.roletemplates = resgrid.units.roletemplates || {};
 
+    // Single shared source of truth for the next #unitRoles row index. Both this templates modal and the
+    // page-level addRole handlers (new/edit unit) use it, so they can never generate duplicate
+    // unitRole_<n> ids/names. Defined once, defensively, since this markup renders before the page scripts.
+    resgrid.units.roleCounter = resgrid.units.roleCounter || {
+        value: 0,
+        seed: function (start) {
+            this.value = (typeof start === 'number' && !isNaN(start)) ? start : 0;
+        },
+        next: function () {
+            this.value++;
+            return this.value;
+        }
+    };
+
     resgrid.units.roletemplates.templates = @Json.Serialize(templatesJs);
 
     resgrid.units.roletemplates.personnelRoles = @Json.Serialize(personnelRolesJs);
 
     (function (rt) {
         function nextCount() {
-            if (typeof window.count === 'undefined' || window.count === null) { window.count = 0; }
-            window.count++;
-            return window.count;
+            return resgrid.units.roleCounter.next();
         }
 
         function findPersonnelRoleId(name) {
@@ -112,12 +124,12 @@
             var safeName = $('<div>').text(name || '').html();
             var checked = required ? " checked" : "";
             $('#unitRoles tbody').append(
-                "<tr>" +
-                "<td><input id='unitRole_" + c + "' name='unitRole_" + c + "' style='width:100%;' value=\"" + safeName + "\"></td>" +
-                "<td><select id='unitRolePersonnelRole_" + c + "' name='unitRolePersonnelRole_" + c + "' style='width:100%;'>" + options + "</select></td>" +
-                "<td style='text-align:center;'><input type='checkbox' id='unitRoleRequired_" + c + "' name='unitRoleRequired_" + c + "'" + checked + "></td>" +
-                "<td style='text-align:center;'><a onclick='$(this).closest(\"tr\").remove();' class='btn btn-xs btn-danger' data-original-title='Remove this role'>Remove</a></td>" +
-                "</tr>");
+                `<tr>
+                    <td><input id='unitRole_${c}' name='unitRole_${c}' style='width:100%;' value="${safeName}"></td>
+                    <td><select id='unitRolePersonnelRole_${c}' name='unitRolePersonnelRole_${c}' style='width:100%;'>${options}</select></td>
+                    <td style='text-align:center;'><input type='checkbox' id='unitRoleRequired_${c}' name='unitRoleRequired_${c}'${checked}></td>
+                    <td style='text-align:center;'><a onclick='$(this).closest("tr").remove();' class='btn btn-xs btn-danger' data-original-title='Remove this role'>Remove</a></td>
+                </tr>`);
         }
 
         rt.apply = function (templateId) {

--- a/Web/Resgrid.Web/Areas/User/Views/Units/_UnitRoleTemplatesModal.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Units/_UnitRoleTemplatesModal.cshtml
@@ -1,0 +1,150 @@
+@using Resgrid.Model.UnitRoles
+@using System.Linq
+@model List<Resgrid.Model.PersonnelRole>
+@{
+    var templates = UnitRoleTemplateCatalog.All;
+    var templatesJs = templates.Select(t => new
+    {
+        id = t.Id,
+        roles = t.Roles.Select(r => new { name = r.Name, personnelRole = r.SuggestedPersonnelRole, required = r.Required })
+    });
+    var personnelRolesJs = (Model ?? new List<Resgrid.Model.PersonnelRole>()).Select(x => new { id = x.PersonnelRoleId, name = x.Name });
+}
+
+<div class="modal fade" id="unitRoleTemplatesModal" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title">Unit Role Templates</h4>
+            </div>
+            <div class="modal-body">
+                <p>
+                    Pick a starting point for this unit's accountability roles. The seats are added to the roles table
+                    where you can rename them, change or clear the required personnel role, and add or remove seats
+                    before saving. Suggested qualifications are matched to your department's personnel roles by name.
+                </p>
+
+                <div class="input-group" style="max-width: 420px; margin-bottom: 16px;">
+                    <span class="input-group-addon"><i class="fa fa-search"></i></span>
+                    <input type="text" id="unitRoleTemplateSearch" class="form-control" placeholder="Search templates (e.g. engine, medic, patrol)..." autocomplete="off" onkeyup="resgrid.units.roletemplates.filter(this.value);" />
+                </div>
+
+                <div class="row" id="unitRoleTemplateGrid" style="max-height: 55vh; overflow-y: auto;">
+                    @foreach (var t in templates)
+                    {
+                        <div class="col-md-6 role-template-card" data-search="@t.SearchText" style="margin-bottom: 14px;">
+                            <div class="ibox" style="margin-bottom: 0;">
+                                <div class="ibox-content">
+                                    <div class="clearfix" style="margin-bottom: 4px;">
+                                        <strong style="font-size: 15px;">@t.Name</strong>
+                                        <span class="label label-primary pull-right">@t.Category</span>
+                                    </div>
+                                    <p class="text-muted" style="min-height: 40px; margin-bottom: 8px;">@t.Description</p>
+                                    <div style="margin-bottom: 10px;">
+                                        @foreach (var r in t.Roles)
+                                        {
+                                            <span class="label label-default" style="display:inline-block; margin: 0 4px 4px 0; font-weight: normal;">@(r.Name + (!string.IsNullOrWhiteSpace(r.SuggestedPersonnelRole) ? " · " + r.SuggestedPersonnelRole + (r.Required ? "*" : "") : ""))</span>
+                                        }
+                                    </div>
+                                    <div class="clearfix">
+                                        <small class="text-muted pull-left" style="line-height: 26px;">@t.RoleCount seats</small>
+                                        <button type="button" class="btn btn-primary btn-sm pull-right" onclick="resgrid.units.roletemplates.apply('@t.Id');">Use these roles</button>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    }
+                </div>
+                <div id="noUnitRoleTemplateResults" class="alert alert-warning" style="display:none;">No templates match your search.</div>
+                <small class="text-muted">* = suggested as a hard requirement (blocks unqualified members) when the matching personnel role exists.</small>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+    // Self-contained: create the namespace defensively (this markup renders in the body, before the
+    // page's own unit scripts in the Scripts section).
+    var resgrid = resgrid || {};
+    resgrid.units = resgrid.units || {};
+    resgrid.units.roletemplates = resgrid.units.roletemplates || {};
+
+    resgrid.units.roletemplates.templates = @Json.Serialize(templatesJs);
+
+    resgrid.units.roletemplates.personnelRoles = @Json.Serialize(personnelRolesJs);
+
+    (function (rt) {
+        function nextCount() {
+            if (typeof window.count === 'undefined' || window.count === null) { window.count = 0; }
+            window.count++;
+            return window.count;
+        }
+
+        function findPersonnelRoleId(name) {
+            if (!name) return null;
+            var roles = rt.personnelRoles || [];
+            for (var i = 0; i < roles.length; i++) {
+                if (roles[i].name && roles[i].name.toLowerCase() === name.toLowerCase()) {
+                    return roles[i].id;
+                }
+            }
+            return null;
+        }
+
+        function buildOptions(selectedId) {
+            var opts = "<option value=''>-- None --</option>";
+            var roles = rt.personnelRoles || [];
+            for (var i = 0; i < roles.length; i++) {
+                var sel = (selectedId != null && String(selectedId) === String(roles[i].id)) ? " selected" : "";
+                var nm = $('<div>').text(roles[i].name).html();
+                opts += "<option value='" + roles[i].id + "'" + sel + ">" + nm + "</option>";
+            }
+            return opts;
+        }
+
+        function addRow(name, personnelRoleId, required) {
+            var c = nextCount();
+            var options = buildOptions(personnelRoleId);
+            var safeName = $('<div>').text(name || '').html();
+            var checked = required ? " checked" : "";
+            $('#unitRoles tbody').append(
+                "<tr>" +
+                "<td><input id='unitRole_" + c + "' name='unitRole_" + c + "' style='width:100%;' value=\"" + safeName + "\"></td>" +
+                "<td><select id='unitRolePersonnelRole_" + c + "' name='unitRolePersonnelRole_" + c + "' style='width:100%;'>" + options + "</select></td>" +
+                "<td style='text-align:center;'><input type='checkbox' id='unitRoleRequired_" + c + "' name='unitRoleRequired_" + c + "'" + checked + "></td>" +
+                "<td style='text-align:center;'><a onclick='$(this).closest(\"tr\").remove();' class='btn btn-xs btn-danger' data-original-title='Remove this role'>Remove</a></td>" +
+                "</tr>");
+        }
+
+        rt.apply = function (templateId) {
+            var tpl = (rt.templates || []).filter(function (t) { return t.id === templateId; })[0];
+            if (!tpl) return;
+
+            for (var i = 0; i < tpl.roles.length; i++) {
+                var r = tpl.roles[i];
+                addRow(r.name, findPersonnelRoleId(r.personnelRole), r.required);
+            }
+
+            $('#unitRoleTemplatesModal').modal('hide');
+        };
+
+        rt.filter = function (query) {
+            var q = (query || '').toLowerCase().trim();
+            var terms = q.length ? q.split(/[\s,]+/) : [];
+            var visible = 0;
+
+            $('#unitRoleTemplateGrid .role-template-card').each(function () {
+                var hay = $(this).attr('data-search') || '';
+                var match = terms.every(function (t) { return hay.indexOf(t) !== -1; });
+                $(this).toggle(match);
+                if (match) { visible++; }
+            });
+
+            $('#noUnitRoleTemplateResults').toggle(visible === 0);
+        };
+    })(resgrid.units.roletemplates);
+</script>

--- a/Web/Resgrid.Web/wwwroot/js/app/internal/statuses/resgrid.statuses.newstatus.js
+++ b/Web/Resgrid.Web/wwwroot/js/app/internal/statuses/resgrid.statuses.newstatus.js
@@ -7,7 +7,12 @@ var resgrid;
         (function (newstatus) {
             $(document).ready(function () {
                 resgrid.common.analytics.track('Custom Statuses - New');
-                resgrid.statuses.newstatus.optionsCount = 0;
+
+                // Preserve any count set by the view when the form is pre-filled from a template
+                // (rows already rendered server-side); only default to 0 for a blank/fresh slate.
+                if (typeof resgrid.statuses.newstatus.optionsCount === 'undefined') {
+                    resgrid.statuses.newstatus.optionsCount = 0;
+                }
 
                 let quill = new Quill('#editor-container', {
                     placeholder: '',

--- a/Web/Resgrid.Web/wwwroot/js/app/internal/units/resgrid.units.editunit.js
+++ b/Web/Resgrid.Web/wwwroot/js/app/internal/units/resgrid.units.editunit.js
@@ -23,7 +23,7 @@ var resgrid;
             }
             editunit.buildPersonnelRoleOptions = buildPersonnelRoleOptions;
             function addRole() {
-                count++;
+                var count = resgrid.units.roleCounter.next();
                 var options = buildPersonnelRoleOptions(null);
                 $('#unitRoles tbody').append(
                     "<tr>" +

--- a/Web/Resgrid.Web/wwwroot/js/app/internal/units/resgrid.units.editunit.js
+++ b/Web/Resgrid.Web/wwwroot/js/app/internal/units/resgrid.units.editunit.js
@@ -11,9 +11,27 @@ var resgrid;
                     $(this).closest('tr').remove();
                 });
             });
+            function buildPersonnelRoleOptions(selectedId) {
+                var opts = "<option value=''>-- None --</option>";
+                var roles = resgrid.units.editunit.personnelRoles || [];
+                for (var i = 0; i < roles.length; i++) {
+                    var sel = (selectedId != null && String(selectedId) === String(roles[i].id)) ? " selected" : "";
+                    var name = $('<div>').text(roles[i].name).html();
+                    opts += "<option value='" + roles[i].id + "'" + sel + ">" + name + "</option>";
+                }
+                return opts;
+            }
+            editunit.buildPersonnelRoleOptions = buildPersonnelRoleOptions;
             function addRole() {
                 count++;
-                $('#unitRoles tbody').append("<tr><td><input id='unitRole_" + count + "' name='unitRole_" + count + "' style='width:100%;'></td><td style='text-align:center;'><a onclick='$(this).parent().parent().remove();' class='btn btn-xs btn-danger' data-original-title='Remove this role'>Remove</a></td></tr>");
+                var options = buildPersonnelRoleOptions(null);
+                $('#unitRoles tbody').append(
+                    "<tr>" +
+                    "<td><input id='unitRole_" + count + "' name='unitRole_" + count + "' style='width:100%;'></td>" +
+                    "<td><select id='unitRolePersonnelRole_" + count + "' name='unitRolePersonnelRole_" + count + "' style='width:100%;'>" + options + "</select></td>" +
+                    "<td style='text-align:center;'><input type='checkbox' id='unitRoleRequired_" + count + "' name='unitRoleRequired_" + count + "'></td>" +
+                    "<td style='text-align:center;'><a onclick='$(this).closest(\"tr\").remove();' class='btn btn-xs btn-danger' data-original-title='Remove this role'>Remove</a></td>" +
+                    "</tr>");
             }
             editunit.addRole = addRole;
             function removeRole() {

--- a/Web/Resgrid.Web/wwwroot/js/app/internal/units/resgrid.units.newunit.js
+++ b/Web/Resgrid.Web/wwwroot/js/app/internal/units/resgrid.units.newunit.js
@@ -12,9 +12,27 @@ var resgrid;
                     $(this).closest('tr').remove();
                 });
             });
+            function buildPersonnelRoleOptions(selectedId) {
+                var opts = "<option value=''>-- None --</option>";
+                var roles = resgrid.units.newunit.personnelRoles || [];
+                for (var i = 0; i < roles.length; i++) {
+                    var sel = (selectedId != null && String(selectedId) === String(roles[i].id)) ? " selected" : "";
+                    var name = $('<div>').text(roles[i].name).html();
+                    opts += "<option value='" + roles[i].id + "'" + sel + ">" + name + "</option>";
+                }
+                return opts;
+            }
+            newunit.buildPersonnelRoleOptions = buildPersonnelRoleOptions;
             function addRole() {
                 count++;
-                $('#unitRoles tbody').append("<tr><td><input id='unitRole_" + count + "' name='unitRole_" + count + "' style='width:100%;'></td><td style='text-align:center;'><a onclick='$(this).parent().parent().remove();' class='btn btn-xs btn-danger' data-original-title='Remove this role'>Remove</a></td></tr>");
+                var options = buildPersonnelRoleOptions(null);
+                $('#unitRoles tbody').append(
+                    "<tr>" +
+                    "<td><input id='unitRole_" + count + "' name='unitRole_" + count + "' style='width:100%;'></td>" +
+                    "<td><select id='unitRolePersonnelRole_" + count + "' name='unitRolePersonnelRole_" + count + "' style='width:100%;'>" + options + "</select></td>" +
+                    "<td style='text-align:center;'><input type='checkbox' id='unitRoleRequired_" + count + "' name='unitRoleRequired_" + count + "'></td>" +
+                    "<td style='text-align:center;'><a onclick='$(this).closest(\"tr\").remove();' class='btn btn-xs btn-danger' data-original-title='Remove this role'>Remove</a></td>" +
+                    "</tr>");
             }
             newunit.addRole = addRole;
             function removeRole() {

--- a/Web/Resgrid.Web/wwwroot/js/app/internal/units/resgrid.units.newunit.js
+++ b/Web/Resgrid.Web/wwwroot/js/app/internal/units/resgrid.units.newunit.js
@@ -6,7 +6,7 @@ var resgrid;
         var newunit;
         (function (newunit) {
             $(document).ready(function () {
-                count = 0;
+                resgrid.units.roleCounter.seed(0);
                 $('select').select2();
                 $(".removeRole").click(function () {
                     $(this).closest('tr').remove();
@@ -24,7 +24,7 @@ var resgrid;
             }
             newunit.buildPersonnelRoleOptions = buildPersonnelRoleOptions;
             function addRole() {
-                count++;
+                var count = resgrid.units.roleCounter.next();
                 var options = buildPersonnelRoleOptions(null);
                 $('#unitRoles tbody').append(
                     "<tr>" +


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## PR Description: RG-T124 Base Status Type Fixes and Helper Catalogs

This PR significantly expands the custom status and unit role system with new base status types, prebuilt template catalogs for quick setup, and personnel qualification requirements for unit roles.

### Key Changes

**1. Extended Action Base Types**
Added 12 new canonical base status types to `ActionBaseTypes` (Enroute, Transporting, Delivering, AtPatient, AtHospital, Searching, Loading, Standby, OnPatrol, Maintenance, OnBreak, Completed) with full XML documentation. Each new type is classified in the `AvailabilityMatrix` so it drives availability/reporting/automations correctly (e.g., OnPatrol = Available, Transporting = Committed, Maintenance = Unavailable). The enum's `DescriptionAttribute` was changed to carry richer help text, and a `_BaseTypeDescription` partial renders these descriptions live in the UI when selecting a base type.

**2. Custom State Template Catalogs**
Introduced a code-defined catalog of predefined status "starter packs" (`CustomStateTemplate`, `CustomStateTemplateDetail`, `CustomStateTemplateCatalog`) covering disciplines including EMS, Fire, Law Enforcement, Search & Rescue, Disaster Response, Security, Industrial/Fleet, and Commodity Delivery. A new Templates gallery page lets users browse/search/filter templates by type and category, pick one, and pre-fill the New Custom Status form with editable, unsaved options. Blank-from-scratch remains available.

**3. Unit Role Template Catalogs**
Introduced a parallel code-defined catalog of unit accountability role sets (`UnitRoleTemplate`, `UnitRoleTemplateRole`, `UnitRoleTemplateCatalog`) such as Fire Engine Company, Ambulance (ALS/BLS), K9 Unit, SWAT Team, SAR Ground Team, Industrial Fire Brigade, Delivery Vehicle, etc. A modal picker on the New/Edit Unit page applies a template's seats (with suggested personnel qualifications matched by name to the department's existing roles).

**4. Personnel Role Qualifications on Unit Roles**
Added optional `PersonnelRoleId` and `PersonnelRoleRequired` columns to `UnitRole` (with SQL Server and PostgreSQL migrations M0086). A unit role can now require (hard block) or prefer (warn) a specific personnel qualification. Both the web UI and the v4 API enforce hard requirements on assignment and surface qualification status on responses.

**5. Computed Unit Staffing Levels**
Added `UnitStaffingLevel` enum (Unknown, NotStaffed, PartiallyStaffed, Degraded, FullyStaffed) and `UnitRoleStaffingResult` which calculates a unit's staffing from defined roles, active assignments, and qualification checks. The Unit Staffing page now displays staffing badges and per-seat qualification warnings. A new `GetAllRolesByDepartmentIdAsync` repository method supports batch loading to avoid N+1 queries.

**6. API Enhancements**
The v4 `UnitRolesController` now returns `PersonnelRoleId`, `PersonnelRoleName`, `PersonnelRoleRequired`, and `IsQualified` in role responses, and validates hard qualification requirements before accepting role assignments.

**7. Localization**
Added translations for the 12 new base type names and the new unit role headers (Required Personnel Role, Required?) across all supported languages (ar, de, en, es, fr, it, pl, sv, uk).
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ready-made custom status and unit role templates to speed up setup.
  * Introduced personnel-role awareness for unit roles, including required vs. preferred assignments.
  * Added clearer staffing status levels and qualification indicators.

* **Bug Fixes**
  * Improved staffing and availability reporting so more status types now map correctly.
  * Prevented saving unit role assignments when a required personnel qualification isn’t met.

* **Documentation**
  * Expanded on-screen descriptions and help text for status and role setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->