### PR TITLE
RG-T125 Chatbot fix

### DIFF
--- a/Core/Resgrid.Model/Helpers/SerializerHelper.cs
+++ b/Core/Resgrid.Model/Helpers/SerializerHelper.cs
@@ -1,5 +1,7 @@
-﻿using ProtoBuf;
+using ProtoBuf;
+using Resgrid.Model.Events;
 using Resgrid.Model.Identity;
+using Resgrid.Model.Queue;
 
 namespace Resgrid.Model.Helpers
 {
@@ -7,6 +9,7 @@ namespace Resgrid.Model.Helpers
 	{
 		public static void WarmUpProtobufSerializer()
 		{
+			// Core model types (also serialized into the cache).
 			Serializer.PrepareSerializer<Department>();
 			Serializer.PrepareSerializer<Address>();
 			Serializer.PrepareSerializer<DepartmentMember>();
@@ -17,6 +20,22 @@ namespace Resgrid.Model.Helpers
 			Serializer.PrepareSerializer<PlanLimit>();
 			Serializer.PrepareSerializer<IdentityUser>();
 			Serializer.PrepareSerializer<UserProfile>();
+
+			// Every payload type published to RabbitMQ (see RabbitOutboundQueueProvider).
+			// Preparing them here builds the protobuf contract at startup, so a type that is
+			// missing [ProtoContract] fails fast on boot instead of on the first enqueue.
+			Serializer.PrepareSerializer<CallQueueItem>();
+			Serializer.PrepareSerializer<ChatbotMessageQueueItem>();
+			Serializer.PrepareSerializer<MessageQueueItem>();
+			Serializer.PrepareSerializer<DistributionListQueueItem>();
+			Serializer.PrepareSerializer<NotificationItem>();
+			Serializer.PrepareSerializer<ShiftQueueItem>();
+			Serializer.PrepareSerializer<WorkflowQueueItem>();
+			Serializer.PrepareSerializer<CqrsEvent>();
+			Serializer.PrepareSerializer<AuditEvent>();
+			Serializer.PrepareSerializer<UnitLocationEvent>();
+			Serializer.PrepareSerializer<PersonnelLocationEvent>();
+			Serializer.PrepareSerializer<SecurityRefreshEvent>();
 		}
 	}
 }

--- a/Core/Resgrid.Model/Queue/ChatbotMessageQueueItem.cs
+++ b/Core/Resgrid.Model/Queue/ChatbotMessageQueueItem.cs
@@ -8,6 +8,7 @@ namespace Resgrid.Model.Queue
 	/// The worker resolves IChatbotIngressService, processes the message, and sends the reply
 	/// back to <see cref="From"/> via the SMS transport.
 	/// </summary>
+	[ProtoContract]
 	public class ChatbotMessageQueueItem
 	{
 		[ProtoMember(1)]


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
# PR Description: RG-T125 Chatbot fix

This pull request fixes an issue with the chatbot messaging functionality by addressing a protobuf serialization defect and adding fail-fast validation for queue message types.

## Changes

1. **Added missing `[ProtoContract]` attribute to `ChatbotMessageQueueItem`**
   - The class was already decorated with `[ProtoMember]` attributes but was missing the required `[ProtoContract]` attribute at the class level. Without it, protobuf-net cannot properly serialize instances of this type, causing failures when chatbot messages are published to the RabbitMQ queue.

2. **Extended the Protobuf serializer warmup to cover all queue payload types**
   - `SerializerHelper.WarmUpProtobufSerializer()` now prepares serializers for every payload type published to RabbitMQ (e.g., `CallQueueItem`, `MessageQueueItem`, `ShiftQueueItem`, `CqrsEvent`, `AuditEvent`, etc.).
   - This builds the protobuf contracts at application startup, ensuring that any type missing the `[ProtoContract]` attribute fails immediately on boot rather than surfacing as a runtime error the first time a message of that type is enqueued.

## Functional Impact
Chatbot messages will now serialize correctly for queue transport, and the application will detect missing protobuf contract attributes early during startup, preventing similar serialization failures across other message types.
<!-- kody-pr-summary:end -->