### PR TITLE
RG-T117 Chatbot fix

### DIFF
--- a/Core/Resgrid.Chatbot/Models/ChatbotPlatform.cs
+++ b/Core/Resgrid.Chatbot/Models/ChatbotPlatform.cs
@@ -1,5 +1,7 @@
 namespace Resgrid.Chatbot.Models
 {
+	// The SMS values (SmsTwilio, SmsSignalWire) are mirrored as constants on
+	// Resgrid.Model.ChatbotIdentity for consumers that cannot reference this project.
 	public enum ChatbotPlatform
 	{
 		Unknown = 0,

--- a/Core/Resgrid.Chatbot/Models/ChatbotSession.cs
+++ b/Core/Resgrid.Chatbot/Models/ChatbotSession.cs
@@ -12,7 +12,13 @@ namespace Resgrid.Chatbot.Models
 		AwaitingConfirmation = 4,
 		AwaitingParameter = 5,
 		AwaitingAuth = 6,
-		Completed = 7
+		Completed = 7,
+
+		/// <summary>
+		/// Step-up security-PIN prompt for a confirmed destructive action (the user already replied
+		/// YES; the pending intent executes once the correct PIN is supplied).
+		/// </summary>
+		AwaitingPin = 8
 	}
 
 	public class ChatbotSession

--- a/Core/Resgrid.Chatbot/Services/ChatbotIngressService.cs
+++ b/Core/Resgrid.Chatbot/Services/ChatbotIngressService.cs
@@ -241,15 +241,33 @@ namespace Resgrid.Chatbot.Services
 						// before it executes.
 						if (await _securityPinService.IsPinRequiredAsync(identity.UserId, department.DepartmentId))
 						{
+							// Provision a missing PIN BEFORE persisting the awaiting-PIN state: if
+							// provisioning fails (no profile, or a thrown error caught by the outer
+							// handler) the session stays parked in AwaitingConfirmation instead of
+							// being stranded awaiting a PIN that doesn't exist.
+							bool pinGenerated = false;
+							if (!await _securityPinService.HasPinAsync(identity.UserId))
+							{
+								var provisioned = await _securityPinService.EnsurePinAsync(identity.UserId, department.DepartmentId);
+								if (provisioned == null || string.IsNullOrWhiteSpace(provisioned.SecurityPin))
+								{
+									return new ChatbotResponse
+									{
+										Text = "This action requires a security PIN, but one couldn't be set up for your account. Please set a PIN on your Resgrid profile page, then reply YES again.",
+										Processed = true
+									};
+								}
+								pinGenerated = true;
+							}
+
 							session.State = ChatbotDialogState.AwaitingPin;
 							session.Context["__pinAttempts"] = "0";
 							await _sessionManager.SaveSessionAsync(session);
 
-							if (!await _securityPinService.HasPinAsync(identity.UserId))
+							if (pinGenerated)
 							{
-								// Department forces PINs but this user doesn't have one yet — generate one
-								// so they can look it up on their profile page and complete the action.
-								await _securityPinService.EnsurePinAsync(identity.UserId, department.DepartmentId);
+								// Department forces PINs but this user didn't have one yet — one was
+								// generated so they can look it up on their profile page and continue.
 								return new ChatbotResponse
 								{
 									Text = "This action requires your security PIN. A PIN has been generated for you — view or change it on your Resgrid profile page, then reply with the 4-digit PIN to continue, or NO to cancel.",
@@ -260,37 +278,7 @@ namespace Resgrid.Chatbot.Services
 							return new ChatbotResponse { Text = "For security, reply with your 4-digit security PIN to complete this action, or NO to cancel.", Processed = true };
 						}
 
-						var confirmResponse = await DispatchConfirmedIntentAsync(message, session);
-						if (confirmResponse != null)
-							return confirmResponse;
-						var pendingType = session.PendingIntent.Value;
-
-						// Locate the owning handler BEFORE mutating session state. If none can handle
-						// the pending intent, leave the session parked in AwaitingConfirmation and return
-						// an explicit error rather than silently dropping the confirmation.
-						var confirmHandler = _actionHandlers.FirstOrDefault(h => h.CanHandle(pendingType));
-						if (confirmHandler == null)
-						{
-							return new ChatbotResponse
-							{
-								Text = "Unable to complete confirmation — please try again or contact support.",
-								Processed = false
-							};
-						}
-
-						var confirmedIntent = new ChatbotIntent
-						{
-							Type = pendingType,
-							Parameters = new Dictionary<string, string>(session.Context) { ["__confirmed"] = "true" }
-						};
-
-						var confirmResponse = await confirmHandler.HandleAsync(message, confirmedIntent, session);
-						confirmResponse.Intent = confirmedIntent;
-						session.Context.Clear();
-						session.State = ChatbotDialogState.Idle;
-						session.PendingIntent = null;
-						await _sessionManager.SaveSessionAsync(session);
-						return confirmResponse;
+						return await DispatchConfirmedIntentAsync(message, session);
 					}
 					else if (reply == "NO" || reply == "N" || reply == "CANCEL")
 					{
@@ -323,9 +311,7 @@ namespace Resgrid.Chatbot.Services
 					if (await _securityPinService.ValidatePinAsync(identity.UserId, pinReply))
 					{
 						session.Context.Remove("__pinAttempts");
-						var confirmResponse = await DispatchConfirmedIntentAsync(message, session);
-						if (confirmResponse != null)
-							return confirmResponse;
+						return await DispatchConfirmedIntentAsync(message, session);
 					}
 					else
 					{
@@ -448,27 +434,35 @@ namespace Resgrid.Chatbot.Services
 
 		/// <summary>
 		/// Executes the pending (already confirmed, and PIN-verified when required) destructive intent.
-		/// Returns the handler's response, or null when no handler claims the intent (the caller then
-		/// falls through to normal classification, matching the original confirmation-gate behavior).
+		/// The owning handler is located BEFORE any session state is mutated: if none can handle the
+		/// pending intent the session stays parked and an explicit error is returned rather than
+		/// silently dropping the confirmation.
 		/// </summary>
 		private async Task<ChatbotResponse> DispatchConfirmedIntentAsync(ChatbotMessage message, ChatbotSession session)
 		{
 			var pendingType = session.PendingIntent.Value;
+
+			var confirmHandler = _actionHandlers.FirstOrDefault(h => h.CanHandle(pendingType));
+			if (confirmHandler == null)
+			{
+				return new ChatbotResponse
+				{
+					Text = "Unable to complete confirmation — please try again or contact support.",
+					Processed = false
+				};
+			}
+
 			var confirmedIntent = new ChatbotIntent
 			{
 				Type = pendingType,
 				Parameters = new Dictionary<string, string>(session.Context) { ["__confirmed"] = "true" }
 			};
-			session.State = ChatbotDialogState.Idle;
-			session.PendingIntent = null;
-
-			var confirmHandler = _actionHandlers.FirstOrDefault(h => h.CanHandle(pendingType));
-			if (confirmHandler == null)
-				return null;
 
 			var confirmResponse = await confirmHandler.HandleAsync(message, confirmedIntent, session);
 			confirmResponse.Intent = confirmedIntent;
 			session.Context.Clear();
+			session.State = ChatbotDialogState.Idle;
+			session.PendingIntent = null;
 			await _sessionManager.SaveSessionAsync(session);
 			return confirmResponse;
 		}

--- a/Core/Resgrid.Chatbot/Services/ChatbotIngressService.cs
+++ b/Core/Resgrid.Chatbot/Services/ChatbotIngressService.cs
@@ -25,6 +25,9 @@ namespace Resgrid.Chatbot.Services
 		private readonly IAuthorizationService _authorizationService;
 		private readonly IChatbotDepartmentConfigService _departmentConfigService;
 		private readonly IChatbotRateLimiter _rateLimiter;
+		private readonly ISecurityPinService _securityPinService;
+
+		private const int MaxPinAttempts = 3;
 
 		public ChatbotIngressService(
 			IChatbotUserIdentityService userIdentityService,
@@ -39,7 +42,8 @@ namespace Resgrid.Chatbot.Services
 			ILimitsService limitsService,
 			IAuthorizationService authorizationService,
 			IChatbotDepartmentConfigService departmentConfigService,
-			IChatbotRateLimiter rateLimiter)
+			IChatbotRateLimiter rateLimiter,
+			ISecurityPinService securityPinService)
 		{
 			_userIdentityService = userIdentityService;
 			_sessionManager = sessionManager;
@@ -54,6 +58,7 @@ namespace Resgrid.Chatbot.Services
 			_authorizationService = authorizationService;
 			_departmentConfigService = departmentConfigService;
 			_rateLimiter = rateLimiter;
+			_securityPinService = securityPinService;
 		}
 
 		public async Task<ChatbotResponse> ProcessMessageAsync(ChatbotMessage message)
@@ -66,9 +71,30 @@ namespace Resgrid.Chatbot.Services
 				// 1. Identify user from the platform-specific identifier (already-linked only).
 				var identity = await ResolveUserIdentityAsync(message);
 
-				// 1b. SMS: a phone number that matches a Resgrid profile but isn't linked yet. Depending
-				// on the department's RequireLinkingConfirmation setting, either auto-link or run a
-				// one-time "Reply YES to link" confirmation before trusting the number.
+				// 1b. SMS identities are only trusted while the linked profile's mobile number is
+				// verified AND still matches the sending number. Links created before verification was
+				// required, or made stale by a number change, must not authenticate the sender — drop
+				// them and fall through to the fresh phone-match below (the number may now belong to a
+				// different, verified profile).
+				if (identity != null && IsSmsPlatform(message.Platform))
+				{
+					var linkedProfile = await _userProfileService.GetProfileByUserIdAsync(identity.UserId);
+					if (linkedProfile == null
+						|| linkedProfile.MobileNumberVerified != true
+						|| !PhoneNumbersMatch(linkedProfile.GetPhoneNumber(), message.From))
+					{
+						// Only physically remove SMS links. The phone fallback can also surface a
+						// cross-platform identity (e.g. WhatsApp ids are phone numbers); those are
+						// merely not trusted for this SMS message, not deleted.
+						if (IsSmsPlatform(identity.Platform))
+							await _userIdentityService.UnlinkUserAsync(identity.Id);
+						identity = null;
+					}
+				}
+
+				// 1c. SMS: a phone number that matches a Resgrid profile but isn't linked yet. Only a
+				// VERIFIED mobile number may authenticate a sender; when it is verified the identity link
+				// is created silently (it's an internal optimization, not something the user is asked about).
 				if (identity == null && IsSmsPlatform(message.Platform))
 				{
 					var cleanPhone = message.From?.Replace("+", "").Trim();
@@ -77,19 +103,18 @@ namespace Resgrid.Chatbot.Services
 						var profile = await _userProfileService.GetProfileByMobileNumberAsync(cleanPhone);
 						if (profile != null)
 						{
-							var candidateDepartment = await ResolveActiveDepartmentAsync(profile.UserId);
-							var requireConfirmation = candidateDepartment == null
-								|| ((await _departmentConfigService.GetConfigAsync(candidateDepartment.DepartmentId))?.RequireLinkingConfirmation ?? true);
-
-							if (!requireConfirmation)
+							if (profile.MobileNumberVerified == true)
 							{
 								identity = await _userIdentityService.LinkUserAsync(
-									profile.UserId, message.Platform, message.From, profile.FullName.AsFirstNameLastName, "phone_match");
+									profile.UserId, message.Platform, message.From, profile.FullName.AsFirstNameLastName, "phone_match_verified");
 							}
 							else
 							{
-								// Returns the prompt / acknowledgement; links the number on a YES reply.
-								return await HandlePhoneLinkConfirmationAsync(message, profile, candidateDepartment);
+								return new ChatbotResponse
+								{
+									Text = "This mobile number matches a Resgrid profile but hasn't been verified yet. Please verify your mobile number on your Resgrid profile page, then text again.",
+									Processed = true
+								};
 							}
 						}
 					}
@@ -206,24 +231,33 @@ namespace Resgrid.Chatbot.Services
 					var reply = message.Text?.Trim().ToUpperInvariant();
 					if (reply == "YES" || reply == "Y" || reply == "CONFIRM" || reply == "OK")
 					{
-						var pendingType = session.PendingIntent.Value;
-						var confirmedIntent = new ChatbotIntent
+						// Step-up auth: when the department forces security-PIN usage (or the user opted
+						// in), a confirmed destructive action additionally requires the user's 4-digit PIN
+						// before it executes.
+						if (await _securityPinService.IsPinRequiredAsync(identity.UserId, department.DepartmentId))
 						{
-							Type = pendingType,
-							Parameters = new Dictionary<string, string>(session.Context) { ["__confirmed"] = "true" }
-						};
-						session.State = ChatbotDialogState.Idle;
-						session.PendingIntent = null;
-
-						var confirmHandler = _actionHandlers.FirstOrDefault(h => h.CanHandle(pendingType));
-						if (confirmHandler != null)
-						{
-							var confirmResponse = await confirmHandler.HandleAsync(message, confirmedIntent, session);
-							confirmResponse.Intent = confirmedIntent;
-							session.Context.Clear();
+							session.State = ChatbotDialogState.AwaitingPin;
+							session.Context["__pinAttempts"] = "0";
 							await _sessionManager.SaveSessionAsync(session);
-							return confirmResponse;
+
+							if (!await _securityPinService.HasPinAsync(identity.UserId))
+							{
+								// Department forces PINs but this user doesn't have one yet — generate one
+								// so they can look it up on their profile page and complete the action.
+								await _securityPinService.EnsurePinAsync(identity.UserId, department.DepartmentId);
+								return new ChatbotResponse
+								{
+									Text = "This action requires your security PIN. A PIN has been generated for you — view or change it on your Resgrid profile page, then reply with the 4-digit PIN to continue, or NO to cancel.",
+									Processed = true
+								};
+							}
+
+							return new ChatbotResponse { Text = "For security, reply with your 4-digit security PIN to complete this action, or NO to cancel.", Processed = true };
 						}
+
+						var confirmResponse = await DispatchConfirmedIntentAsync(message, session);
+						if (confirmResponse != null)
+							return confirmResponse;
 					}
 					else if (reply == "NO" || reply == "N" || reply == "CANCEL")
 					{
@@ -234,6 +268,48 @@ namespace Resgrid.Chatbot.Services
 					else
 					{
 						return new ChatbotResponse { Text = "Please reply YES to confirm or NO to cancel.", Processed = true };
+					}
+				}
+
+				// 5b. PIN step-up for an already-confirmed destructive action: the user replied YES and a
+				// security PIN is required, so the pending intent only executes on a correct PIN.
+				if (session.State == ChatbotDialogState.AwaitingPin && session.PendingIntent.HasValue)
+				{
+					var pinReply = message.Text?.Trim();
+
+					if (IsNegative(pinReply))
+					{
+						session.Reset();
+						await _sessionManager.SaveSessionAsync(session);
+						return new ChatbotResponse { Text = "Cancelled.", Processed = true };
+					}
+
+					if (!SecurityPinUtility.IsValidFormat(pinReply))
+						return new ChatbotResponse { Text = "Please reply with your 4-digit security PIN, or NO to cancel.", Processed = true };
+
+					if (await _securityPinService.ValidatePinAsync(identity.UserId, pinReply))
+					{
+						session.Context.Remove("__pinAttempts");
+						var confirmResponse = await DispatchConfirmedIntentAsync(message, session);
+						if (confirmResponse != null)
+							return confirmResponse;
+					}
+					else
+					{
+						session.Context.TryGetValue("__pinAttempts", out var attemptsRaw);
+						int.TryParse(attemptsRaw, out var attempts);
+						attempts++;
+
+						if (attempts >= MaxPinAttempts)
+						{
+							session.Reset();
+							await _sessionManager.SaveSessionAsync(session);
+							return new ChatbotResponse { Text = "Too many incorrect PIN attempts. The action has been cancelled.", Processed = true };
+						}
+
+						session.Context["__pinAttempts"] = attempts.ToString();
+						await _sessionManager.SaveSessionAsync(session);
+						return new ChatbotResponse { Text = "Incorrect PIN. Reply with your 4-digit security PIN, or NO to cancel.", Processed = true };
 					}
 				}
 
@@ -331,12 +407,6 @@ namespace Resgrid.Chatbot.Services
 			return t.Contains("mayday") || t.Contains("emergency") || t.Contains("officer down") || t.Contains("firefighter down");
 		}
 
-		private static bool IsAffirmative(string text)
-		{
-			var t = text?.Trim().ToLowerInvariant();
-			return t == "yes" || t == "y" || t == "confirm";
-		}
-
 		private static bool IsNegative(string text)
 		{
 			var t = text?.Trim().ToLowerInvariant();
@@ -344,54 +414,51 @@ namespace Resgrid.Chatbot.Services
 		}
 
 		/// <summary>
-		/// One-time confirmation before linking an unrecognized SMS number to the matching Resgrid
-		/// account. Prompts on first contact, links on YES, cancels on NO.
+		/// Executes the pending (already confirmed, and PIN-verified when required) destructive intent.
+		/// Returns the handler's response, or null when no handler claims the intent (the caller then
+		/// falls through to normal classification, matching the original confirmation-gate behavior).
 		/// </summary>
-		private async Task<ChatbotResponse> HandlePhoneLinkConfirmationAsync(ChatbotMessage message, Model.UserProfile profile, Model.Department department)
+		private async Task<ChatbotResponse> DispatchConfirmedIntentAsync(ChatbotMessage message, ChatbotSession session)
 		{
-			// A matched profile may have no active department membership, in which case the caller
-			// passes a null department. The phone-link confirmation only tracks trust of the number
-			// (linking doesn't depend on a department), so fall back to department id 0 for the
-			// temporary session rather than dereferencing a null department.
-			var session = await _sessionManager.GetOrCreateSessionAsync(profile.UserId, department?.DepartmentId ?? 0, message.Platform, message.From);
-
-			var awaitingConfirmation = session.State == ChatbotDialogState.AwaitingConfirmation
-				&& session.Context != null
-				&& session.Context.TryGetValue("pendingAction", out var pendingAction)
-				&& pendingAction == "confirm_phone_link";
-
-			if (awaitingConfirmation)
+			var pendingType = session.PendingIntent.Value;
+			var confirmedIntent = new ChatbotIntent
 			{
-				if (IsAffirmative(message.Text))
-				{
-					await _userIdentityService.LinkUserAsync(
-						profile.UserId, message.Platform, message.From, profile.FullName.AsFirstNameLastName, "phone_match_confirmed");
-					session.State = ChatbotDialogState.Idle;
-					session.Context.Remove("pendingAction");
-					await _sessionManager.SaveSessionAsync(session);
-					return new ChatbotResponse { Text = "Your number is now linked to your Resgrid account. Text HELP to see what you can do.", Processed = true };
-				}
-
-				if (IsNegative(message.Text))
-				{
-					await _sessionManager.EndSessionAsync(session.SessionId);
-					return new ChatbotResponse { Text = "No problem — I won't link this number. Reply LINK anytime to connect your account.", Processed = true };
-				}
-
-				return new ChatbotResponse { Text = "Please reply YES to link this number to your Resgrid account, or NO to cancel.", Processed = false };
-			}
-
-			// First contact for this number: ask for confirmation before linking.
-			session.State = ChatbotDialogState.AwaitingConfirmation;
-			session.Context["pendingAction"] = "confirm_phone_link";
-			await _sessionManager.SaveSessionAsync(session);
-
-			return new ChatbotResponse
-			{
-				Text = $"We found a Resgrid account for {profile.FirstName}. Reply YES to link this number, or NO to cancel.",
-				Processed = true
+				Type = pendingType,
+				Parameters = new Dictionary<string, string>(session.Context) { ["__confirmed"] = "true" }
 			};
+			session.State = ChatbotDialogState.Idle;
+			session.PendingIntent = null;
+
+			var confirmHandler = _actionHandlers.FirstOrDefault(h => h.CanHandle(pendingType));
+			if (confirmHandler == null)
+				return null;
+
+			var confirmResponse = await confirmHandler.HandleAsync(message, confirmedIntent, session);
+			confirmResponse.Intent = confirmedIntent;
+			session.Context.Clear();
+			await _sessionManager.SaveSessionAsync(session);
+			return confirmResponse;
 		}
+
+		/// <summary>
+		/// Compares a profile phone number against a sender number, ignoring formatting and tolerating
+		/// a leading US country code on either side (mirrors GetProfileByMobileNumberAsync).
+		/// </summary>
+		private static bool PhoneNumbersMatch(string profileNumber, string senderNumber)
+		{
+			var a = NormalizePhone(profileNumber);
+			var b = NormalizePhone(senderNumber);
+
+			if (string.IsNullOrWhiteSpace(a) || string.IsNullOrWhiteSpace(b))
+				return false;
+
+			return a == b
+				|| (a.Length == 11 && a[0] == '1' && a.Substring(1) == b)
+				|| (b.Length == 11 && b[0] == '1' && b.Substring(1) == a);
+		}
+
+		private static string NormalizePhone(string number)
+			=> number?.Replace(" ", "").Replace("(", "").Replace(")", "").Replace("+", "").Replace("-", "").Replace(".", "").Trim();
 
 		private async Task<Model.Department> ResolveActiveDepartmentAsync(string userId)
 		{

--- a/Core/Resgrid.Framework/SecurityPinUtility.cs
+++ b/Core/Resgrid.Framework/SecurityPinUtility.cs
@@ -1,0 +1,71 @@
+using System.Security.Cryptography;
+
+namespace Resgrid.Framework
+{
+	/// <summary>
+	/// Generation and validation rules for the 4-digit user security PIN used as a step-up
+	/// (2FA-style) check for dangerous/department-wide chatbot and SMS actions.
+	/// </summary>
+	public static class SecurityPinUtility
+	{
+		public const int PinLength = 4;
+
+		/// <summary>True when the value is exactly <see cref="PinLength"/> ASCII digits.</summary>
+		public static bool IsValidFormat(string pin)
+		{
+			if (string.IsNullOrWhiteSpace(pin) || pin.Length != PinLength)
+				return false;
+
+			foreach (var c in pin)
+			{
+				if (c < '0' || c > '9')
+					return false;
+			}
+
+			return true;
+		}
+
+		/// <summary>
+		/// True for trivially guessable PINs: all-same-digit (0000, 1111, ...) and consecutive
+		/// ascending/descending runs (1234, 0123, 4321, 9876, ...).
+		/// </summary>
+		public static bool IsWeak(string pin)
+		{
+			if (!IsValidFormat(pin))
+				return true;
+
+			bool allSame = true, ascending = true, descending = true;
+			for (int i = 1; i < pin.Length; i++)
+			{
+				if (pin[i] != pin[0])
+					allSame = false;
+				if (pin[i] != pin[i - 1] + 1)
+					ascending = false;
+				if (pin[i] != pin[i - 1] - 1)
+					descending = false;
+			}
+
+			return allSame || ascending || descending;
+		}
+
+		/// <summary>Valid format and not weak.</summary>
+		public static bool IsAcceptable(string pin) => IsValidFormat(pin) && !IsWeak(pin);
+
+		/// <summary>Generates a random PIN that passes <see cref="IsAcceptable"/> using a crypto RNG.</summary>
+		public static string Generate()
+		{
+			using var rng = RandomNumberGenerator.Create();
+			var bytes = new byte[4];
+
+			while (true)
+			{
+				rng.GetBytes(bytes);
+				uint value = (uint)(bytes[0] | bytes[1] << 8 | bytes[2] << 16 | bytes[3] << 24);
+				string pin = (value % 10000).ToString().PadLeft(PinLength, '0');
+
+				if (IsAcceptable(pin))
+					return pin;
+			}
+		}
+	}
+}

--- a/Core/Resgrid.Framework/StringHelpers.cs
+++ b/Core/Resgrid.Framework/StringHelpers.cs
@@ -22,6 +22,22 @@ namespace Resgrid.Framework
 	public static class StringHelpers
 	{
 		/// <summary>
+		/// Masks a phone number for diagnostic logging (PII redaction), keeping only the last
+		/// four digits (e.g. "***4567"). Values with four or fewer characters are fully masked.
+		/// </summary>
+		public static string MaskPhoneNumber(string number)
+		{
+			if (string.IsNullOrWhiteSpace(number))
+				return "***";
+
+			var trimmed = number.Trim();
+			if (trimmed.Length <= 4)
+				return "***";
+
+			return "***" + trimmed.Substring(trimmed.Length - 4);
+		}
+
+		/// <summary>
 		/// Remove HTML tags from string using char array.
 		/// </summary>
 		public static string StripHtmlTagsCharArray(string source)

--- a/Core/Resgrid.Localization/Areas/User/Department/Department.ar.resx
+++ b/Core/Resgrid.Localization/Areas/User/Department/Department.ar.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
     Microsoft ResX Schema
@@ -731,5 +731,11 @@
   </data>
   <data name="EnableModernNotificationsHelp" xml:space="preserve">
     <value>When enabled, push notifications will use the modern notification sounds instead of the legacy sounds for all users in this department.</value>
+  </data>
+  <data name="ForceChatbotSecurityPin" xml:space="preserve">
+    <value>طلب رمز PIN الأمان</value>
+  </data>
+  <data name="ForceChatbotSecurityPinHelp" xml:space="preserve">
+    <value>يتطلب من كل عضو تأكيد الإجراءات الخطرة أو على مستوى القسم عبر روبوت الدردشة/الرسائل النصية باستخدام رمز PIN الأمان الشخصي المكون من 4 أرقام. يحصل الأعضاء الذين ليس لديهم رمز PIN على رمز يتم إنشاؤه عشوائيًا (يمكن عرضه في صفحة ملفهم الشخصي).</value>
   </data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Department/Department.de.resx
+++ b/Core/Resgrid.Localization/Areas/User/Department/Department.de.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -682,5 +682,11 @@
   </data>
   <data name="EnableModernNotificationsHelp" xml:space="preserve">
     <value>When enabled, push notifications will use the modern notification sounds instead of the legacy sounds for all users in this department.</value>
+  </data>
+  <data name="ForceChatbotSecurityPin" xml:space="preserve">
+    <value>Sicherheits-PIN erforderlich</value>
+  </data>
+  <data name="ForceChatbotSecurityPinHelp" xml:space="preserve">
+    <value>Verlangt, dass jedes Mitglied gefährliche oder abteilungsweite Chatbot-/SMS-Aktionen mit seiner persönlichen 4-stelligen Sicherheits-PIN bestätigt. Mitglieder ohne PIN erhalten eine zufällig generierte (einsehbar auf ihrer Profilseite).</value>
   </data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Department/Department.en.resx
+++ b/Core/Resgrid.Localization/Areas/User/Department/Department.en.resx
@@ -762,4 +762,10 @@
   <data name="EnableModernNotificationsHelp" xml:space="preserve">
     <value>When enabled, push notifications will use the modern notification sounds instead of the legacy sounds for all users in this department.</value>
   </data>
+  <data name="ForceChatbotSecurityPin" xml:space="preserve">
+    <value>Require Security PIN</value>
+  </data>
+  <data name="ForceChatbotSecurityPinHelp" xml:space="preserve">
+    <value>Require every member to confirm dangerous or department-wide chatbot/text actions with their personal 4-digit security PIN. Members without a PIN get a randomly generated one (viewable on their profile page).</value>
+  </data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Department/Department.es.resx
+++ b/Core/Resgrid.Localization/Areas/User/Department/Department.es.resx
@@ -618,4 +618,10 @@
   <data name="EnableModernNotificationsHelp" xml:space="preserve">
     <value>When enabled, push notifications will use the modern notification sounds instead of the legacy sounds for all users in this department.</value>
   </data>
+  <data name="ForceChatbotSecurityPin" xml:space="preserve">
+    <value>Requerir PIN de seguridad</value>
+  </data>
+  <data name="ForceChatbotSecurityPinHelp" xml:space="preserve">
+    <value>Exige que cada miembro confirme las acciones peligrosas o de todo el departamento del chatbot/mensajes de texto con su PIN de seguridad personal de 4 dígitos. Los miembros sin PIN reciben uno generado aleatoriamente (visible en su página de perfil).</value>
+  </data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Department/Department.fr.resx
+++ b/Core/Resgrid.Localization/Areas/User/Department/Department.fr.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -682,5 +682,11 @@
   </data>
   <data name="EnableModernNotificationsHelp" xml:space="preserve">
     <value>When enabled, push notifications will use the modern notification sounds instead of the legacy sounds for all users in this department.</value>
+  </data>
+  <data name="ForceChatbotSecurityPin" xml:space="preserve">
+    <value>Exiger le code PIN de sécurité</value>
+  </data>
+  <data name="ForceChatbotSecurityPinHelp" xml:space="preserve">
+    <value>Exige que chaque membre confirme les actions dangereuses ou à l'échelle du service du chatbot/SMS avec son code PIN de sécurité personnel à 4 chiffres. Les membres sans PIN en reçoivent un généré aléatoirement (visible sur leur page de profil).</value>
   </data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Department/Department.it.resx
+++ b/Core/Resgrid.Localization/Areas/User/Department/Department.it.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -682,5 +682,11 @@
   </data>
   <data name="EnableModernNotificationsHelp" xml:space="preserve">
     <value>When enabled, push notifications will use the modern notification sounds instead of the legacy sounds for all users in this department.</value>
+  </data>
+  <data name="ForceChatbotSecurityPin" xml:space="preserve">
+    <value>Richiedi PIN di sicurezza</value>
+  </data>
+  <data name="ForceChatbotSecurityPinHelp" xml:space="preserve">
+    <value>Richiede che ogni membro confermi le azioni pericolose o a livello di dipartimento del chatbot/SMS con il proprio PIN di sicurezza personale a 4 cifre. I membri senza PIN ne ricevono uno generato casualmente (visibile nella pagina del profilo).</value>
   </data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Department/Department.pl.resx
+++ b/Core/Resgrid.Localization/Areas/User/Department/Department.pl.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -682,5 +682,11 @@
   </data>
   <data name="EnableModernNotificationsHelp" xml:space="preserve">
     <value>When enabled, push notifications will use the modern notification sounds instead of the legacy sounds for all users in this department.</value>
+  </data>
+  <data name="ForceChatbotSecurityPin" xml:space="preserve">
+    <value>Wymagaj kodu PIN bezpieczeństwa</value>
+  </data>
+  <data name="ForceChatbotSecurityPinHelp" xml:space="preserve">
+    <value>Wymaga, aby każdy członek potwierdzał niebezpieczne lub obejmujące cały wydział akcje chatbota/SMS swoim osobistym 4-cyfrowym kodem PIN bezpieczeństwa. Członkowie bez kodu PIN otrzymują losowo wygenerowany (widoczny na stronie profilu).</value>
   </data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Department/Department.resx
+++ b/Core/Resgrid.Localization/Areas/User/Department/Department.resx
@@ -357,4 +357,10 @@
   <data name="EnableModernNotificationsHelp" xml:space="preserve">
     <value>When enabled, push notifications will use the modern notification sounds instead of the legacy sounds for all users in this department.</value>
   </data>
+  <data name="ForceChatbotSecurityPin" xml:space="preserve">
+    <value>Require Security PIN</value>
+  </data>
+  <data name="ForceChatbotSecurityPinHelp" xml:space="preserve">
+    <value>Require every member to confirm dangerous or department-wide chatbot/text actions with their personal 4-digit security PIN. Members without a PIN get a randomly generated one (viewable on their profile page).</value>
+  </data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Department/Department.sv.resx
+++ b/Core/Resgrid.Localization/Areas/User/Department/Department.sv.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -682,5 +682,11 @@
   </data>
   <data name="EnableModernNotificationsHelp" xml:space="preserve">
     <value>When enabled, push notifications will use the modern notification sounds instead of the legacy sounds for all users in this department.</value>
+  </data>
+  <data name="ForceChatbotSecurityPin" xml:space="preserve">
+    <value>Kräv säkerhets-PIN</value>
+  </data>
+  <data name="ForceChatbotSecurityPinHelp" xml:space="preserve">
+    <value>Kräver att varje medlem bekräftar farliga eller avdelningsövergripande chatbot-/SMS-åtgärder med sin personliga 4-siffriga säkerhets-PIN. Medlemmar utan PIN får en slumpmässigt genererad (visas på deras profilsida).</value>
   </data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Department/Department.uk.resx
+++ b/Core/Resgrid.Localization/Areas/User/Department/Department.uk.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -682,5 +682,11 @@
   </data>
   <data name="EnableModernNotificationsHelp" xml:space="preserve">
     <value>When enabled, push notifications will use the modern notification sounds instead of the legacy sounds for all users in this department.</value>
+  </data>
+  <data name="ForceChatbotSecurityPin" xml:space="preserve">
+    <value>Вимагати PIN-код безпеки</value>
+  </data>
+  <data name="ForceChatbotSecurityPinHelp" xml:space="preserve">
+    <value>Вимагає, щоб кожен учасник підтверджував небезпечні або загальновідомчі дії чат-бота/SMS своїм особистим 4-значним PIN-кодом безпеки. Учасники без PIN-коду отримують випадково згенерований (доступний на сторінці профілю).</value>
   </data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Home/EditProfile.ar.resx
+++ b/Core/Resgrid.Localization/Areas/User/Home/EditProfile.ar.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
   <resheader name="version"><value>2.0</value></resheader>
@@ -107,4 +107,22 @@
   <data name="PasswordRequirementsLength" xml:space="preserve"><value>على الأقل {0} أحرف</value></data>
   <data name="PasswordRequirementsDigit" xml:space="preserve"><value>رقم واحد على الأقل</value></data>
   <data name="PasswordRequirementsCase" xml:space="preserve"><value>حرف كبير وحرف صغير على الأقل</value></data>
+  <data name="SecurityPinEnabledHelp" xml:space="preserve">
+    <value>عند التفعيل، تطلب الإجراءات الخطرة عبر روبوت الدردشة/الرسائل النصية رمز PIN كخطوة أمان إضافية. إذا فعّلت هذا بدون رمز PIN، يتم إنشاء رمز عشوائي لك.</value>
+  </data>
+  <data name="SecurityPinEnabledLabel" xml:space="preserve">
+    <value>طلب رمز PIN الأمان</value>
+  </data>
+  <data name="SecurityPinForcedHelp" xml:space="preserve">
+    <value>يتطلب قسمك رمز PIN الأمان للإجراءات الخطرة عبر روبوت الدردشة/الرسائل النصية، لذلك يكون هذا الخيار مفعلاً دائمًا.</value>
+  </data>
+  <data name="SecurityPinHelp" xml:space="preserve">
+    <value>يؤكد رمز PIN الأمان المكون من 4 أرقام الإجراءات الخطرة أو على مستوى القسم التي تتم عبر الرسائل النصية أو روبوت الدردشة. تجنب الأرقام المتكررة (0000) والمتسلسلة (1234، 4321). اتركه فارغًا للاحتفاظ برمز PIN الحالي.</value>
+  </data>
+  <data name="SecurityPinLabel" xml:space="preserve">
+    <value>رمز PIN الأمان</value>
+  </data>
+  <data name="SecurityPinPlaceholder" xml:space="preserve">
+    <value>رمز PIN من 4 أرقام</value>
+  </data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Home/EditProfile.de.resx
+++ b/Core/Resgrid.Localization/Areas/User/Home/EditProfile.de.resx
@@ -365,4 +365,22 @@
   <data name="PasswordRequirementsLength" xml:space="preserve"><value>Mindestens {0} Zeichen lang</value></data>
   <data name="PasswordRequirementsDigit" xml:space="preserve"><value>Mindestens eine Ziffer (Zahl)</value></data>
   <data name="PasswordRequirementsCase" xml:space="preserve"><value>Mindestens ein Groß- und ein Kleinbuchstabe</value></data>
+  <data name="SecurityPinEnabledHelp" xml:space="preserve">
+    <value>Wenn aktiviert, fragen gefährliche Chatbot-/SMS-Aktionen Ihre PIN als zusätzlichen Sicherheitsschritt ab. Wenn Sie dies ohne PIN aktivieren, wird eine zufällige PIN für Sie generiert.</value>
+  </data>
+  <data name="SecurityPinEnabledLabel" xml:space="preserve">
+    <value>Sicherheits-PIN erforderlich</value>
+  </data>
+  <data name="SecurityPinForcedHelp" xml:space="preserve">
+    <value>Ihre Abteilung verlangt eine Sicherheits-PIN für gefährliche Chatbot-/SMS-Aktionen, daher ist diese Option immer aktiviert.</value>
+  </data>
+  <data name="SecurityPinHelp" xml:space="preserve">
+    <value>Ihre 4-stellige Sicherheits-PIN bestätigt gefährliche oder abteilungsweite Aktionen per SMS oder Chatbot. Vermeiden Sie wiederholte Ziffern (0000) und Folgen (1234, 4321). Leer lassen, um Ihre aktuelle PIN zu behalten.</value>
+  </data>
+  <data name="SecurityPinLabel" xml:space="preserve">
+    <value>Sicherheits-PIN</value>
+  </data>
+  <data name="SecurityPinPlaceholder" xml:space="preserve">
+    <value>4-stellige PIN</value>
+  </data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Home/EditProfile.en.resx
+++ b/Core/Resgrid.Localization/Areas/User/Home/EditProfile.en.resx
@@ -420,4 +420,22 @@
   <data name="PasswordRequirementsLength" xml:space="preserve"><value>At least {0} characters long</value></data>
   <data name="PasswordRequirementsDigit" xml:space="preserve"><value>At least one digit (number)</value></data>
   <data name="PasswordRequirementsCase" xml:space="preserve"><value>At least one uppercase and one lowercase letter</value></data>
+  <data name="SecurityPinEnabledHelp" xml:space="preserve">
+    <value>When enabled, dangerous chatbot/text actions ask for your PIN as an extra security step. If you enable this without a PIN a random one is generated for you.</value>
+  </data>
+  <data name="SecurityPinEnabledLabel" xml:space="preserve">
+    <value>Require Security PIN</value>
+  </data>
+  <data name="SecurityPinForcedHelp" xml:space="preserve">
+    <value>Your department requires a security PIN for dangerous chatbot/text actions, so this option is always on.</value>
+  </data>
+  <data name="SecurityPinHelp" xml:space="preserve">
+    <value>Your 4-digit security PIN confirms dangerous or department-wide actions performed over text message or chatbot. Avoid repeated digits (0000) and sequences (1234, 4321). Leave blank to keep your current PIN.</value>
+  </data>
+  <data name="SecurityPinLabel" xml:space="preserve">
+    <value>Security PIN</value>
+  </data>
+  <data name="SecurityPinPlaceholder" xml:space="preserve">
+    <value>4-digit PIN</value>
+  </data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Home/EditProfile.es.resx
+++ b/Core/Resgrid.Localization/Areas/User/Home/EditProfile.es.resx
@@ -411,4 +411,22 @@
   <data name="PasswordRequirementsLength" xml:space="preserve"><value>Al menos {0} caracteres</value></data>
   <data name="PasswordRequirementsDigit" xml:space="preserve"><value>Al menos un dígito (número)</value></data>
   <data name="PasswordRequirementsCase" xml:space="preserve"><value>Al menos una letra mayúscula y una minúscula</value></data>
+  <data name="SecurityPinEnabledHelp" xml:space="preserve">
+    <value>Cuando está activado, las acciones peligrosas de chatbot/mensajes de texto solicitan su PIN como paso de seguridad adicional. Si lo activa sin un PIN, se genera uno aleatorio para usted.</value>
+  </data>
+  <data name="SecurityPinEnabledLabel" xml:space="preserve">
+    <value>Requerir PIN de seguridad</value>
+  </data>
+  <data name="SecurityPinForcedHelp" xml:space="preserve">
+    <value>Su departamento requiere un PIN de seguridad para acciones peligrosas de chatbot/mensajes de texto, por lo que esta opción está siempre activada.</value>
+  </data>
+  <data name="SecurityPinHelp" xml:space="preserve">
+    <value>Su PIN de seguridad de 4 dígitos confirma acciones peligrosas o de todo el departamento realizadas por mensaje de texto o chatbot. Evite dígitos repetidos (0000) y secuencias (1234, 4321). Déjelo en blanco para conservar su PIN actual.</value>
+  </data>
+  <data name="SecurityPinLabel" xml:space="preserve">
+    <value>PIN de seguridad</value>
+  </data>
+  <data name="SecurityPinPlaceholder" xml:space="preserve">
+    <value>PIN de 4 dígitos</value>
+  </data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Home/EditProfile.fr.resx
+++ b/Core/Resgrid.Localization/Areas/User/Home/EditProfile.fr.resx
@@ -365,4 +365,22 @@
   <data name="PasswordRequirementsLength" xml:space="preserve"><value>Au moins {0} caractères</value></data>
   <data name="PasswordRequirementsDigit" xml:space="preserve"><value>Au moins un chiffre</value></data>
   <data name="PasswordRequirementsCase" xml:space="preserve"><value>Au moins une lettre majuscule et une minuscule</value></data>
+  <data name="SecurityPinEnabledHelp" xml:space="preserve">
+    <value>Lorsqu'elle est activée, les actions dangereuses du chatbot/SMS demandent votre PIN comme étape de sécurité supplémentaire. Si vous l'activez sans PIN, un code aléatoire est généré pour vous.</value>
+  </data>
+  <data name="SecurityPinEnabledLabel" xml:space="preserve">
+    <value>Exiger le code PIN de sécurité</value>
+  </data>
+  <data name="SecurityPinForcedHelp" xml:space="preserve">
+    <value>Votre service exige un code PIN de sécurité pour les actions dangereuses du chatbot/SMS, cette option est donc toujours activée.</value>
+  </data>
+  <data name="SecurityPinHelp" xml:space="preserve">
+    <value>Votre code PIN de sécurité à 4 chiffres confirme les actions dangereuses ou à l'échelle du service effectuées par SMS ou chatbot. Évitez les chiffres répétés (0000) et les séquences (1234, 4321). Laissez vide pour conserver votre PIN actuel.</value>
+  </data>
+  <data name="SecurityPinLabel" xml:space="preserve">
+    <value>Code PIN de sécurité</value>
+  </data>
+  <data name="SecurityPinPlaceholder" xml:space="preserve">
+    <value>PIN à 4 chiffres</value>
+  </data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Home/EditProfile.it.resx
+++ b/Core/Resgrid.Localization/Areas/User/Home/EditProfile.it.resx
@@ -365,4 +365,22 @@
   <data name="PasswordRequirementsLength" xml:space="preserve"><value>Almeno {0} caratteri</value></data>
   <data name="PasswordRequirementsDigit" xml:space="preserve"><value>Almeno una cifra (numero)</value></data>
   <data name="PasswordRequirementsCase" xml:space="preserve"><value>Almeno una lettera maiuscola e una minuscola</value></data>
+  <data name="SecurityPinEnabledHelp" xml:space="preserve">
+    <value>Se attivato, le azioni pericolose di chatbot/SMS richiedono il tuo PIN come passaggio di sicurezza aggiuntivo. Se lo attivi senza un PIN, ne viene generato uno casuale per te.</value>
+  </data>
+  <data name="SecurityPinEnabledLabel" xml:space="preserve">
+    <value>Richiedi PIN di sicurezza</value>
+  </data>
+  <data name="SecurityPinForcedHelp" xml:space="preserve">
+    <value>Il tuo dipartimento richiede un PIN di sicurezza per le azioni pericolose di chatbot/SMS, quindi questa opzione è sempre attiva.</value>
+  </data>
+  <data name="SecurityPinHelp" xml:space="preserve">
+    <value>Il tuo PIN di sicurezza a 4 cifre conferma le azioni pericolose o a livello di dipartimento eseguite tramite SMS o chatbot. Evita cifre ripetute (0000) e sequenze (1234, 4321). Lascia vuoto per mantenere il PIN attuale.</value>
+  </data>
+  <data name="SecurityPinLabel" xml:space="preserve">
+    <value>PIN di sicurezza</value>
+  </data>
+  <data name="SecurityPinPlaceholder" xml:space="preserve">
+    <value>PIN a 4 cifre</value>
+  </data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Home/EditProfile.pl.resx
+++ b/Core/Resgrid.Localization/Areas/User/Home/EditProfile.pl.resx
@@ -365,4 +365,22 @@
   <data name="PasswordRequirementsLength" xml:space="preserve"><value>Co najmniej {0} znaków</value></data>
   <data name="PasswordRequirementsDigit" xml:space="preserve"><value>Co najmniej jedna cyfra</value></data>
   <data name="PasswordRequirementsCase" xml:space="preserve"><value>Co najmniej jedna wielka i jedna mała litera</value></data>
+  <data name="SecurityPinEnabledHelp" xml:space="preserve">
+    <value>Po włączeniu niebezpieczne akcje chatbota/SMS wymagają podania kodu PIN jako dodatkowego zabezpieczenia. Jeśli włączysz tę opcję bez kodu PIN, zostanie wygenerowany losowy.</value>
+  </data>
+  <data name="SecurityPinEnabledLabel" xml:space="preserve">
+    <value>Wymagaj kodu PIN bezpieczeństwa</value>
+  </data>
+  <data name="SecurityPinForcedHelp" xml:space="preserve">
+    <value>Twój wydział wymaga kodu PIN bezpieczeństwa dla niebezpiecznych akcji chatbota/SMS, więc ta opcja jest zawsze włączona.</value>
+  </data>
+  <data name="SecurityPinHelp" xml:space="preserve">
+    <value>Twój 4-cyfrowy kod PIN bezpieczeństwa potwierdza niebezpieczne lub obejmujące cały wydział akcje wykonywane przez SMS lub chatbota. Unikaj powtarzających się cyfr (0000) i sekwencji (1234, 4321). Pozostaw puste, aby zachować obecny PIN.</value>
+  </data>
+  <data name="SecurityPinLabel" xml:space="preserve">
+    <value>Kod PIN bezpieczeństwa</value>
+  </data>
+  <data name="SecurityPinPlaceholder" xml:space="preserve">
+    <value>4-cyfrowy PIN</value>
+  </data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Home/EditProfile.sv.resx
+++ b/Core/Resgrid.Localization/Areas/User/Home/EditProfile.sv.resx
@@ -365,4 +365,22 @@
   <data name="PasswordRequirementsLength" xml:space="preserve"><value>Minst {0} tecken</value></data>
   <data name="PasswordRequirementsDigit" xml:space="preserve"><value>Minst en siffra</value></data>
   <data name="PasswordRequirementsCase" xml:space="preserve"><value>Minst en stor och en liten bokstav</value></data>
+  <data name="SecurityPinEnabledHelp" xml:space="preserve">
+    <value>När det är aktiverat begär farliga chatbot-/SMS-åtgärder din PIN som ett extra säkerhetssteg. Om du aktiverar detta utan PIN genereras en slumpmässig åt dig.</value>
+  </data>
+  <data name="SecurityPinEnabledLabel" xml:space="preserve">
+    <value>Kräv säkerhets-PIN</value>
+  </data>
+  <data name="SecurityPinForcedHelp" xml:space="preserve">
+    <value>Din avdelning kräver en säkerhets-PIN för farliga chatbot-/SMS-åtgärder, så det här alternativet är alltid på.</value>
+  </data>
+  <data name="SecurityPinHelp" xml:space="preserve">
+    <value>Din 4-siffriga säkerhets-PIN bekräftar farliga eller avdelningsövergripande åtgärder som utförs via SMS eller chatbot. Undvik upprepade siffror (0000) och sekvenser (1234, 4321). Lämna tomt för att behålla din nuvarande PIN.</value>
+  </data>
+  <data name="SecurityPinLabel" xml:space="preserve">
+    <value>Säkerhets-PIN</value>
+  </data>
+  <data name="SecurityPinPlaceholder" xml:space="preserve">
+    <value>4-siffrig PIN</value>
+  </data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Home/EditProfile.uk.resx
+++ b/Core/Resgrid.Localization/Areas/User/Home/EditProfile.uk.resx
@@ -365,4 +365,22 @@
   <data name="PasswordRequirementsLength" xml:space="preserve"><value>Щонайменше {0} символів</value></data>
   <data name="PasswordRequirementsDigit" xml:space="preserve"><value>Щонайменше одна цифра</value></data>
   <data name="PasswordRequirementsCase" xml:space="preserve"><value>Щонайменше одна велика та одна мала літера</value></data>
+  <data name="SecurityPinEnabledHelp" xml:space="preserve">
+    <value>Якщо ввімкнено, небезпечні дії чат-бота/SMS запитують ваш PIN як додатковий крок безпеки. Якщо ви ввімкнете це без PIN-коду, для вас буде згенеровано випадковий.</value>
+  </data>
+  <data name="SecurityPinEnabledLabel" xml:space="preserve">
+    <value>Вимагати PIN-код безпеки</value>
+  </data>
+  <data name="SecurityPinForcedHelp" xml:space="preserve">
+    <value>Ваш відділ вимагає PIN-код безпеки для небезпечних дій чат-бота/SMS, тому цей параметр завжди ввімкнено.</value>
+  </data>
+  <data name="SecurityPinHelp" xml:space="preserve">
+    <value>Ваш 4-значний PIN-код безпеки підтверджує небезпечні або загальновідомчі дії, виконані через SMS або чат-бот. Уникайте повторюваних цифр (0000) і послідовностей (1234, 4321). Залиште порожнім, щоб зберегти поточний PIN.</value>
+  </data>
+  <data name="SecurityPinLabel" xml:space="preserve">
+    <value>PIN-код безпеки</value>
+  </data>
+  <data name="SecurityPinPlaceholder" xml:space="preserve">
+    <value>4-значний PIN</value>
+  </data>
 </root>

--- a/Core/Resgrid.Model/ChatbotIdentity.cs
+++ b/Core/Resgrid.Model/ChatbotIdentity.cs
@@ -14,6 +14,14 @@ namespace Resgrid.Model
 	[Table("ChatbotUserIdentities")]
 	public class ChatbotIdentity : IEntity
 	{
+		/// <summary>
+		/// SMS platform values, kept in sync with <c>Resgrid.Chatbot.Models.ChatbotPlatform</c>
+		/// (which Resgrid.Services cannot reference). Used when services outside the chatbot
+		/// project need to invalidate SMS-based identity links.
+		/// </summary>
+		public const int PlatformSmsTwilio = 1;
+		public const int PlatformSmsSignalWire = 2;
+
 		public string Id { get; set; }
 
 		[Required]

--- a/Core/Resgrid.Model/DepartmentSettingTypes.cs
+++ b/Core/Resgrid.Model/DepartmentSettingTypes.cs
@@ -55,5 +55,6 @@
 		UnitCallReleaseStatusToSet = 51,
 		UnitCallStatusOverridesByUnitType = 52,
 		EnableModernNotifications = 53,
+		ForceChatbotSecurityPin = 54,
 	}
 }

--- a/Core/Resgrid.Model/Repositories/IUserProfilesRepository.cs
+++ b/Core/Resgrid.Model/Repositories/IUserProfilesRepository.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Resgrid.Model.Repositories
@@ -51,5 +52,14 @@ namespace Resgrid.Model.Repositories
 		/// <param name="departmentId">The department identifier.</param>
 		/// <returns>Task&lt;IEnumerable&lt;UserProfile&gt;&gt;.</returns>
 		Task<IEnumerable<UserProfile>> GetAllUserProfilesForDepartmentIncDisabledDeletedAsync(int departmentId);
+
+		/// <summary>
+		/// Updates only the SecurityPin (and LastUpdated) columns for the supplied profiles as a
+		/// single batched command. Used for department-wide security PIN provisioning; callers are
+		/// responsible for profile cache eviction.
+		/// </summary>
+		/// <param name="profiles">Profiles with SecurityPin and LastUpdated already set.</param>
+		/// <param name="cancellationToken">The cancellation token.</param>
+		Task UpdateSecurityPinsAsync(IEnumerable<UserProfile> profiles, CancellationToken cancellationToken = default);
 	}
 }

--- a/Core/Resgrid.Model/Services/IDepartmentSettingsService.cs
+++ b/Core/Resgrid.Model/Services/IDepartmentSettingsService.cs
@@ -314,5 +314,11 @@ namespace Resgrid.Model.Services
 		Task<DepartmentSetting> GetSettingByTypeAsync(int departmentId, DepartmentSettingTypes type);
 
 		Task<bool> GetModernNotificationsEnabledAsync(int departmentId, bool bypassCache = false);
+
+		/// <summary>
+		/// True when the department forces every member to use their security PIN for dangerous
+		/// chatbot/SMS actions (overrides the per-user opt-in).
+		/// </summary>
+		Task<bool> GetForceChatbotSecurityPinAsync(int departmentId, bool bypassCache = false);
 	}
 }

--- a/Core/Resgrid.Model/Services/ISecurityPinService.cs
+++ b/Core/Resgrid.Model/Services/ISecurityPinService.cs
@@ -1,0 +1,41 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Resgrid.Model.Services
+{
+	/// <summary>
+	/// Manages the per-user 4-digit security PIN used as a step-up (2FA-style) check for
+	/// dangerous/department-wide chatbot and SMS actions. PINs are stored AES-encrypted on the
+	/// user profile. A user can opt in personally (UserProfile.SecurityPinEnabled) or a
+	/// department can force PIN usage for all members (DepartmentSettingTypes.ForceChatbotSecurityPin).
+	/// </summary>
+	public interface ISecurityPinService
+	{
+		/// <summary>
+		/// True when the user must supply their security PIN for dangerous actions: either the
+		/// department forces PIN usage or the user opted in on their profile.
+		/// </summary>
+		Task<bool> IsPinRequiredAsync(string userId, int departmentId);
+
+		/// <summary>True when the user has a security PIN set on their profile.</summary>
+		Task<bool> HasPinAsync(string userId);
+
+		/// <summary>Validates the supplied PIN against the user's stored (encrypted) PIN.</summary>
+		Task<bool> ValidatePinAsync(string userId, string pin);
+
+		/// <summary>Gets the user's decrypted PIN (for own-profile display), or null when none is set.</summary>
+		Task<string> GetPinAsync(string userId);
+
+		/// <summary>
+		/// Generates and saves a random PIN for the user when they don't have one yet.
+		/// Returns the profile (with a PIN guaranteed set) or null when no profile exists.
+		/// </summary>
+		Task<UserProfile> EnsurePinAsync(string userId, int departmentId, CancellationToken cancellationToken = default);
+
+		/// <summary>
+		/// Generates a random PIN for every member of the department that doesn't have one yet.
+		/// Used when a department enables the ForceChatbotSecurityPin setting.
+		/// </summary>
+		Task EnsurePinsForDepartmentAsync(int departmentId, CancellationToken cancellationToken = default);
+	}
+}

--- a/Core/Resgrid.Model/UserProfile.cs
+++ b/Core/Resgrid.Model/UserProfile.cs
@@ -184,6 +184,20 @@ namespace Resgrid.Model
 		[ProtoMember(50)]
 		public bool HomeVerificationVoiceCodeConsumed { get; set; }
 
+		/// <summary>
+		/// AES-encrypted (via IEncryptionService) 4-digit security PIN used as a step-up check for
+		/// dangerous/department-wide chatbot and SMS actions. Null = no PIN set yet.
+		/// </summary>
+		[ProtoMember(51)]
+		public string SecurityPin { get; set; }
+
+		/// <summary>
+		/// The user opted in to requiring their security PIN for dangerous chatbot/SMS actions.
+		/// The department-level ForceChatbotSecurityPin setting overrides this to on for everyone.
+		/// </summary>
+		[ProtoMember(52)]
+		public bool SecurityPinEnabled { get; set; }
+
 		[NotMapped]
 		[JsonIgnore]
 		public object IdValue

--- a/Core/Resgrid.Services/DepartmentSettingsService.cs
+++ b/Core/Resgrid.Services/DepartmentSettingsService.cs
@@ -23,6 +23,7 @@ namespace Resgrid.Services
 		private static string TtsLanguageCacheKey = "DSetTtsLanguage_{0}";
 		private static string PersonnelOnUnitSetUnitStatusCacheKey = "DSetPersonnelOnUnitSetUnitStatus_{0}";
 		private static string ModernNotificationsCacheKey = "DSetModernNotifications_{0}";
+		private static string ForceChatbotSecurityPinCacheKey = "DSetForceChatbotSecurityPin_{0}";
 		private static TimeSpan LongCacheLength = TimeSpan.FromDays(14);
 		private static TimeSpan ThatsNotLongThisIsLongCacheLength = TimeSpan.FromDays(365);
 		private static TimeSpan TwoYearCacheLength = TimeSpan.FromDays(730);
@@ -84,6 +85,9 @@ namespace Resgrid.Services
 						break;
 					case DepartmentSettingTypes.EnableModernNotifications:
 						await _cacheProvider.RemoveAsync(string.Format(ModernNotificationsCacheKey, departmentId));
+						break;
+					case DepartmentSettingTypes.ForceChatbotSecurityPin:
+						await _cacheProvider.RemoveAsync(string.Format(ForceChatbotSecurityPinCacheKey, departmentId));
 						break;
 				}
 
@@ -948,6 +952,23 @@ namespace Resgrid.Services
 			if (Config.SystemBehaviorConfig.CacheEnabled && !bypassCache)
 			{
 				var cachedValue = await _cacheProvider.RetrieveAsync<string>(string.Format(ModernNotificationsCacheKey, departmentId), getSetting, LongCacheLength);
+				return bool.Parse(cachedValue);
+			}
+
+			return bool.Parse(await getSetting());
+		}
+
+		public async Task<bool> GetForceChatbotSecurityPinAsync(int departmentId, bool bypassCache = false)
+		{
+			async Task<string> getSetting()
+			{
+				var s = await GetSettingByDepartmentIdType(departmentId, DepartmentSettingTypes.ForceChatbotSecurityPin);
+				return s?.Setting ?? "false";
+			}
+
+			if (Config.SystemBehaviorConfig.CacheEnabled && !bypassCache)
+			{
+				var cachedValue = await _cacheProvider.RetrieveAsync<string>(string.Format(ForceChatbotSecurityPinCacheKey, departmentId), getSetting, LongCacheLength);
 				return bool.Parse(cachedValue);
 			}
 

--- a/Core/Resgrid.Services/SecurityPinService.cs
+++ b/Core/Resgrid.Services/SecurityPinService.cs
@@ -1,8 +1,10 @@
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Resgrid.Framework;
 using Resgrid.Model;
+using Resgrid.Model.Repositories;
 using Resgrid.Model.Services;
 
 namespace Resgrid.Services
@@ -17,13 +19,15 @@ namespace Resgrid.Services
 		private readonly IUserProfileService _userProfileService;
 		private readonly IDepartmentSettingsService _departmentSettingsService;
 		private readonly IEncryptionService _encryptionService;
+		private readonly IUserProfilesRepository _userProfileRepository;
 
 		public SecurityPinService(IUserProfileService userProfileService, IDepartmentSettingsService departmentSettingsService,
-			IEncryptionService encryptionService)
+			IEncryptionService encryptionService, IUserProfilesRepository userProfileRepository)
 		{
 			_userProfileService = userProfileService;
 			_departmentSettingsService = departmentSettingsService;
 			_encryptionService = encryptionService;
+			_userProfileRepository = userProfileRepository;
 		}
 
 		public async Task<bool> IsPinRequiredAsync(string userId, int departmentId)
@@ -87,14 +91,30 @@ namespace Resgrid.Services
 			if (profiles == null)
 				return;
 
-			foreach (var profile in profiles.Values)
-			{
-				if (!string.IsNullOrWhiteSpace(profile.SecurityPin))
-					continue;
+			// Batch: generate all PINs in memory, then persist in a single bulk update rather than a
+			// full profile save per member.
+			var toUpdate = profiles.Values
+				.Where(p => string.IsNullOrWhiteSpace(p.SecurityPin))
+				.ToList();
 
+			if (toUpdate.Count == 0)
+				return;
+
+			var now = DateTime.UtcNow;
+			foreach (var profile in toUpdate)
+			{
 				profile.SecurityPin = _encryptionService.Encrypt(SecurityPinUtility.Generate());
-				await _userProfileService.SaveProfileAsync(departmentId, profile, cancellationToken);
+				profile.LastUpdated = now;
 			}
+
+			await _userProfileRepository.UpdateSecurityPinsAsync(toUpdate, cancellationToken);
+
+			// Match SaveProfileAsync's cache eviction: each member's profile cache plus the
+			// department-wide profile list.
+			foreach (var profile in toUpdate)
+				_userProfileService.ClearUserProfileFromCache(profile.UserId);
+
+			_userProfileService.ClearAllUserProfilesFromCache(departmentId);
 		}
 	}
 }

--- a/Core/Resgrid.Services/SecurityPinService.cs
+++ b/Core/Resgrid.Services/SecurityPinService.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Resgrid.Framework;
+using Resgrid.Model;
+using Resgrid.Model.Services;
+
+namespace Resgrid.Services
+{
+	/// <summary>
+	/// Implements the per-user security PIN used as a step-up check for dangerous/department-wide
+	/// chatbot and SMS actions. PINs are stored AES-encrypted (via <see cref="IEncryptionService"/>)
+	/// on the user profile, mirroring how contact verification codes are stored.
+	/// </summary>
+	public class SecurityPinService : ISecurityPinService
+	{
+		private readonly IUserProfileService _userProfileService;
+		private readonly IDepartmentSettingsService _departmentSettingsService;
+		private readonly IEncryptionService _encryptionService;
+
+		public SecurityPinService(IUserProfileService userProfileService, IDepartmentSettingsService departmentSettingsService,
+			IEncryptionService encryptionService)
+		{
+			_userProfileService = userProfileService;
+			_departmentSettingsService = departmentSettingsService;
+			_encryptionService = encryptionService;
+		}
+
+		public async Task<bool> IsPinRequiredAsync(string userId, int departmentId)
+		{
+			if (await _departmentSettingsService.GetForceChatbotSecurityPinAsync(departmentId))
+				return true;
+
+			var profile = await _userProfileService.GetProfileByUserIdAsync(userId);
+			return profile != null && profile.SecurityPinEnabled;
+		}
+
+		public async Task<bool> HasPinAsync(string userId)
+		{
+			var profile = await _userProfileService.GetProfileByUserIdAsync(userId);
+			return !string.IsNullOrWhiteSpace(profile?.SecurityPin);
+		}
+
+		public async Task<bool> ValidatePinAsync(string userId, string pin)
+		{
+			if (!SecurityPinUtility.IsValidFormat(pin))
+				return false;
+
+			var storedPin = await GetPinAsync(userId);
+			return storedPin != null && string.Equals(storedPin, pin, StringComparison.Ordinal);
+		}
+
+		public async Task<string> GetPinAsync(string userId)
+		{
+			var profile = await _userProfileService.GetProfileByUserIdAsync(userId);
+			if (string.IsNullOrWhiteSpace(profile?.SecurityPin))
+				return null;
+
+			try
+			{
+				return _encryptionService.Decrypt(profile.SecurityPin);
+			}
+			catch (Exception ex)
+			{
+				// An undecryptable value (corrupted or written with a different key) is treated as no PIN.
+				Logging.LogException(ex);
+				return null;
+			}
+		}
+
+		public async Task<UserProfile> EnsurePinAsync(string userId, int departmentId, CancellationToken cancellationToken = default)
+		{
+			var profile = await _userProfileService.GetProfileByUserIdAsync(userId, bypassCache: true);
+			if (profile == null)
+				return null;
+
+			if (!string.IsNullOrWhiteSpace(profile.SecurityPin))
+				return profile;
+
+			profile.SecurityPin = _encryptionService.Encrypt(SecurityPinUtility.Generate());
+			return await _userProfileService.SaveProfileAsync(departmentId, profile, cancellationToken);
+		}
+
+		public async Task EnsurePinsForDepartmentAsync(int departmentId, CancellationToken cancellationToken = default)
+		{
+			var profiles = await _userProfileService.GetAllProfilesForDepartmentAsync(departmentId, bypassCache: true);
+			if (profiles == null)
+				return;
+
+			foreach (var profile in profiles.Values)
+			{
+				if (!string.IsNullOrWhiteSpace(profile.SecurityPin))
+					continue;
+
+				profile.SecurityPin = _encryptionService.Encrypt(SecurityPinUtility.Generate());
+				await _userProfileService.SaveProfileAsync(departmentId, profile, cancellationToken);
+			}
+		}
+	}
+}

--- a/Core/Resgrid.Services/ServicesModule.cs
+++ b/Core/Resgrid.Services/ServicesModule.cs
@@ -93,6 +93,7 @@ namespace Resgrid.Services
 			builder.RegisterType<VoiceService>().As<IVoiceService>().InstancePerLifetimeScope();
 			builder.RegisterType<SystemAuditsService>().As<ISystemAuditsService>().InstancePerLifetimeScope();
 			builder.RegisterType<ContactVerificationService>().As<IContactVerificationService>().InstancePerLifetimeScope();
+			builder.RegisterType<SecurityPinService>().As<ISecurityPinService>().InstancePerLifetimeScope();
 			builder.RegisterType<AutofillsService>().As<IAutofillsService>().InstancePerLifetimeScope();
 			builder.RegisterType<UnitStatesService>().As<IUnitStatesService>().InstancePerLifetimeScope();
 			builder.Register(_ =>

--- a/Core/Resgrid.Services/UserProfileService.cs
+++ b/Core/Resgrid.Services/UserProfileService.cs
@@ -18,11 +18,14 @@ namespace Resgrid.Services
 
 		private readonly IUserProfilesRepository _userProfileRepository;
 		private readonly ICacheProvider _cacheProvider;
+		private readonly IChatbotIdentityRepository _chatbotIdentityRepository;
 
-		public UserProfileService(IUserProfilesRepository userProfileRepository, ICacheProvider cacheProvider)
+		public UserProfileService(IUserProfilesRepository userProfileRepository, ICacheProvider cacheProvider,
+			IChatbotIdentityRepository chatbotIdentityRepository)
 		{
 			_userProfileRepository = userProfileRepository;
 			_cacheProvider = cacheProvider;
+			_chatbotIdentityRepository = chatbotIdentityRepository;
 		}
 
 		public async Task<UserProfile> GetProfileByUserIdAsync(string userId, bool bypassCache = false)
@@ -75,6 +78,12 @@ namespace Resgrid.Services
 			// Load existing profile directly from repository (bypass cache) to detect contact changes
 			var existing = await _userProfileRepository.GetProfileByUserIdAsync(profile.UserId);
 
+			// A null SecurityPin means "not supplied by this caller" — keep the stored (encrypted) PIN
+			// so profile saves from flows that don't know about PINs can't silently wipe it. Clearing a
+			// PIN intentionally is done by saving an empty string.
+			if (existing != null && profile.SecurityPin == null && existing.SecurityPin != null)
+				profile.SecurityPin = existing.SecurityPin;
+
 			if (existing == null)
 			{
 				// Brand-new profile (admin-created user) — mark all contact methods as pending
@@ -96,6 +105,11 @@ namespace Resgrid.Services
 					profile.MobileVerificationVoiceCodeConsumed = false;
 					profile.MobileVerificationAttempts = 0;
 					profile.MobileVerificationAttemptsResetDate = null;
+
+					// The old number no longer identifies this user: remove any SMS chatbot identity
+					// links so inbound texts can't act as this account until the new number is verified
+					// and re-linked.
+					await RemoveSmsChatbotIdentitiesAsync(profile.UserId, cancellationToken);
 				}
 				if (!string.Equals(existing.HomeNumber ?? string.Empty, profile.HomeNumber ?? string.Empty, StringComparison.OrdinalIgnoreCase))
 				{
@@ -123,6 +137,19 @@ namespace Resgrid.Services
 			ClearAllUserProfilesFromCache(DepartmentId);
 
 			return savedProfile;
+		}
+
+		private async Task RemoveSmsChatbotIdentitiesAsync(string userId, CancellationToken cancellationToken)
+		{
+			var identities = await _chatbotIdentityRepository.GetAllByUserIdAsync(userId);
+			if (identities == null)
+				return;
+
+			foreach (var identity in identities.Where(i =>
+						 i.Platform == ChatbotIdentity.PlatformSmsTwilio || i.Platform == ChatbotIdentity.PlatformSmsSignalWire))
+			{
+				await _chatbotIdentityRepository.DeleteAsync(identity, cancellationToken);
+			}
 		}
 
 		public void ClearUserProfileFromCache(string userId)

--- a/Providers/Resgrid.Providers.Migrations/Migrations/M0089_AddingUserSecurityPin.cs
+++ b/Providers/Resgrid.Providers.Migrations/Migrations/M0089_AddingUserSecurityPin.cs
@@ -1,0 +1,21 @@
+using FluentMigrator;
+
+namespace Resgrid.Providers.Migrations.Migrations
+{
+	[Migration(89)]
+	public class M0089_AddingUserSecurityPin : Migration
+	{
+		public override void Up()
+		{
+			Alter.Table("UserProfiles")
+				.AddColumn("SecurityPin").AsString(512).Nullable()
+				.AddColumn("SecurityPinEnabled").AsBoolean().NotNullable().WithDefaultValue(false);
+		}
+
+		public override void Down()
+		{
+			Delete.Column("SecurityPin").FromTable("UserProfiles");
+			Delete.Column("SecurityPinEnabled").FromTable("UserProfiles");
+		}
+	}
+}

--- a/Providers/Resgrid.Providers.MigrationsPg/Migrations/M0089_AddingUserSecurityPinPg.cs
+++ b/Providers/Resgrid.Providers.MigrationsPg/Migrations/M0089_AddingUserSecurityPinPg.cs
@@ -1,0 +1,21 @@
+using FluentMigrator;
+
+namespace Resgrid.Providers.MigrationsPg.Migrations
+{
+	[Migration(89)]
+	public class M0089_AddingUserSecurityPinPg : Migration
+	{
+		public override void Up()
+		{
+			Alter.Table("UserProfiles".ToLower())
+				.AddColumn("SecurityPin".ToLower()).AsCustom("citext").Nullable()
+				.AddColumn("SecurityPinEnabled".ToLower()).AsBoolean().NotNullable().WithDefaultValue(false);
+		}
+
+		public override void Down()
+		{
+			Delete.Column("SecurityPin".ToLower()).FromTable("UserProfiles".ToLower());
+			Delete.Column("SecurityPinEnabled".ToLower()).FromTable("UserProfiles".ToLower());
+		}
+	}
+}

--- a/Repositories/Resgrid.Repositories.DataRepository/Modules/TestingDataModule.cs
+++ b/Repositories/Resgrid.Repositories.DataRepository/Modules/TestingDataModule.cs
@@ -189,6 +189,7 @@ namespace Resgrid.Repositories.DataRepository
 			builder.RegisterType<ContactNotesRepository>().As<IContactNotesRepository>().InstancePerLifetimeScope();
 			builder.RegisterType<ContactsRepository>().As<IContactsRepository>().InstancePerLifetimeScope();
 			builder.RegisterType<ContactCategoryRepository>().As<IContactCategoryRepository>().InstancePerLifetimeScope();
+			builder.RegisterType<ChatbotIdentityRepository>().As<IChatbotIdentityRepository>().InstancePerLifetimeScope();
 
 			// Indoor Maps Repositories
 			builder.RegisterType<IndoorMapsRepository>().As<IIndoorMapsRepository>().InstancePerLifetimeScope();

--- a/Repositories/Resgrid.Repositories.DataRepository/UserProfilesRepository.cs
+++ b/Repositories/Resgrid.Repositories.DataRepository/UserProfilesRepository.cs
@@ -4,8 +4,10 @@ using System.Data.Common;
 using System.Linq;
 using Resgrid.Model;
 using Resgrid.Model.Repositories;
+using System.Threading;
 using System.Threading.Tasks;
 using Dapper;
+using Resgrid.Config;
 using Resgrid.Framework;
 using Resgrid.Model.Identity;
 using Resgrid.Model.Repositories.Connection;
@@ -309,6 +311,55 @@ namespace Resgrid.Repositories.DataRepository
 				Logging.LogException(ex);
 
 				return null;
+			}
+		}
+
+		public async Task UpdateSecurityPinsAsync(IEnumerable<UserProfile> profiles, CancellationToken cancellationToken = default)
+		{
+			try
+			{
+				var items = profiles?
+					.Where(p => p != null)
+					.Select(p => new { p.SecurityPin, p.LastUpdated, p.UserProfileId })
+					.ToList();
+
+				if (items == null || items.Count == 0)
+					return;
+
+				var pn = _sqlConfiguration.ParameterNotation;
+				var sql = DataConfig.DatabaseType == DatabaseTypes.Postgres
+					? $"UPDATE {_sqlConfiguration.SchemaName}.userprofiles SET securitypin = {pn}SecurityPin, lastupdated = {pn}LastUpdated WHERE userprofileid = {pn}UserProfileId"
+					: $"UPDATE {_sqlConfiguration.SchemaName}.[UserProfiles] SET [SecurityPin] = {pn}SecurityPin, [LastUpdated] = {pn}LastUpdated WHERE [UserProfileId] = {pn}UserProfileId";
+
+				// Dapper executes the statement once per item over a single prepared command/connection.
+				if (_unitOfWork?.Connection == null)
+				{
+					using (var conn = _connectionProvider.Create())
+					{
+						await conn.OpenAsync(cancellationToken);
+
+						// No ambient unit-of-work: run the batch atomically so a mid-batch failure
+						// rolls back rather than leaving some members with PINs and others without.
+						using (var transaction = await conn.BeginTransactionAsync(cancellationToken))
+						{
+							await conn.ExecuteAsync(sql, items, transaction);
+							await transaction.CommitAsync(cancellationToken);
+						}
+					}
+				}
+				else
+				{
+					// Ambient unit-of-work: participate in the caller's transaction.
+					var connection = _unitOfWork.CreateOrGetConnection();
+					await connection.ExecuteAsync(sql, items, _unitOfWork.Transaction);
+				}
+			}
+			catch (Exception ex)
+			{
+				// Rethrow (unlike the read paths): callers gate follow-on writes — e.g. persisting the
+				// department force-PIN setting — on this batch succeeding.
+				Logging.LogException(ex);
+				throw;
 			}
 		}
 

--- a/Tests/Resgrid.Tests/Services/SecurityPinServiceTests.cs
+++ b/Tests/Resgrid.Tests/Services/SecurityPinServiceTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -6,6 +7,7 @@ using Moq;
 using NUnit.Framework;
 using Resgrid.Framework;
 using Resgrid.Model;
+using Resgrid.Model.Repositories;
 using Resgrid.Model.Services;
 using Resgrid.Services;
 
@@ -79,6 +81,7 @@ namespace Resgrid.Tests.Services
 			protected Mock<IUserProfileService> _userProfileServiceMock;
 			protected Mock<IDepartmentSettingsService> _departmentSettingsServiceMock;
 			protected Mock<IEncryptionService> _encryptionServiceMock;
+			protected Mock<IUserProfilesRepository> _userProfileRepositoryMock;
 			protected ISecurityPinService _securityPinService;
 
 			protected const string UserId = "user1";
@@ -100,10 +103,13 @@ namespace Resgrid.Tests.Services
 					.Setup(e => e.Decrypt(It.IsAny<string>()))
 					.Returns<string>(cipher => cipher.StartsWith("ENC:") ? cipher.Substring(4) : cipher);
 
+				_userProfileRepositoryMock = new Mock<IUserProfilesRepository>();
+
 				_securityPinService = new SecurityPinService(
 					_userProfileServiceMock.Object,
 					_departmentSettingsServiceMock.Object,
-					_encryptionServiceMock.Object);
+					_encryptionServiceMock.Object,
+					_userProfileRepositoryMock.Object);
 			}
 
 			protected void SetupProfile(UserProfile profile)
@@ -231,7 +237,7 @@ namespace Resgrid.Tests.Services
 		public class when_ensuring_pins_for_a_department : with_the_security_pin_service
 		{
 			[Test]
-			public async Task only_members_without_a_pin_get_one()
+			public async Task only_members_without_a_pin_get_one_via_a_single_bulk_update()
 			{
 				var withPin = new UserProfile { UserId = "hasPin", SecurityPin = "ENC:2580" };
 				var withoutPin = new UserProfile { UserId = "noPin" };
@@ -239,16 +245,42 @@ namespace Resgrid.Tests.Services
 				_userProfileServiceMock
 					.Setup(s => s.GetAllProfilesForDepartmentAsync(DepartmentId, It.IsAny<bool>()))
 					.ReturnsAsync(new Dictionary<string, UserProfile> { { withPin.UserId, withPin }, { withoutPin.UserId, withoutPin } });
-				_userProfileServiceMock
-					.Setup(s => s.SaveProfileAsync(DepartmentId, It.IsAny<UserProfile>(), It.IsAny<CancellationToken>()))
-					.ReturnsAsync((int d, UserProfile p, CancellationToken c) => p);
+
+				List<UserProfile> updated = null;
+				_userProfileRepositoryMock
+					.Setup(r => r.UpdateSecurityPinsAsync(It.IsAny<IEnumerable<UserProfile>>(), It.IsAny<CancellationToken>()))
+					.Callback<IEnumerable<UserProfile>, CancellationToken>((p, c) => updated = p.ToList())
+					.Returns(Task.CompletedTask);
 
 				await _securityPinService.EnsurePinsForDepartmentAsync(DepartmentId);
 
 				withPin.SecurityPin.Should().Be("ENC:2580");
 				withoutPin.SecurityPin.Should().StartWith("ENC:");
-				_userProfileServiceMock.Verify(s => s.SaveProfileAsync(DepartmentId, withoutPin, It.IsAny<CancellationToken>()), Times.Once);
-				_userProfileServiceMock.Verify(s => s.SaveProfileAsync(DepartmentId, withPin, It.IsAny<CancellationToken>()), Times.Never);
+				withoutPin.LastUpdated.Should().NotBeNull();
+
+				updated.Should().ContainSingle().Which.Should().BeSameAs(withoutPin);
+				_userProfileRepositoryMock.Verify(r => r.UpdateSecurityPinsAsync(It.IsAny<IEnumerable<UserProfile>>(), It.IsAny<CancellationToken>()), Times.Once);
+				_userProfileServiceMock.Verify(s => s.SaveProfileAsync(It.IsAny<int>(), It.IsAny<UserProfile>(), It.IsAny<CancellationToken>()), Times.Never);
+
+				// Cache eviction must match SaveProfileAsync: the updated member plus the department list.
+				_userProfileServiceMock.Verify(s => s.ClearUserProfileFromCache(withoutPin.UserId), Times.Once);
+				_userProfileServiceMock.Verify(s => s.ClearUserProfileFromCache(withPin.UserId), Times.Never);
+				_userProfileServiceMock.Verify(s => s.ClearAllUserProfilesFromCache(DepartmentId), Times.Once);
+			}
+
+			[Test]
+			public async Task no_bulk_update_when_everyone_has_a_pin()
+			{
+				var withPin = new UserProfile { UserId = "hasPin", SecurityPin = "ENC:2580" };
+
+				_userProfileServiceMock
+					.Setup(s => s.GetAllProfilesForDepartmentAsync(DepartmentId, It.IsAny<bool>()))
+					.ReturnsAsync(new Dictionary<string, UserProfile> { { withPin.UserId, withPin } });
+
+				await _securityPinService.EnsurePinsForDepartmentAsync(DepartmentId);
+
+				_userProfileRepositoryMock.Verify(r => r.UpdateSecurityPinsAsync(It.IsAny<IEnumerable<UserProfile>>(), It.IsAny<CancellationToken>()), Times.Never);
+				_userProfileServiceMock.Verify(s => s.ClearAllUserProfilesFromCache(It.IsAny<int>()), Times.Never);
 			}
 		}
 	}

--- a/Tests/Resgrid.Tests/Services/SecurityPinServiceTests.cs
+++ b/Tests/Resgrid.Tests/Services/SecurityPinServiceTests.cs
@@ -1,0 +1,255 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using Resgrid.Framework;
+using Resgrid.Model;
+using Resgrid.Model.Services;
+using Resgrid.Services;
+
+namespace Resgrid.Tests.Services
+{
+	namespace SecurityPinUtilityTests
+	{
+		[TestFixture]
+		public class when_validating_pin_format
+		{
+			[TestCase("2580", ExpectedResult = true)]
+			[TestCase("7392", ExpectedResult = true)]
+			[TestCase("123", ExpectedResult = false)]
+			[TestCase("12345", ExpectedResult = false)]
+			[TestCase("12a4", ExpectedResult = false)]
+			[TestCase("", ExpectedResult = false)]
+			[TestCase(null, ExpectedResult = false)]
+			[TestCase(" 123", ExpectedResult = false)]
+			public bool validates_format(string pin) => SecurityPinUtility.IsValidFormat(pin);
+		}
+
+		[TestFixture]
+		public class when_checking_pin_strength
+		{
+			[TestCase("0000")]
+			[TestCase("1111")]
+			[TestCase("9999")]
+			[TestCase("1234")]
+			[TestCase("0123")]
+			[TestCase("6789")]
+			[TestCase("4321")]
+			[TestCase("9876")]
+			[TestCase("3210")]
+			public void rejects_weak_pins(string pin)
+			{
+				SecurityPinUtility.IsWeak(pin).Should().BeTrue();
+				SecurityPinUtility.IsAcceptable(pin).Should().BeFalse();
+			}
+
+			[TestCase("2580")]
+			[TestCase("1357")]
+			[TestCase("7392")]
+			[TestCase("1233")]
+			[TestCase("1235")]
+			public void accepts_normal_pins(string pin)
+			{
+				SecurityPinUtility.IsWeak(pin).Should().BeFalse();
+				SecurityPinUtility.IsAcceptable(pin).Should().BeTrue();
+			}
+		}
+
+		[TestFixture]
+		public class when_generating_a_pin
+		{
+			[Test]
+			public void generated_pins_are_always_acceptable()
+			{
+				for (int i = 0; i < 250; i++)
+				{
+					var pin = SecurityPinUtility.Generate();
+					SecurityPinUtility.IsAcceptable(pin).Should().BeTrue($"generated pin '{pin}' should be acceptable");
+				}
+			}
+		}
+	}
+
+	namespace SecurityPinServiceTests
+	{
+		public class with_the_security_pin_service : TestBase
+		{
+			protected Mock<IUserProfileService> _userProfileServiceMock;
+			protected Mock<IDepartmentSettingsService> _departmentSettingsServiceMock;
+			protected Mock<IEncryptionService> _encryptionServiceMock;
+			protected ISecurityPinService _securityPinService;
+
+			protected const string UserId = "user1";
+			protected const int DepartmentId = 42;
+
+			[SetUp]
+			public void SetUpSecurityPinService()
+			{
+				_userProfileServiceMock = new Mock<IUserProfileService>();
+				_departmentSettingsServiceMock = new Mock<IDepartmentSettingsService>();
+
+				// Passthrough encryption mock: Encrypt wraps with "ENC:" so tests can verify the
+				// persisted value is transformed, and Decrypt strips it back.
+				_encryptionServiceMock = new Mock<IEncryptionService>();
+				_encryptionServiceMock
+					.Setup(e => e.Encrypt(It.IsAny<string>()))
+					.Returns<string>(plain => "ENC:" + plain);
+				_encryptionServiceMock
+					.Setup(e => e.Decrypt(It.IsAny<string>()))
+					.Returns<string>(cipher => cipher.StartsWith("ENC:") ? cipher.Substring(4) : cipher);
+
+				_securityPinService = new SecurityPinService(
+					_userProfileServiceMock.Object,
+					_departmentSettingsServiceMock.Object,
+					_encryptionServiceMock.Object);
+			}
+
+			protected void SetupProfile(UserProfile profile)
+			{
+				_userProfileServiceMock
+					.Setup(s => s.GetProfileByUserIdAsync(UserId, It.IsAny<bool>()))
+					.ReturnsAsync(profile);
+			}
+
+			protected void SetupForcePin(bool forced)
+			{
+				_departmentSettingsServiceMock
+					.Setup(s => s.GetForceChatbotSecurityPinAsync(DepartmentId, It.IsAny<bool>()))
+					.ReturnsAsync(forced);
+			}
+		}
+
+		[TestFixture]
+		public class when_checking_if_a_pin_is_required : with_the_security_pin_service
+		{
+			[Test]
+			public async Task required_when_department_forces_pins()
+			{
+				SetupForcePin(true);
+				SetupProfile(new UserProfile { UserId = UserId, SecurityPinEnabled = false });
+
+				(await _securityPinService.IsPinRequiredAsync(UserId, DepartmentId)).Should().BeTrue();
+			}
+
+			[Test]
+			public async Task required_when_the_user_opted_in()
+			{
+				SetupForcePin(false);
+				SetupProfile(new UserProfile { UserId = UserId, SecurityPinEnabled = true });
+
+				(await _securityPinService.IsPinRequiredAsync(UserId, DepartmentId)).Should().BeTrue();
+			}
+
+			[Test]
+			public async Task not_required_when_neither_forced_nor_opted_in()
+			{
+				SetupForcePin(false);
+				SetupProfile(new UserProfile { UserId = UserId, SecurityPinEnabled = false });
+
+				(await _securityPinService.IsPinRequiredAsync(UserId, DepartmentId)).Should().BeFalse();
+			}
+
+			[Test]
+			public async Task not_required_when_no_profile_exists_and_not_forced()
+			{
+				SetupForcePin(false);
+				SetupProfile(null);
+
+				(await _securityPinService.IsPinRequiredAsync(UserId, DepartmentId)).Should().BeFalse();
+			}
+		}
+
+		[TestFixture]
+		public class when_validating_a_pin : with_the_security_pin_service
+		{
+			[Test]
+			public async Task correct_pin_validates()
+			{
+				SetupProfile(new UserProfile { UserId = UserId, SecurityPin = "ENC:2580" });
+
+				(await _securityPinService.ValidatePinAsync(UserId, "2580")).Should().BeTrue();
+			}
+
+			[Test]
+			public async Task wrong_pin_fails()
+			{
+				SetupProfile(new UserProfile { UserId = UserId, SecurityPin = "ENC:2580" });
+
+				(await _securityPinService.ValidatePinAsync(UserId, "2581")).Should().BeFalse();
+			}
+
+			[Test]
+			public async Task malformed_pin_fails_without_touching_the_store()
+			{
+				(await _securityPinService.ValidatePinAsync(UserId, "not-a-pin")).Should().BeFalse();
+				_userProfileServiceMock.Verify(s => s.GetProfileByUserIdAsync(It.IsAny<string>(), It.IsAny<bool>()), Times.Never);
+			}
+
+			[Test]
+			public async Task fails_when_no_pin_is_set()
+			{
+				SetupProfile(new UserProfile { UserId = UserId, SecurityPin = null });
+
+				(await _securityPinService.ValidatePinAsync(UserId, "2580")).Should().BeFalse();
+			}
+		}
+
+		[TestFixture]
+		public class when_ensuring_a_pin : with_the_security_pin_service
+		{
+			[Test]
+			public async Task generates_and_saves_a_pin_when_missing()
+			{
+				var profile = new UserProfile { UserId = UserId };
+				SetupProfile(profile);
+				_userProfileServiceMock
+					.Setup(s => s.SaveProfileAsync(DepartmentId, It.IsAny<UserProfile>(), It.IsAny<CancellationToken>()))
+					.ReturnsAsync((int d, UserProfile p, CancellationToken c) => p);
+
+				var saved = await _securityPinService.EnsurePinAsync(UserId, DepartmentId);
+
+				saved.SecurityPin.Should().StartWith("ENC:");
+				SecurityPinUtility.IsAcceptable(saved.SecurityPin.Substring(4)).Should().BeTrue();
+				_userProfileServiceMock.Verify(s => s.SaveProfileAsync(DepartmentId, profile, It.IsAny<CancellationToken>()), Times.Once);
+			}
+
+			[Test]
+			public async Task keeps_the_existing_pin()
+			{
+				SetupProfile(new UserProfile { UserId = UserId, SecurityPin = "ENC:2580" });
+
+				var saved = await _securityPinService.EnsurePinAsync(UserId, DepartmentId);
+
+				saved.SecurityPin.Should().Be("ENC:2580");
+				_userProfileServiceMock.Verify(s => s.SaveProfileAsync(It.IsAny<int>(), It.IsAny<UserProfile>(), It.IsAny<CancellationToken>()), Times.Never);
+			}
+		}
+
+		[TestFixture]
+		public class when_ensuring_pins_for_a_department : with_the_security_pin_service
+		{
+			[Test]
+			public async Task only_members_without_a_pin_get_one()
+			{
+				var withPin = new UserProfile { UserId = "hasPin", SecurityPin = "ENC:2580" };
+				var withoutPin = new UserProfile { UserId = "noPin" };
+
+				_userProfileServiceMock
+					.Setup(s => s.GetAllProfilesForDepartmentAsync(DepartmentId, It.IsAny<bool>()))
+					.ReturnsAsync(new Dictionary<string, UserProfile> { { withPin.UserId, withPin }, { withoutPin.UserId, withoutPin } });
+				_userProfileServiceMock
+					.Setup(s => s.SaveProfileAsync(DepartmentId, It.IsAny<UserProfile>(), It.IsAny<CancellationToken>()))
+					.ReturnsAsync((int d, UserProfile p, CancellationToken c) => p);
+
+				await _securityPinService.EnsurePinsForDepartmentAsync(DepartmentId);
+
+				withPin.SecurityPin.Should().Be("ENC:2580");
+				withoutPin.SecurityPin.Should().StartWith("ENC:");
+				_userProfileServiceMock.Verify(s => s.SaveProfileAsync(DepartmentId, withoutPin, It.IsAny<CancellationToken>()), Times.Once);
+				_userProfileServiceMock.Verify(s => s.SaveProfileAsync(DepartmentId, withPin, It.IsAny<CancellationToken>()), Times.Never);
+			}
+		}
+	}
+}

--- a/Web/Resgrid.Web.Services/Controllers/SignalWireController.cs
+++ b/Web/Resgrid.Web.Services/Controllers/SignalWireController.cs
@@ -179,7 +179,7 @@ namespace Resgrid.Web.Services.Controllers
 					// Verification (MobileNumberVerified == true) is the bar for trusting an inbound sender.
 					if (profile != null && profile.MobileNumberVerified != true)
 					{
-						Framework.Logging.LogInfo($"[SignalWire SMS] MessageSid={textMessage.MessageId} From={textMessage.Msisdn} matched a profile but the mobile number is not verified; not linking sender to user.");
+						Framework.Logging.LogInfo($"[SignalWire SMS] MessageSid={textMessage.MessageId} From={Framework.StringHelpers.MaskPhoneNumber(textMessage.Msisdn)} matched a profile but the mobile number is not verified; not linking sender to user.");
 						profile = null;
 					}
 

--- a/Web/Resgrid.Web.Services/Controllers/SignalWireController.cs
+++ b/Web/Resgrid.Web.Services/Controllers/SignalWireController.cs
@@ -175,6 +175,14 @@ namespace Resgrid.Web.Services.Controllers
 				{
 					profile = await _userProfileService.GetProfileByMobileNumberAsync(textMessage.Msisdn);
 
+					// SECURITY: an unverified mobile number must never identify/act as the matched user.
+					// Verification (MobileNumberVerified == true) is the bar for trusting an inbound sender.
+					if (profile != null && profile.MobileNumberVerified != true)
+					{
+						Framework.Logging.LogInfo($"[SignalWire SMS] MessageSid={textMessage.MessageId} From={textMessage.Msisdn} matched a profile but the mobile number is not verified; not linking sender to user.");
+						profile = null;
+					}
+
 					if (profile != null)
 					{
 						var department = await _departmentsService.GetDepartmentByUserIdAsync(profile.UserId);

--- a/Web/Resgrid.Web.Services/Controllers/TwilioController.cs
+++ b/Web/Resgrid.Web.Services/Controllers/TwilioController.cs
@@ -142,6 +142,17 @@ namespace Resgrid.Web.Services.Controllers
 				// department the sender operates in. Legacy clients that still text a per-department provisioned
 				// inbound number fall back to resolving the department from that number.
 				UserProfile userProfile = await _userProfileService.GetProfileByMobileNumberAsync(textMessage.Msisdn);
+
+				// SECURITY: an unverified mobile number must never identify/act as the matched user —
+				// anyone can type someone else's number into a profile. Verification (MobileNumberVerified
+				// == true) is the bar for trusting an inbound sender.
+				bool senderNumberUnverified = userProfile != null && userProfile.MobileNumberVerified != true;
+				if (senderNumberUnverified)
+				{
+					Framework.Logging.LogInfo($"[Twilio SMS] MessageSid={request.MessageSid} From={textMessage.Msisdn} matched a profile but the mobile number is not verified; not linking sender to user.");
+					userProfile = null;
+				}
+
 				int? departmentId = null;
 				if (userProfile != null)
 				{
@@ -194,7 +205,7 @@ namespace Resgrid.Web.Services.Controllers
 				}
 				else
 				{
-					await ProcessTextCommandsAsync(textMessage, messageEvent, response, departmentId, userProfile);
+					await ProcessTextCommandsAsync(textMessage, messageEvent, response, departmentId, userProfile, senderNumberUnverified);
 				}
 			}
 			catch (Exception ex)
@@ -225,7 +236,7 @@ namespace Resgrid.Web.Services.Controllers
 		// enabled the Chatbot Twilio integration feature flag keep their existing behavior. departmentId
 		// and userProfile are resolved by the caller so the flag can be evaluated before dispatching here.
 		private async System.Threading.Tasks.Task ProcessTextCommandsAsync(TextMessage textMessage, InboundMessageEvent messageEvent,
-			MessagingResponse response, int? departmentId, UserProfile userProfile)
+			MessagingResponse response, int? departmentId, UserProfile userProfile, bool senderNumberUnverified = false)
 		{
 			// Diagnostic: without a department the legacy path adds no message, so the sender gets no reply.
 			if (!departmentId.HasValue)
@@ -300,13 +311,25 @@ namespace Resgrid.Web.Services.Controllers
 						// only hit the DB again if the department came from the phone-number lookup path.
 						var profile = userProfile ?? await _userProfileService.GetProfileByMobileNumberAsync(textMessage.Msisdn);
 
+						// SECURITY: same verified-number bar as the caller — an unverified number must not
+						// act as the matched user.
+						if (profile != null && profile.MobileNumberVerified != true)
+						{
+							senderNumberUnverified = true;
+							profile = null;
+						}
+
 						// No matching user profile for the sender's number: reply so the user knows, rather than
 						// returning an empty response (pre-refactor behavior).
 						if (profile == null)
 						{
-							Framework.Logging.LogInfo($"[Twilio SMS] DepartmentId={departmentId.Value} sender {textMessage.Msisdn} has no matching user profile; replying with not-found message.");
+							Framework.Logging.LogInfo($"[Twilio SMS] DepartmentId={departmentId.Value} sender {textMessage.Msisdn} has no usable user profile (unverified={senderNumberUnverified}); replying with not-found message.");
 							messageEvent.Processed = true;
-							response.Message("Resgrid: We couldn't find a Resgrid user linked to this mobile number. Please add this number to your Resgrid profile to use text commands.");
+
+							if (senderNumberUnverified)
+								response.Message("Resgrid: This mobile number matches a Resgrid profile but hasn't been verified. Please verify your mobile number on your Resgrid profile page to use text commands.");
+							else
+								response.Message("Resgrid: We couldn't find a Resgrid user linked to this mobile number. Please add this number to your Resgrid profile to use text commands.");
 						}
 
 						if (profile != null)

--- a/Web/Resgrid.Web.Services/Controllers/TwilioController.cs
+++ b/Web/Resgrid.Web.Services/Controllers/TwilioController.cs
@@ -149,7 +149,7 @@ namespace Resgrid.Web.Services.Controllers
 				bool senderNumberUnverified = userProfile != null && userProfile.MobileNumberVerified != true;
 				if (senderNumberUnverified)
 				{
-					Framework.Logging.LogInfo($"[Twilio SMS] MessageSid={request.MessageSid} From={textMessage.Msisdn} matched a profile but the mobile number is not verified; not linking sender to user.");
+					Framework.Logging.LogInfo($"[Twilio SMS] MessageSid={request.MessageSid} From={Framework.StringHelpers.MaskPhoneNumber(textMessage.Msisdn)} matched a profile but the mobile number is not verified; not linking sender to user.");
 					userProfile = null;
 				}
 
@@ -171,7 +171,7 @@ namespace Resgrid.Web.Services.Controllers
 					messageEvent.CustomerId = departmentId.Value.ToString();
 
 				// Diagnostic: did we resolve a department for this inbound text? If not, no reply is sent.
-				Framework.Logging.LogInfo($"[Twilio SMS] MessageSid={request.MessageSid} To={textMessage.To} From={textMessage.Msisdn} resolved DepartmentId={(departmentId.HasValue ? departmentId.Value.ToString() : "none")}");
+				Framework.Logging.LogInfo($"[Twilio SMS] MessageSid={request.MessageSid} To={textMessage.To} From={Framework.StringHelpers.MaskPhoneNumber(textMessage.Msisdn)} resolved DepartmentId={(departmentId.HasValue ? departmentId.Value.ToString() : "none")}");
 
 				// Feature-flagged rollout: the chatbot ingress is the new path. When the flag is off
 				// (globally or for this department) fall back to the original text-command handling so
@@ -240,7 +240,7 @@ namespace Resgrid.Web.Services.Controllers
 		{
 			// Diagnostic: without a department the legacy path adds no message, so the sender gets no reply.
 			if (!departmentId.HasValue)
-				Framework.Logging.LogInfo($"[Twilio SMS] Text-command path: no department resolved for sender {textMessage.Msisdn} → number {textMessage.To}; no reply will be sent.");
+				Framework.Logging.LogInfo($"[Twilio SMS] Text-command path: no department resolved for sender {Framework.StringHelpers.MaskPhoneNumber(textMessage.Msisdn)} → number {textMessage.To}; no reply will be sent.");
 
 			if (departmentId.HasValue)
 			{
@@ -323,7 +323,7 @@ namespace Resgrid.Web.Services.Controllers
 						// returning an empty response (pre-refactor behavior).
 						if (profile == null)
 						{
-							Framework.Logging.LogInfo($"[Twilio SMS] DepartmentId={departmentId.Value} sender {textMessage.Msisdn} has no usable user profile (unverified={senderNumberUnverified}); replying with not-found message.");
+							Framework.Logging.LogInfo($"[Twilio SMS] DepartmentId={departmentId.Value} sender {Framework.StringHelpers.MaskPhoneNumber(textMessage.Msisdn)} has no usable user profile (unverified={senderNumberUnverified}); replying with not-found message.");
 							messageEvent.Processed = true;
 
 							if (senderNumberUnverified)

--- a/Web/Resgrid.Web/Areas/User/Controllers/DepartmentController.cs
+++ b/Web/Resgrid.Web/Areas/User/Controllers/DepartmentController.cs
@@ -63,6 +63,7 @@ namespace Resgrid.Web.Areas.User.Controllers
 		private readonly INotesService _notesService;
 		private readonly IContactsService _contactsService;
 		private readonly ICheckInTimerService _checkInTimerService;
+		private readonly ISecurityPinService _securityPinService;
 
 		public DepartmentController(IDepartmentsService departmentsService, IUsersService usersService, IActionLogsService actionLogsService,
 			IEmailService emailService, IDepartmentGroupsService departmentGroupsService, IUserProfileService userProfileService, IDeleteService deleteService,
@@ -70,7 +71,8 @@ namespace Resgrid.Web.Areas.User.Controllers
 			ILimitsService limitsService, ICallsService callsService, IDepartmentSettingsService departmentSettingsService, IUnitsService unitsService,
 			ICertificationService certificationService, INumbersService numbersService, IScheduledTasksService scheduledTasksService, IPersonnelRolesService personnelRolesService,
 			IEventAggregator eventAggregator, ICustomStateService customStateService, ICqrsProvider cqrsProvider, IPrinterProvider printerProvider, IQueueService queueService,
-			IDocumentsService documentsService, INotesService notesService, IContactsService contactsService, ICheckInTimerService checkInTimerService)
+			IDocumentsService documentsService, INotesService notesService, IContactsService contactsService, ICheckInTimerService checkInTimerService,
+			ISecurityPinService securityPinService)
 		{
 			_departmentsService = departmentsService;
 			_usersService = usersService;
@@ -100,6 +102,7 @@ namespace Resgrid.Web.Areas.User.Controllers
 			_notesService = notesService;
 			_contactsService = contactsService;
 			_checkInTimerService = checkInTimerService;
+			_securityPinService = securityPinService;
 		}
 
 		#endregion Private Members and Constructors
@@ -244,6 +247,7 @@ namespace Resgrid.Web.Areas.User.Controllers
 			var activeCallRssKey = await _departmentSettingsService.GetRssKeyForDepartmentAsync(DepartmentId);
 			model.DisableAutoAvailable = await _departmentSettingsService.GetDisableAutoAvailableForDepartmentAsync(DepartmentId);
 			model.EnableModernNotifications = await _departmentSettingsService.GetModernNotificationsEnabledAsync(DepartmentId);
+			model.ForceChatbotSecurityPin = await _departmentSettingsService.GetForceChatbotSecurityPinAsync(DepartmentId);
 			model.TtsLanguage = await _departmentSettingsService.GetTtsLanguageForDepartmentAsync(DepartmentId);
 			model.TtsLanguages = BuildTtsLanguageSelectList(model.TtsLanguage);
 
@@ -541,6 +545,15 @@ namespace Resgrid.Web.Areas.User.Controllers
 					cancellationToken);
 				await _departmentSettingsService.SaveOrUpdateSettingAsync(DepartmentId, model.EnableModernNotifications.ToString(), DepartmentSettingTypes.EnableModernNotifications,
 					cancellationToken);
+
+				var forcePinWasEnabled = await _departmentSettingsService.GetForceChatbotSecurityPinAsync(DepartmentId, bypassCache: true);
+				await _departmentSettingsService.SaveOrUpdateSettingAsync(DepartmentId, model.ForceChatbotSecurityPin.ToString(), DepartmentSettingTypes.ForceChatbotSecurityPin,
+					cancellationToken);
+
+				// Turning the forced-PIN requirement on: give every member without a PIN a random one so
+				// they can complete PIN-protected chatbot/text actions immediately.
+				if (model.ForceChatbotSecurityPin && !forcePinWasEnabled)
+					await _securityPinService.EnsurePinsForDepartmentAsync(DepartmentId, cancellationToken);
 				await _departmentSettingsService.SaveOrUpdateSettingAsync(DepartmentId, model.TtsLanguage, DepartmentSettingTypes.TtsLanguage,
 					cancellationToken);
 

--- a/Web/Resgrid.Web/Areas/User/Controllers/DepartmentController.cs
+++ b/Web/Resgrid.Web/Areas/User/Controllers/DepartmentController.cs
@@ -547,13 +547,16 @@ namespace Resgrid.Web.Areas.User.Controllers
 					cancellationToken);
 
 				var forcePinWasEnabled = await _departmentSettingsService.GetForceChatbotSecurityPinAsync(DepartmentId, bypassCache: true);
-				await _departmentSettingsService.SaveOrUpdateSettingAsync(DepartmentId, model.ForceChatbotSecurityPin.ToString(), DepartmentSettingTypes.ForceChatbotSecurityPin,
-					cancellationToken);
 
 				// Turning the forced-PIN requirement on: give every member without a PIN a random one so
-				// they can complete PIN-protected chatbot/text actions immediately.
+				// they can complete PIN-protected chatbot/text actions immediately. Provision BEFORE
+				// persisting the enabled setting — if generation fails the setting stays off, so a
+				// later save re-detects the transition and retries PIN generation.
 				if (model.ForceChatbotSecurityPin && !forcePinWasEnabled)
 					await _securityPinService.EnsurePinsForDepartmentAsync(DepartmentId, cancellationToken);
+
+				await _departmentSettingsService.SaveOrUpdateSettingAsync(DepartmentId, model.ForceChatbotSecurityPin.ToString(), DepartmentSettingTypes.ForceChatbotSecurityPin,
+					cancellationToken);
 				await _departmentSettingsService.SaveOrUpdateSettingAsync(DepartmentId, model.TtsLanguage, DepartmentSettingTypes.TtsLanguage,
 					cancellationToken);
 

--- a/Web/Resgrid.Web/Areas/User/Controllers/HomeController.cs
+++ b/Web/Resgrid.Web/Areas/User/Controllers/HomeController.cs
@@ -696,6 +696,9 @@ namespace Resgrid.Web.Areas.User.Controllers
 
 				if (!String.IsNullOrWhiteSpace(model.SecurityPin))
 				{
+					// Normalize once so validation sees the same value that gets encrypted on save.
+					model.SecurityPin = model.SecurityPin.Trim();
+
 					if (!SecurityPinUtility.IsValidFormat(model.SecurityPin))
 						ModelState.AddModelError("SecurityPin", "The security PIN must be exactly 4 digits.");
 					else if (SecurityPinUtility.IsWeak(model.SecurityPin))

--- a/Web/Resgrid.Web/Areas/User/Controllers/HomeController.cs
+++ b/Web/Resgrid.Web/Areas/User/Controllers/HomeController.cs
@@ -71,6 +71,8 @@ namespace Resgrid.Web.Areas.User.Controllers
 		private readonly IGdprDataExportService _gdprDataExportService;
 		private readonly ISystemAuditsService _systemAuditsService;
 		private readonly IPhoneNumberProcesserProvider _phoneNumberProcesser;
+		private readonly ISecurityPinService _securityPinService;
+		private readonly IEncryptionService _encryptionService;
 
 		public HomeController(IDepartmentsService departmentsService, IUsersService usersService, IActionLogsService actionLogsService,
 			IUserStateService userStateService, IDepartmentGroupsService departmentGroupsService, Resgrid.Model.Services.IAuthorizationService authorizationService,
@@ -80,7 +82,8 @@ namespace Resgrid.Web.Areas.User.Controllers
 			IStringLocalizerFactory factory, ISubscriptionsService subscriptionsService, IContactVerificationService contactVerificationService,
 			IUserDefinedFieldsService userDefinedFieldsService, IUdfRenderingService udfRenderingService, IDepartmentSsoService departmentSsoService,
 			IStringLocalizer<Resgrid.Localization.Areas.User.Security.Security> secLocalizer, IGdprDataExportService gdprDataExportService,
-			ISystemAuditsService systemAuditsService, IPhoneNumberProcesserProvider phoneNumberProcesser)
+			ISystemAuditsService systemAuditsService, IPhoneNumberProcesserProvider phoneNumberProcesser,
+			ISecurityPinService securityPinService, IEncryptionService encryptionService)
 		{
 			_departmentsService = departmentsService;
 			_usersService = usersService;
@@ -110,6 +113,8 @@ namespace Resgrid.Web.Areas.User.Controllers
 			_gdprDataExportService = gdprDataExportService;
 			_systemAuditsService = systemAuditsService;
 			_phoneNumberProcesser = phoneNumberProcesser;
+			_securityPinService = securityPinService;
+			_encryptionService = encryptionService;
 
 			_localizer = factory.Create("Home.Dashboard", new AssemblyName(typeof(SupportedLocales).GetTypeInfo().Assembly.FullName).Name);
 		}
@@ -411,6 +416,14 @@ namespace Resgrid.Web.Areas.User.Controllers
 			if (model.Profile == null)
 				model.Profile = new UserProfile();
 
+			// Security PIN is only shown to the profile's owner (never to admins editing another user).
+			model.DepartmentForcesSecurityPin = await _departmentSettingsService.GetForceChatbotSecurityPinAsync(DepartmentId);
+			if (model.IsOwnProfile)
+			{
+				model.SecurityPinEnabled = model.Profile.SecurityPinEnabled;
+				model.SecurityPin = await _securityPinService.GetPinAsync(userId);
+			}
+
 			if (model.Profile.Image == null)
 				model.HasCustomIamge = false;
 			else
@@ -680,6 +693,14 @@ namespace Resgrid.Web.Areas.User.Controllers
 					if (newUser != null)
 						ModelState.AddModelError("", "The NEW username you have supplied is already in use, please try another one. If you didn't mean to update your username please leave that field blank.");
 				}
+
+				if (!String.IsNullOrWhiteSpace(model.SecurityPin))
+				{
+					if (!SecurityPinUtility.IsValidFormat(model.SecurityPin))
+						ModelState.AddModelError("SecurityPin", "The security PIN must be exactly 4 digits.");
+					else if (SecurityPinUtility.IsWeak(model.SecurityPin))
+						ModelState.AddModelError("SecurityPin", "That security PIN is too easy to guess. Avoid repeated digits (like 0000) and sequences (like 1234 or 4321).");
+				}
 			}
 
 			if (ModelState.IsValid)
@@ -726,6 +747,18 @@ namespace Resgrid.Web.Areas.User.Controllers
 				savedProfile.IdentificationNumber = model.Profile.IdentificationNumber;
 				savedProfile.TimeZone = model.Profile.TimeZone;
 				savedProfile.Language = model.Profile.Language;
+
+				// Security PIN: only the profile owner can manage it. A blank input keeps the current
+				// PIN; enabling the option with no PIN on file generates a random one.
+				if (model.IsOwnProfile)
+				{
+					savedProfile.SecurityPinEnabled = model.SecurityPinEnabled;
+
+					if (!String.IsNullOrWhiteSpace(model.SecurityPin))
+						savedProfile.SecurityPin = _encryptionService.Encrypt(model.SecurityPin.Trim());
+					else if (model.SecurityPinEnabled && String.IsNullOrWhiteSpace(savedProfile.SecurityPin))
+						savedProfile.SecurityPin = _encryptionService.Encrypt(SecurityPinUtility.Generate());
+				}
 
 				if (model.CanEnableVoice)
 				{

--- a/Web/Resgrid.Web/Areas/User/Models/DepartmentSettingsModel.cs
+++ b/Web/Resgrid.Web/Areas/User/Models/DepartmentSettingsModel.cs
@@ -68,6 +68,9 @@ namespace Resgrid.Web.Areas.User.Models
 
 		public bool EnableModernNotifications { get; set; }
 
+		[Display(Name = "Require security PIN for dangerous chatbot/text actions")]
+		public bool ForceChatbotSecurityPin { get; set; }
+
 		public DepartmentSettingsModel()
 		{
 			Users = new Dictionary<string, string>();

--- a/Web/Resgrid.Web/Areas/User/Models/EditProfileModel.cs
+++ b/Web/Resgrid.Web/Areas/User/Models/EditProfileModel.cs
@@ -111,6 +111,18 @@ namespace Resgrid.Web.Areas.User.Models
 
 		public bool EnableSms { get; set; }
 
+		// ── Security PIN (step-up auth for dangerous chatbot/SMS actions; own profile only) ──
+
+		/// <summary>The user's decrypted 4-digit security PIN (only populated for the own-profile view).</summary>
+		[Display(Name = "Security PIN")]
+		public string SecurityPin { get; set; }
+
+		[Display(Name = "Require my security PIN for dangerous chatbot/text actions")]
+		public bool SecurityPinEnabled { get; set; }
+
+		/// <summary>True when the department forces PIN usage for all members (personal opt-in is then moot).</summary>
+		public bool DepartmentForcesSecurityPin { get; set; }
+
 		// ── Contact verification status (tri-state: null = grandfathered, false = pending, true = verified) ──
 		public bool? EmailVerified => Profile?.EmailVerified;
 		public bool? MobileNumberVerified => Profile?.MobileNumberVerified;

--- a/Web/Resgrid.Web/Areas/User/Views/Department/Settings.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Department/Settings.cshtml
@@ -92,6 +92,17 @@
                             </div>
                         </div>
                         <div class="form-group">
+                            <label class="col-sm-2 control-label">Require Security PIN</label>
+                            <div class="col-sm-10">
+                                <div class="row">
+                                    <div class="col-sm-10">
+                                        <input type="checkbox" asp-for="ForceChatbotSecurityPin">
+                                    </div>
+                                </div>
+                                <span class="help-block m-b-none">Require every member to confirm dangerous or department-wide chatbot/text actions with their personal 4-digit security PIN. Members without a PIN get a randomly generated one (viewable on their profile page).</span>
+                            </div>
+                        </div>
+                        <div class="form-group">
                             <label class="col-sm-2 control-label">@localizer["TtsLanguage"]</label>
                             <div class="col-sm-10">
                                 <select asp-for="TtsLanguage" asp-items="Model.TtsLanguages" style="padding-left: 0; width: 100%;"></select>

--- a/Web/Resgrid.Web/Areas/User/Views/Department/Settings.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Department/Settings.cshtml
@@ -92,14 +92,14 @@
                             </div>
                         </div>
                         <div class="form-group">
-                            <label class="col-sm-2 control-label">Require Security PIN</label>
+                            <label class="col-sm-2 control-label">@localizer["ForceChatbotSecurityPin"]</label>
                             <div class="col-sm-10">
                                 <div class="row">
                                     <div class="col-sm-10">
                                         <input type="checkbox" asp-for="ForceChatbotSecurityPin">
                                     </div>
                                 </div>
-                                <span class="help-block m-b-none">Require every member to confirm dangerous or department-wide chatbot/text actions with their personal 4-digit security PIN. Members without a PIN get a randomly generated one (viewable on their profile page).</span>
+                                <span class="help-block m-b-none">@localizer["ForceChatbotSecurityPinHelp"]</span>
                             </div>
                         </div>
                         <div class="form-group">

--- a/Web/Resgrid.Web/Areas/User/Views/Home/EditUserProfile.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Home/EditUserProfile.cshtml
@@ -296,6 +296,35 @@
                         </div>
                         <div class="hr-line-dashed"></div>
 
+                        @if (Model.IsOwnProfile)
+                        {
+                            <div class="form-group">
+                                <label class="col-sm-2 control-label">Security PIN</label>
+                                <div class="col-sm-10">
+                                    <input type="text" class="form-control" style="max-width:160px;" maxlength="4" inputmode="numeric" pattern="[0-9]*" autocomplete="off" placeholder="4-digit PIN" asp-for="SecurityPin">
+                                    <span asp-validation-for="SecurityPin" class="text-danger"></span>
+                                    <span class="help-block m-b-none">Your 4-digit security PIN confirms dangerous or department-wide actions performed over text message or chatbot. Avoid repeated digits (0000) and sequences (1234, 4321). Leave blank to keep your current PIN.</span>
+                                </div>
+                            </div>
+                            <div class="form-group">
+                                <label class="col-sm-2 control-label">Require Security PIN</label>
+                                <div class="col-sm-10">
+                                    @if (Model.DepartmentForcesSecurityPin)
+                                    {
+                                        <input type="checkbox" checked="checked" disabled="disabled">
+                                        <input type="hidden" asp-for="SecurityPinEnabled" value="true">
+                                        <span class="help-block m-b-none">Your department requires a security PIN for dangerous chatbot/text actions, so this option is always on.</span>
+                                    }
+                                    else
+                                    {
+                                        <input type="checkbox" asp-for="SecurityPinEnabled">
+                                        <span class="help-block m-b-none">When enabled, dangerous chatbot/text actions ask for your PIN as an extra security step. If you enable this without a PIN a random one is generated for you.</span>
+                                    }
+                                </div>
+                            </div>
+                            <div class="hr-line-dashed"></div>
+                        }
+
                         @if (ClaimsAuthorizationHelper.IsUserDepartmentAdmin())
                         {
                             <div class="form-group">

--- a/Web/Resgrid.Web/Areas/User/Views/Home/EditUserProfile.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Home/EditUserProfile.cshtml
@@ -299,26 +299,26 @@
                         @if (Model.IsOwnProfile)
                         {
                             <div class="form-group">
-                                <label class="col-sm-2 control-label">Security PIN</label>
+                                <label class="col-sm-2 control-label">@localizer["SecurityPinLabel"]</label>
                                 <div class="col-sm-10">
-                                    <input type="text" class="form-control" style="max-width:160px;" maxlength="4" inputmode="numeric" pattern="[0-9]*" autocomplete="off" placeholder="4-digit PIN" asp-for="SecurityPin">
+                                    <input type="text" class="form-control" style="max-width:160px;" maxlength="4" inputmode="numeric" pattern="[0-9]*" autocomplete="off" placeholder="@localizer["SecurityPinPlaceholder"]" asp-for="SecurityPin">
                                     <span asp-validation-for="SecurityPin" class="text-danger"></span>
-                                    <span class="help-block m-b-none">Your 4-digit security PIN confirms dangerous or department-wide actions performed over text message or chatbot. Avoid repeated digits (0000) and sequences (1234, 4321). Leave blank to keep your current PIN.</span>
+                                    <span class="help-block m-b-none">@localizer["SecurityPinHelp"]</span>
                                 </div>
                             </div>
                             <div class="form-group">
-                                <label class="col-sm-2 control-label">Require Security PIN</label>
+                                <label class="col-sm-2 control-label">@localizer["SecurityPinEnabledLabel"]</label>
                                 <div class="col-sm-10">
                                     @if (Model.DepartmentForcesSecurityPin)
                                     {
                                         <input type="checkbox" checked="checked" disabled="disabled">
                                         <input type="hidden" asp-for="SecurityPinEnabled" value="true">
-                                        <span class="help-block m-b-none">Your department requires a security PIN for dangerous chatbot/text actions, so this option is always on.</span>
+                                        <span class="help-block m-b-none">@localizer["SecurityPinForcedHelp"]</span>
                                     }
                                     else
                                     {
                                         <input type="checkbox" asp-for="SecurityPinEnabled">
-                                        <span class="help-block m-b-none">When enabled, dangerous chatbot/text actions ask for your PIN as an extra security step. If you enable this without a PIN a random one is generated for you.</span>
+                                        <span class="help-block m-b-none">@localizer["SecurityPinEnabledHelp"]</span>
                                     }
                                 </div>
                             </div>


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
# Pull Request Description

## RG-T117: Chatbot Security Hardening — Step-up PIN Authentication and SMS Identity Verification

This pull request introduces two major security improvements to the chatbot and SMS integration:

### 1. Security PIN (Step-up Authentication for Destructive Actions)

Adds a new 4-digit security PIN system that acts as a second factor for confirmed destructive or department-wide chatbot/text actions:

- **Per-user opt-in**: Users can enable a security PIN on their profile page and set or regenerate their own PIN.
- **Department-level enforcement**: A new department setting (`ForceChatbotSecurityPin`) forces all members to use a PIN. When enabled, every member without a PIN automatically receives a randomly generated one.
- **Chatbot flow**: After a user replies YES to confirm an action, if a PIN is required, the session enters an `AwaitingPin` state. The pending intent only executes after the correct PIN is supplied. After 3 failed attempts, the action is cancelled.
- **PIN security rules**: PINs must be exactly 4 digits and are rejected if weak (all-same-digit or consecutive sequences). PINs are generated using a crypto RNG and stored AES-encrypted on the user profile.
- **UI**: Department settings page has a new checkbox; user profile page (own profile only) shows PIN input and opt-in toggle.

### 2. SMS Identity Verification Hardening

Tightens trust rules so an unverified mobile number can never identify or act as a Resgrid user:

- **Existing links re-validated**: On every inbound SMS, existing chatbot identity links are only trusted if the linked profile's mobile number is verified AND still matches the sender's number. Stale or unverified SMS links are removed.
- **Removed phone-link confirmation flow**: The previous "Reply YES to link" confirmation is replaced by a stricter rule — only a verified mobile number may be auto-linked. Unverified numbers receive a message directing the user to verify their number on their profile.
- **Number change invalidates links**: When a user changes their mobile number, all SMS-based chatbot identity links are automatically removed.
- **Controller-level enforcement**: Both the Twilio and SignalWire inbound SMS controllers now reject unverified matched profiles and respond with an appropriate verification prompt.
- **Profile save protection**: The `SecurityPin` field is preserved when a caller doesn't supply it (null = unchanged), preventing accidental PIN deletion by unrelated profile saves.

### Database
- Migration M0089 (SQL Server and PostgreSQL) adds `SecurityPin` (nullable string, encrypted) and `SecurityPinEnabled` (boolean, default false) columns to `UserProfiles`.

### Tests
- Added unit tests for `SecurityPinUtility` (format validation, weakness detection, generation) and `SecurityPinService` (PIN requirement logic, validation, and generation/ensuring flows).
<!-- kody-pr-summary:end -->