### PR TITLE
RG-T117 Chatbot fixes

### DIFF
--- a/Core/Resgrid.Chatbot/Handlers/DepartmentActionHandler.cs
+++ b/Core/Resgrid.Chatbot/Handlers/DepartmentActionHandler.cs
@@ -17,29 +17,45 @@ namespace Resgrid.Chatbot.Handlers
 		private readonly IUserProfileService _userProfileService;
 		private readonly IUsersService _usersService;
 		private readonly ILimitsService _limitsService;
+		private readonly IChatbotDepartmentConfigService _departmentConfigService;
 
 		public DepartmentActionHandler(
 			IDepartmentsService departmentsService,
 			IUserProfileService userProfileService,
 			IUsersService usersService,
-			ILimitsService limitsService)
+			ILimitsService limitsService,
+			IChatbotDepartmentConfigService departmentConfigService)
 		{
 			_departmentsService = departmentsService;
 			_userProfileService = userProfileService;
 			_usersService = usersService;
 			_limitsService = limitsService;
+			_departmentConfigService = departmentConfigService;
 		}
 
 		/// <summary>
-		/// The user's non-deleted memberships restricted to departments that support SMS (i.e. are on a
-		/// non-free plan). SMS operations — including switching — are only offered for these, so the list
-		/// the user sees and the indexes they pick from are the SMS-supporting departments, in a stable order.
+		/// The user's non-deleted memberships restricted to departments the CHATBOT can serve here: on a
+		/// plan that supports SMS AND with the chatbot enabled for the current platform (per-department
+		/// config; no config row means enabled). Listing/switching to a department whose chatbot is
+		/// disabled would strand the user behind the ingress config gate with no in-band way back. The
+		/// legacy SMS SWITCH command uses the unfiltered plan-based list — switching is account-wide and
+		/// a chatbot-disabled department is still valid for legacy text commands.
 		/// </summary>
-		private async Task<System.Collections.Generic.List<DepartmentMember>> GetSmsSupportingMembershipsAsync(string userId)
+		private async Task<System.Collections.Generic.List<DepartmentMember>> GetSmsSupportingMembershipsAsync(string userId, ChatbotPlatform platform)
 		{
-			// Shared with the legacy SMS SWITCH command and the ingress restricted mode so every surface
-			// shows the same departments in the same order (numeric picks stay stable across requests).
-			return await _departmentsService.GetSmsSupportedMembershipsForUserAsync(userId);
+			// Same base list (and order) as the legacy SMS surfaces, then chatbot-eligibility filtering.
+			// The ingress restricted mode applies the identical filter, so the numbered options it shows
+			// map to the same memberships this handler resolves.
+			var supported = await _departmentsService.GetSmsSupportedMembershipsForUserAsync(userId);
+
+			var usable = new System.Collections.Generic.List<DepartmentMember>();
+			foreach (var membership in supported)
+			{
+				if (await _departmentConfigService.IsChatbotUsableForDepartmentAsync(membership.DepartmentId, platform))
+					usable.Add(membership);
+			}
+
+			return usable;
 		}
 
 		public ChatbotIntentType IntentType => ChatbotIntentType.ListDepartments;
@@ -71,8 +87,9 @@ namespace Resgrid.Chatbot.Handlers
 			var culture = session.Culture;
 			try
 			{
-				// Only SMS-supporting (non-free plan) departments are switchable, so only list those.
-				var activeMemberships = await GetSmsSupportingMembershipsAsync(session.UserId);
+				// Only departments the chatbot can serve here (non-free plan + chatbot enabled for this
+				// platform) are switchable, so only list those.
+				var activeMemberships = await GetSmsSupportingMembershipsAsync(session.UserId, session.Platform);
 
 				if (activeMemberships.Count == 0)
 					return new ChatbotResponse { Text = ChatbotResources.Get("Dept_NoActiveMemberships", culture), Processed = true };
@@ -170,9 +187,10 @@ namespace Resgrid.Chatbot.Handlers
 				if (string.IsNullOrWhiteSpace(departmentIdentifier))
 					return new ChatbotResponse { Text = ChatbotResources.Get("Dept_SwitchSpecify", culture), Processed = true };
 
-				// Switching is limited to SMS-supporting (non-free plan) departments — the same set, in the
-				// same order, that ListDepartments shows, so a numeric pick maps to the displayed list.
-				var activeMemberships = await GetSmsSupportingMembershipsAsync(session.UserId);
+				// Switching is limited to chatbot-usable (non-free plan, chatbot enabled for this platform)
+				// departments — the same set, in the same order, that ListDepartments shows, so a numeric
+				// pick maps to the displayed list.
+				var activeMemberships = await GetSmsSupportingMembershipsAsync(session.UserId, session.Platform);
 
 				if (activeMemberships.Count == 0)
 					return new ChatbotResponse { Text = ChatbotResources.Get("Dept_NoActiveMemberships", culture), Processed = true };

--- a/Core/Resgrid.Chatbot/Handlers/DepartmentActionHandler.cs
+++ b/Core/Resgrid.Chatbot/Handlers/DepartmentActionHandler.cs
@@ -37,24 +37,9 @@ namespace Resgrid.Chatbot.Handlers
 		/// </summary>
 		private async Task<System.Collections.Generic.List<DepartmentMember>> GetSmsSupportingMembershipsAsync(string userId)
 		{
-			var allMemberRecords = await _departmentsService.GetAllDepartmentsForUserAsync(userId);
-			if (allMemberRecords == null || allMemberRecords.Count == 0)
-				return new System.Collections.Generic.List<DepartmentMember>();
-
-			var candidates = allMemberRecords
-				.Where(m => !m.IsDeleted)
-				.OrderByDescending(m => m.IsActive)
-				.ThenBy(m => m.DepartmentId)
-				.ToList();
-
-			var supported = new System.Collections.Generic.List<DepartmentMember>();
-			foreach (var membership in candidates)
-			{
-				if (await _limitsService.CanDepartmentProvisionNumberAsync(membership.DepartmentId))
-					supported.Add(membership);
-			}
-
-			return supported;
+			// Shared with the legacy SMS SWITCH command and the ingress restricted mode so every surface
+			// shows the same departments in the same order (numeric picks stay stable across requests).
+			return await _departmentsService.GetSmsSupportedMembershipsForUserAsync(userId);
 		}
 
 		public ChatbotIntentType IntentType => ChatbotIntentType.ListDepartments;

--- a/Core/Resgrid.Chatbot/Interfaces/IChatbotDepartmentConfigService.cs
+++ b/Core/Resgrid.Chatbot/Interfaces/IChatbotDepartmentConfigService.cs
@@ -26,6 +26,14 @@ namespace Resgrid.Chatbot.Interfaces
 		/// </summary>
 		Task<ChatbotDepartmentConfig> SaveConfigAsync(ChatbotDepartmentConfig config, string newPlaintextLlmKey = null);
 
+		/// <summary>
+		/// Whether the chatbot is usable for a department on the given platform: no config row means
+		/// system defaults (enabled, all platforms); otherwise the row's IsEnabled and AllowedPlatforms
+		/// both have to permit it. Used to keep switch/list targets to departments the chatbot can
+		/// actually serve on the requesting platform.
+		/// </summary>
+		Task<bool> IsChatbotUsableForDepartmentAsync(int departmentId, ChatbotPlatform platform);
+
 		Task InvalidateCacheAsync(int departmentId);
 	}
 }

--- a/Core/Resgrid.Chatbot/Services/ChatbotDepartmentConfigService.cs
+++ b/Core/Resgrid.Chatbot/Services/ChatbotDepartmentConfigService.cs
@@ -49,6 +49,35 @@ namespace Resgrid.Chatbot.Services
 			return await fetch();
 		}
 
+		public async Task<bool> IsChatbotUsableForDepartmentAsync(int departmentId, ChatbotPlatform platform)
+		{
+			var config = await GetConfigAsync(departmentId);
+			if (config == null)
+				return true; // No row: system defaults — enabled, all platforms.
+
+			if (!config.IsEnabled)
+				return false;
+
+			return IsPlatformAllowed(config.AllowedPlatforms, platform);
+		}
+
+		// Mirrors ChatbotIngressService.IsPlatformAllowed: null/blank/"*" = all platforms, otherwise a
+		// comma-separated list of ChatbotPlatform names.
+		private static bool IsPlatformAllowed(string allowedPlatforms, ChatbotPlatform platform)
+		{
+			if (string.IsNullOrWhiteSpace(allowedPlatforms) || allowedPlatforms.Trim() == "*")
+				return true;
+
+			var platformName = platform.ToString();
+			foreach (var entry in allowedPlatforms.Split(','))
+			{
+				if (string.Equals(entry.Trim(), platformName, StringComparison.OrdinalIgnoreCase))
+					return true;
+			}
+
+			return false;
+		}
+
 		public async Task<DepartmentLlmOverride> GetLlmOverrideAsync(int departmentId)
 		{
 			var config = await GetConfigAsync(departmentId);

--- a/Core/Resgrid.Chatbot/Services/ChatbotIngressService.cs
+++ b/Core/Resgrid.Chatbot/Services/ChatbotIngressService.cs
@@ -153,19 +153,29 @@ namespace Resgrid.Chatbot.Services
 						message.Platform, new ChatbotIntent { Type = ChatbotIntentType.Unknown });
 				}
 
-				// 3b. Check department plan supports chatbot features
+				// 3b. Check the ACTIVE department's plan supports chatbot features. When it doesn't but the
+				// user belongs to other departments that do, don't hard-block: they must still be able to
+				// list departments and SWITCH their active department (restricted mode, enforced after
+				// intent classification below). Only when there is no supported alternative is this a dead end.
 				var isAuthorized = await _limitsService.CanDepartmentProvisionNumberAsync(department.DepartmentId);
+				List<Model.DepartmentMember> switchableDepartments = null;
 				if (!isAuthorized)
 				{
-					return await _templateRenderer.RenderResponseAsync("error",
-						new Services.ErrorModel { Message = "Your department's plan does not support chatbot features. Please upgrade your plan." },
-						message.Platform, new ChatbotIntent { Type = ChatbotIntentType.Unknown });
+					switchableDepartments = await _departmentsService.GetSmsSupportedMembershipsForUserAsync(identity.UserId);
+					if (switchableDepartments == null || switchableDepartments.Count == 0)
+					{
+						return await _templateRenderer.RenderResponseAsync("error",
+							new Services.ErrorModel { Message = "Your department's plan does not support chatbot features. Please upgrade your plan." },
+							message.Platform, new ChatbotIntent { Type = ChatbotIntentType.Unknown });
+					}
 				}
 
 				// 3c. Per-department configuration gates (when a config row exists; otherwise the
 				// system defaults apply and the chatbot stays enabled for backward compatibility).
+				// Skipped in restricted (switch-only) mode: the unsupported department's config must not
+				// block the user from switching OUT of it.
 				var deptConfig = await _departmentConfigService.GetConfigAsync(department.DepartmentId);
-				if (deptConfig != null)
+				if (deptConfig != null && isAuthorized)
 				{
 					if (!deptConfig.IsEnabled)
 					{
@@ -223,6 +233,40 @@ namespace Resgrid.Chatbot.Services
 				session.RecentMessages.Add(message);
 				if (session.RecentMessages.Count > 20)
 					session.RecentMessages.RemoveAt(0);
+
+				// Restricted (switch-only) mode: the active department's plan doesn't support the chatbot
+				// but the user belongs to other departments that do. Only department list/switch/active
+				// intents are honored — so the user can move to a supported department — and anything else
+				// gets the switch options. Confirmation/PIN/continuation states are intentionally skipped:
+				// no destructive intent can be pending for a department that can't dispatch them.
+				if (!isAuthorized)
+				{
+					var restrictedIntent = await _intentRouter.ClassifyIntentAsync(message, session);
+					if (restrictedIntent.Type == ChatbotIntentType.ListDepartments
+						|| restrictedIntent.Type == ChatbotIntentType.SwitchDepartment
+						|| restrictedIntent.Type == ChatbotIntentType.GetActiveDepartment)
+					{
+						var restrictedHandler = _actionHandlers.FirstOrDefault(h => h.CanHandle(restrictedIntent.Type));
+						if (restrictedHandler != null)
+						{
+							var restrictedResponse = await restrictedHandler.HandleAsync(message, restrictedIntent, session);
+							restrictedResponse.Intent = restrictedIntent;
+							await _sessionManager.SaveSessionAsync(session);
+							return restrictedResponse;
+						}
+					}
+
+					var optionsBuilder = new System.Text.StringBuilder();
+					optionsBuilder.AppendLine("Your active department's plan does not support chatbot features, but you belong to other departments that do:");
+					for (int i = 0; i < switchableDepartments.Count; i++)
+					{
+						var switchableDept = await _departmentsService.GetDepartmentByIdAsync(switchableDepartments[i].DepartmentId);
+						optionsBuilder.AppendLine($"{i + 1}: {switchableDept?.Name ?? ("Department " + switchableDepartments[i].DepartmentId)}");
+					}
+					optionsBuilder.Append("Reply SWITCH <number or name> to change your active department.");
+
+					return new ChatbotResponse { Text = optionsBuilder.ToString(), Processed = true };
+				}
 
 				// 5. Handle session state machine via ConversationEngine (Phase 2)
 

--- a/Core/Resgrid.Chatbot/Services/ChatbotIngressService.cs
+++ b/Core/Resgrid.Chatbot/Services/ChatbotIngressService.cs
@@ -161,8 +161,22 @@ namespace Resgrid.Chatbot.Services
 				List<Model.DepartmentMember> switchableDepartments = null;
 				if (!isAuthorized)
 				{
-					switchableDepartments = await _departmentsService.GetSmsSupportedMembershipsForUserAsync(identity.UserId);
-					if (switchableDepartments == null || switchableDepartments.Count == 0)
+					// A switch target must be one the chatbot can actually serve on this platform (plan
+					// supports SMS AND chatbot enabled per department config) — the same filter
+					// DepartmentActionHandler applies, so the numbered options shown below map to the
+					// memberships its switch handler resolves. Plan-only filtering could strand the user in
+					// a department whose chatbot config blocks everything, with no in-band way back.
+					var smsSupported = await _departmentsService.GetSmsSupportedMembershipsForUserAsync(identity.UserId)
+						?? new List<Model.DepartmentMember>();
+
+					switchableDepartments = new List<Model.DepartmentMember>();
+					foreach (var membership in smsSupported)
+					{
+						if (await _departmentConfigService.IsChatbotUsableForDepartmentAsync(membership.DepartmentId, message.Platform))
+							switchableDepartments.Add(membership);
+					}
+
+					if (switchableDepartments.Count == 0)
 					{
 						return await _templateRenderer.RenderResponseAsync("error",
 							new Services.ErrorModel { Message = "Your department's plan does not support chatbot features. Please upgrade your plan." },

--- a/Core/Resgrid.Model/Services/IDepartmentsService.cs
+++ b/Core/Resgrid.Model/Services/IDepartmentsService.cs
@@ -71,14 +71,19 @@ namespace Resgrid.Model.Services
 		Task<Department> GetDepartmentByUserIdAsync(string userId, bool bypassCache = false);
 
 		/// <summary>
-		/// Resolves the department to use for a user's SMS/chatbot operations: their active (then default,
-		/// then first) membership, preferring one whose plan supports SMS (non-free). If the preferred
-		/// department is on a free plan but another of the user's departments supports SMS, that one is
-		/// returned so a user isn't dead-ended; if none support SMS the preferred one is returned so the
-		/// downstream plan gate can produce the proper "plan doesn't support" message. Null when the user has
-		/// no non-deleted memberships.
+		/// Resolves the department to use for a user's SMS/chatbot operations: their ACTIVE (then default,
+		/// then first) membership. No plan-based auto-picking — if the active department's plan doesn't
+		/// support SMS the downstream plan gate handles it (offering a department switch when the user has
+		/// other supported memberships). Null when the user has no non-deleted memberships.
 		/// </summary>
 		Task<Department> GetActiveSmsDepartmentForUserAsync(string userId, bool bypassCache = false);
+
+		/// <summary>
+		/// The user's non-deleted memberships restricted to departments whose plan supports SMS/chatbot
+		/// (non-free), in a stable order (active first, then by department id) so a numeric pick from a
+		/// displayed list maps to the same membership across stateless SMS requests.
+		/// </summary>
+		Task<List<DepartmentMember>> GetSmsSupportedMembershipsForUserAsync(string userId);
 
 		Task<ValidateUserForDepartmentResult> GetValidateUserForDepartmentInfoAsync(string userName,
 			bool bypassCache = true);

--- a/Core/Resgrid.Model/Services/ITextDepartmentSwitchService.cs
+++ b/Core/Resgrid.Model/Services/ITextDepartmentSwitchService.cs
@@ -1,0 +1,30 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Resgrid.Model.Services
+{
+	/// <summary>
+	/// Shared handling for the inbound-SMS department SWITCH flow — used by both the Twilio and
+	/// SignalWire controllers so the plan-gate/STOP/switch behavior and reply wording stay identical
+	/// across providers. Methods return the reply body text; the caller wraps it in the
+	/// provider-specific response (TwiML or LaML).
+	/// </summary>
+	public interface ITextDepartmentSwitchService
+	{
+		/// <summary>
+		/// The identified user's ACTIVE department failed the inbound-text plan gate. STOP is honored
+		/// first (opt-out must always work), a SWITCH command is processed, any other text gets the
+		/// switch options, and with no supported alternatives the plan message. Never returns null.
+		/// </summary>
+		Task<string> BuildUnsupportedActiveDepartmentResponseAsync(string messageText, int departmentId, UserProfile profile,
+			string logPrefix, CancellationToken cancellationToken = default(CancellationToken));
+
+		/// <summary>
+		/// Processes a SWITCH [name/number] command: changes the user's active department when the
+		/// identifier resolves to one of their SMS-supported memberships (list index, department id,
+		/// then exact/partial name or code). Empty identifier returns the options list. Never returns null.
+		/// </summary>
+		Task<string> BuildSwitchCommandResponseAsync(UserProfile profile, string departmentIdentifier,
+			string logPrefix, CancellationToken cancellationToken = default(CancellationToken));
+	}
+}

--- a/Core/Resgrid.Model/TextCommandTypes.cs
+++ b/Core/Resgrid.Model/TextCommandTypes.cs
@@ -12,6 +12,7 @@
 		Units = 7,
 		MyStatus = 8,
 		CustomAction = 9,
-		CustomStaffing = 10
+		CustomStaffing = 10,
+		SwitchDepartment = 11
 	}
 }

--- a/Core/Resgrid.Services/DepartmentsService.cs
+++ b/Core/Resgrid.Services/DepartmentsService.cs
@@ -443,32 +443,44 @@ namespace Resgrid.Services
 			if (allMembers == null || allMembers.Count == 0)
 				return null;
 
-			// Prefer the member marked IsActive, then IsDefault, then first.
-			var ordered = allMembers
+			// The user's ACTIVE department (IsActive, then IsDefault, then first) — no plan-based
+			// auto-picking. If the active department's plan doesn't support SMS the caller's plan gate
+			// handles it (offering a switch when the user has other supported departments) rather than
+			// this resolver silently acting in a department the user didn't select.
+			var preferred = allMembers
 				.Where(m => !m.IsDeleted)
 				.OrderByDescending(m => m.IsActive)
 				.ThenByDescending(m => m.IsDefault)
-				.ToList();
+				.FirstOrDefault();
 
-			if (ordered.Count == 0)
+			if (preferred == null)
 				return null;
 
-			var preferred = ordered[0];
+			return await GetDepartmentByIdAsync(preferred.DepartmentId, bypassCache);
+		}
 
-			// If the preferred department supports SMS (non-free plan) use it; otherwise auto-pick the first
-			// of the user's departments that does, so a user whose active department is on the free plan still
-			// lands in an SMS-capable department. If none support SMS, fall back to the preferred one so the
-			// caller's plan gate returns the proper "plan doesn't support" message.
-			var canProvisionNumber = await Task.WhenAll(ordered.Select(membership =>
-				_limitsService.CanDepartmentProvisionNumberAsync(membership.DepartmentId)));
+		public async Task<List<DepartmentMember>> GetSmsSupportedMembershipsForUserAsync(string userId)
+		{
+			var allMembers = await GetAllDepartmentsForUserAsync(userId);
+			if (allMembers == null || allMembers.Count == 0)
+				return new List<DepartmentMember>();
 
-			for (var i = 0; i < ordered.Count; i++)
+			// Stable order (active first, then by id) so a numeric pick from a displayed list maps to the
+			// same membership when the follow-up "switch N" message arrives in a later, stateless request.
+			var candidates = allMembers
+				.Where(m => !m.IsDeleted)
+				.OrderByDescending(m => m.IsActive)
+				.ThenBy(m => m.DepartmentId)
+				.ToList();
+
+			var supported = new List<DepartmentMember>();
+			foreach (var membership in candidates)
 			{
-				if (canProvisionNumber[i])
-					return await GetDepartmentByIdAsync(ordered[i].DepartmentId, bypassCache);
+				if (await _limitsService.CanDepartmentProvisionNumberAsync(membership.DepartmentId))
+					supported.Add(membership);
 			}
 
-			return await GetDepartmentByIdAsync(preferred.DepartmentId, bypassCache);
+			return supported;
 		}
 
 

--- a/Core/Resgrid.Services/DepartmentsService.cs
+++ b/Core/Resgrid.Services/DepartmentsService.cs
@@ -467,8 +467,10 @@ namespace Resgrid.Services
 
 			// Stable order (active first, then by id) so a numeric pick from a displayed list maps to the
 			// same membership when the follow-up "switch N" message arrives in a later, stateless request.
+			// Disabled memberships (IsDisabled is nullable; null means not disabled) are excluded — a user
+			// deactivated in a department must not be offered it as a switch target.
 			var candidates = allMembers
-				.Where(m => !m.IsDeleted)
+				.Where(m => !m.IsDeleted && m.IsDisabled != true)
 				.OrderByDescending(m => m.IsActive)
 				.ThenBy(m => m.DepartmentId)
 				.ToList();

--- a/Core/Resgrid.Services/ServicesModule.cs
+++ b/Core/Resgrid.Services/ServicesModule.cs
@@ -94,6 +94,7 @@ namespace Resgrid.Services
 			builder.RegisterType<SystemAuditsService>().As<ISystemAuditsService>().InstancePerLifetimeScope();
 			builder.RegisterType<ContactVerificationService>().As<IContactVerificationService>().InstancePerLifetimeScope();
 			builder.RegisterType<SecurityPinService>().As<ISecurityPinService>().InstancePerLifetimeScope();
+			builder.RegisterType<TextDepartmentSwitchService>().As<ITextDepartmentSwitchService>().InstancePerLifetimeScope();
 			builder.RegisterType<AutofillsService>().As<IAutofillsService>().InstancePerLifetimeScope();
 			builder.RegisterType<UnitStatesService>().As<IUnitStatesService>().InstancePerLifetimeScope();
 			builder.Register(_ =>

--- a/Core/Resgrid.Services/TextCommandService.cs
+++ b/Core/Resgrid.Services/TextCommandService.cs
@@ -22,10 +22,14 @@ namespace Resgrid.Services
 
 			// SWITCH [department name/number]: change the user's active department. Checked first — the
 			// custom staffing branch below claims any message starting with 's' and would swallow it.
-			if (message.Trim().ToLower() == "switch" || message.Trim().ToLower().StartsWith("switch "))
+			// Ordinal comparison (culture-sensitive lowercasing breaks "SWITCH" under e.g. the Turkish
+			// locale) and any whitespace after the command (spaces or tabs) before the argument.
+			var trimmedMessage = message.Trim();
+			if (trimmedMessage.StartsWith("switch", StringComparison.OrdinalIgnoreCase)
+				&& (trimmedMessage.Length == 6 || char.IsWhiteSpace(trimmedMessage[6])))
 			{
 				payload.Type = TextCommandTypes.SwitchDepartment;
-				payload.Data = message.Trim().Length > 6 ? message.Trim().Substring(6).Trim() : "";
+				payload.Data = trimmedMessage.Length > 6 ? trimmedMessage.Substring(6).Trim() : "";
 				return payload;
 			}
 

--- a/Core/Resgrid.Services/TextCommandService.cs
+++ b/Core/Resgrid.Services/TextCommandService.cs
@@ -20,6 +20,15 @@ namespace Resgrid.Services
 			if (String.IsNullOrWhiteSpace(message))
 				return payload;
 
+			// SWITCH [department name/number]: change the user's active department. Checked first — the
+			// custom staffing branch below claims any message starting with 's' and would swallow it.
+			if (message.Trim().ToLower() == "switch" || message.Trim().ToLower().StartsWith("switch "))
+			{
+				payload.Type = TextCommandTypes.SwitchDepartment;
+				payload.Data = message.Trim().Length > 6 ? message.Trim().Substring(6).Trim() : "";
+				return payload;
+			}
+
 			if (customActions != null && customActions.IsDeleted == false && customActions.GetActiveDetails() != null && customActions.GetActiveDetails().Any())
 			{
 				int actionId = 0;

--- a/Core/Resgrid.Services/TextDepartmentSwitchService.cs
+++ b/Core/Resgrid.Services/TextDepartmentSwitchService.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Resgrid.Framework;
+using Resgrid.Model;
+using Resgrid.Model.Services;
+
+namespace Resgrid.Services
+{
+	/// <summary>
+	/// See <see cref="ITextDepartmentSwitchService"/>. Single implementation of the inbound-SMS
+	/// department switch flow shared by the Twilio and SignalWire controllers.
+	/// </summary>
+	public class TextDepartmentSwitchService : ITextDepartmentSwitchService
+	{
+		private readonly IDepartmentsService _departmentsService;
+		private readonly IUserProfileService _userProfileService;
+		private readonly IUsersService _usersService;
+		private readonly ITextCommandService _textCommandService;
+
+		public TextDepartmentSwitchService(IDepartmentsService departmentsService, IUserProfileService userProfileService,
+			IUsersService usersService, ITextCommandService textCommandService)
+		{
+			_departmentsService = departmentsService;
+			_userProfileService = userProfileService;
+			_usersService = usersService;
+			_textCommandService = textCommandService;
+		}
+
+		public async Task<string> BuildUnsupportedActiveDepartmentResponseAsync(string messageText, int departmentId, UserProfile profile,
+			string logPrefix, CancellationToken cancellationToken = default(CancellationToken))
+		{
+			// STOP always works — checked before the plan/alternatives logic so a verified user whose
+			// active department is on a free plan can still unsubscribe (telecom opt-out compliance).
+			var payload = _textCommandService.DetermineType(messageText);
+			if (payload.Type == TextCommandTypes.Stop)
+			{
+				await _userProfileService.DisableTextMessagesForUserAsync(profile.UserId, cancellationToken);
+				return "Text messages are now turned off for this user, to enable again log in to Resgrid and update your profile.";
+			}
+
+			var supported = await _departmentsService.GetSmsSupportedMembershipsForUserAsync(profile.UserId);
+			if (supported.Count == 0)
+			{
+				Logging.LogInfo($"{logPrefix} DepartmentId={departmentId} not authorized for inbound text (plan gate); user {profile.UserId} has no SMS-supported departments; replying with unsupported message.");
+				return "Resgrid: Inbound text messaging isn't available on your department's current plan. Please upgrade to a paid plan to enable text commands.";
+			}
+
+			if (payload.Type == TextCommandTypes.SwitchDepartment)
+				return await BuildSwitchCommandResponseAsync(profile, payload.Data, logPrefix, cancellationToken);
+
+			Logging.LogInfo($"{logPrefix} DepartmentId={departmentId} not authorized for inbound text (plan gate); user {profile.UserId} has {supported.Count} SMS-supported department(s); replying with switch options.");
+			return await BuildSwitchOptionsMessageAsync(supported,
+				"Resgrid: Your active department's plan doesn't include inbound text messaging, but you belong to other departments that do.");
+		}
+
+		public async Task<string> BuildSwitchCommandResponseAsync(UserProfile profile, string departmentIdentifier,
+			string logPrefix, CancellationToken cancellationToken = default(CancellationToken))
+		{
+			var supported = await _departmentsService.GetSmsSupportedMembershipsForUserAsync(profile.UserId);
+			if (supported.Count == 0)
+				return "Resgrid: None of your departments' current plans include inbound text messaging. Please upgrade to a paid plan to enable text commands.";
+
+			if (string.IsNullOrWhiteSpace(departmentIdentifier))
+				return await BuildSwitchOptionsMessageAsync(supported, "Resgrid: Your departments that support text messaging:");
+
+			DepartmentMember target = null;
+			var trimmedId = departmentIdentifier.Trim();
+
+			// A small number is a pick from the displayed list; otherwise try a department id, then name/code.
+			if (int.TryParse(trimmedId, out var listIndex) && listIndex >= 1 && listIndex <= supported.Count)
+				target = supported[listIndex - 1];
+
+			if (target == null && int.TryParse(trimmedId, out var deptId))
+				target = supported.FirstOrDefault(m => m.DepartmentId == deptId);
+
+			if (target == null)
+			{
+				foreach (var membership in supported)
+				{
+					// Cached read (bypassCache: false): the default bypasses the cache and pulls the
+					// department WITH members per iteration — an N+1 query for a name/code comparison.
+					var dept = await _departmentsService.GetDepartmentByIdAsync(membership.DepartmentId, false);
+					if (dept == null)
+						continue;
+
+					if (string.Equals(dept.Name, trimmedId, StringComparison.OrdinalIgnoreCase)
+						|| string.Equals(dept.Code, trimmedId, StringComparison.OrdinalIgnoreCase))
+					{
+						target = membership;
+						break;
+					}
+
+					if (target == null && !string.IsNullOrWhiteSpace(dept.Name) && dept.Name.IndexOf(trimmedId, StringComparison.OrdinalIgnoreCase) >= 0)
+						target = membership;
+				}
+			}
+
+			if (target == null)
+				return await BuildSwitchOptionsMessageAsync(supported, $"Resgrid: Couldn't find a department matching \"{trimmedId}\".");
+
+			if (target.IsActive)
+			{
+				var alreadyActive = await _departmentsService.GetDepartmentByIdAsync(target.DepartmentId, false);
+				return $"Resgrid: {alreadyActive?.Name ?? "That department"} is already your active department.";
+			}
+
+			var identityUser = _usersService.GetUserById(profile.UserId);
+			var success = await _departmentsService.SetActiveDepartmentForUserAsync(profile.UserId, target.DepartmentId, identityUser, cancellationToken);
+
+			var targetDept = await _departmentsService.GetDepartmentByIdAsync(target.DepartmentId, false);
+			if (success)
+			{
+				Logging.LogInfo($"{logPrefix} User {profile.UserId} switched active department to {target.DepartmentId} via text command.");
+				return $"Resgrid: Your active department is now {targetDept?.Name ?? ("department " + target.DepartmentId)}. Text commands now apply to this department.";
+			}
+
+			return "Resgrid: Unable to switch departments right now. Please try again later.";
+		}
+
+		private async Task<string> BuildSwitchOptionsMessageAsync(System.Collections.Generic.List<DepartmentMember> supported, string prefix)
+		{
+			var sb = new StringBuilder();
+			sb.Append(prefix + Environment.NewLine);
+
+			for (int i = 0; i < supported.Count; i++)
+			{
+				// Cached read (bypassCache: false) — the default hits the database (department + members)
+				// once per listed department just to render its name.
+				var dept = await _departmentsService.GetDepartmentByIdAsync(supported[i].DepartmentId, false);
+				var activeMarker = supported[i].IsActive ? " (active)" : "";
+				sb.Append($"{i + 1}: {dept?.Name ?? ("Department " + supported[i].DepartmentId)}{activeMarker}" + Environment.NewLine);
+			}
+
+			sb.Append("Reply SWITCH <number or name> to change your active department.");
+			return sb.ToString();
+		}
+	}
+}

--- a/Tests/Resgrid.Tests/Web/Services/TwilioControllerVoiceVerificationTests.cs
+++ b/Tests/Resgrid.Tests/Web/Services/TwilioControllerVoiceVerificationTests.cs
@@ -148,7 +148,8 @@ namespace Resgrid.Tests.Web.Services
 				_communicationTestServiceMock.Object,
 				_encryptionServiceMock.Object,
 				_twilioVoiceResponseServiceMock.Object,
-				_featureToggleServiceMock.Object);
+				_featureToggleServiceMock.Object,
+				Mock.Of<ITextDepartmentSwitchService>());
 		}
 
 		private static string InvokeBuildDispatchPrompt(Type controllerType, Call call, string address)

--- a/Web/Resgrid.Web.Services/Controllers/SignalWireController.cs
+++ b/Web/Resgrid.Web.Services/Controllers/SignalWireController.cs
@@ -47,13 +47,14 @@ namespace Resgrid.Web.Services.Controllers
 		private readonly IUnitsService _unitsService;
 		private readonly ICommunicationTestService _communicationTestService;
 	private readonly IChatbotIngressService _chatbotIngressService;
+	private readonly IUsersService _usersService;
 
 	public SignalWireController(IDepartmentSettingsService departmentSettingsService, INumbersService numbersService,
 		ILimitsService limitsService, ICallsService callsService, IQueueService queueService, IDepartmentsService departmentsService,
 		IUserProfileService userProfileService, ITextCommandService textCommandService, IActionLogsService actionLogsService,
 		IUserStateService userStateService, ICommunicationService communicationService, IGeoLocationProvider geoLocationProvider,
 		IDepartmentGroupsService departmentGroupsService, ICustomStateService customStateService, IUnitsService unitsService,
-		ICommunicationTestService communicationTestService, IChatbotIngressService chatbotIngressService)
+		ICommunicationTestService communicationTestService, IChatbotIngressService chatbotIngressService, IUsersService usersService)
 	{
 		_departmentSettingsService = departmentSettingsService;
 		_numbersService = numbersService;
@@ -72,6 +73,7 @@ namespace Resgrid.Web.Services.Controllers
 		_unitsService = unitsService;
 		_communicationTestService = communicationTestService;
 		_chatbotIngressService = chatbotIngressService;
+		_usersService = usersService;
 	}
 	#endregion Private Readonly Properties and Constructors
 
@@ -168,31 +170,41 @@ namespace Resgrid.Web.Services.Controllers
 
 			try
 			{
-				UserProfile profile = null;
-				var departmentId = await _departmentSettingsService.GetDepartmentIdByTextToCallNumberAsync(textMessage.To);
+				// Parity with TwilioController: the sender's profile identifies them and their ACTIVE
+				// department drives routing. The TextToCallNumber lookup is a legacy path used only when no
+				// profile matched (dispatch centers sending text-to-call imports, unknown senders).
+				UserProfile profile = await _userProfileService.GetProfileByMobileNumberAsync(textMessage.Msisdn);
 
-				if (!departmentId.HasValue)
+				// SECURITY: an unverified mobile number may be used for ROUTING (department resolution,
+				// plan gate) so the sender lands in their real department, but it must never authorize
+				// ACTIONS. Downstream handling blocks commands for unverified senders and prompts them to
+				// verify. The single exception is STOP (handled below): opting out must always work.
+				bool senderNumberUnverified = profile != null && profile.MobileNumberVerified != true;
+				if (senderNumberUnverified)
+					Framework.Logging.LogInfo($"[SignalWire SMS] MessageSid={textMessage.MessageId} From={Framework.StringHelpers.MaskPhoneNumber(textMessage.Msisdn)} matched a profile but the mobile number is not verified; using profile for routing only, actions blocked until verified.");
+
+				int? departmentId = null;
+				if (profile != null)
 				{
-					profile = await _userProfileService.GetProfileByMobileNumberAsync(textMessage.Msisdn);
-
-					// SECURITY: an unverified mobile number must never identify/act as the matched user.
-					// Verification (MobileNumberVerified == true) is the bar for trusting an inbound sender.
-					if (profile != null && profile.MobileNumberVerified != true)
-					{
-						Framework.Logging.LogInfo($"[SignalWire SMS] MessageSid={textMessage.MessageId} From={Framework.StringHelpers.MaskPhoneNumber(textMessage.Msisdn)} matched a profile but the mobile number is not verified; not linking sender to user.");
-						profile = null;
-					}
-
-					if (profile != null)
-					{
-						var department = await _departmentsService.GetDepartmentByUserIdAsync(profile.UserId);
-
-						if (department != null)
-							departmentId = department.DepartmentId;
-					}
+					var activeDepartment = await _departmentsService.GetActiveSmsDepartmentForUserAsync(profile.UserId);
+					if (activeDepartment != null)
+						departmentId = activeDepartment.DepartmentId;
+				}
+				else
+				{
+					departmentId = await _departmentSettingsService.GetDepartmentIdByTextToCallNumberAsync(textMessage.To);
 				}
 
-				if (departmentId.HasValue)
+				// STOP from an unverified sender: honor the opt-out immediately — turning off messages must
+				// always work, regardless of verification, plan or department state.
+				if (senderNumberUnverified && _textCommandService.DetermineType(textMessage.Text).Type == TextCommandTypes.Stop)
+				{
+					Framework.Logging.LogInfo($"[SignalWire SMS] MessageSid={textMessage.MessageId} unverified sender texted STOP; disabling SMS messaging on the matched profile.");
+					await _userProfileService.DisableTextMessagesForUserAsync(profile.UserId, cancellationToken);
+					messageEvent.Processed = true;
+					response = LaMLResponse.Message.Respond("Text messages are now turned off for this user, to enable again log in to Resgrid and update your profile.");
+				}
+				else if (departmentId.HasValue)
 				{
 					var department = await _departmentsService.GetDepartmentByIdAsync(departmentId.Value);
 					var textToCallEnabled = await _departmentSettingsService.GetDepartmentIsTextCallImportEnabledAsync(departmentId.Value);
@@ -263,17 +275,52 @@ namespace Resgrid.Web.Services.Controllers
 							var result = await _chatbotIngressService.ProcessMessageAsync(request);
 
 							messageEvent.Processed = true;
-							response = LaMLResponse.Message.Respond(result.Text);
+							if (result != null && !string.IsNullOrWhiteSpace(result.Text))
+								response = LaMLResponse.Message.Respond(result.Text);
 						}
 					}
-					else if (textMessage.To == Config.NumberProviderConfig.SignalWireResgridNumber.Replace("+", "")) // Resgrid master text number
+					else if (senderNumberUnverified)
 					{
-						var payload = _textCommandService.DetermineType(textMessage.Text);
+						// Checked BEFORE the switch offer: switching departments is an action, and an
+						// unverified sender may not act as the matched user (parity with TwilioController).
+						Framework.Logging.LogInfo($"[SignalWire SMS] DepartmentId={departmentId.Value} not authorized for inbound text (plan gate) and sender is unverified; replying with verify-number message.");
+						messageEvent.Processed = true;
+						response = LaMLResponse.Message.Respond("Resgrid: This mobile number matches a Resgrid profile but hasn't been verified. Please verify your mobile number on your Resgrid profile page to use text commands.");
+					}
+					else if (profile != null)
+					{
+						// The user's ACTIVE department doesn't support inbound text. If they belong to other
+						// departments that do, process a SWITCH command or offer the switch options;
+						// otherwise fall through to the plan message.
+						response = await HandleUnsupportedActiveDepartmentAsync(textMessage, messageEvent, departmentId.Value, profile, cancellationToken);
+					}
+					else
+					{
+						Framework.Logging.LogInfo($"[SignalWire SMS] DepartmentId={departmentId.Value} not authorized for inbound text (plan gate); replying with unsupported message.");
+						messageEvent.Processed = true;
+						response = LaMLResponse.Message.Respond("Resgrid: Inbound text messaging isn't available on your department's current plan. Please upgrade to a paid plan to enable text commands.");
+					}
+				}
+				else if (textMessage.To == Config.NumberProviderConfig.SignalWireResgridNumber.Replace("+", "")) // Resgrid master text number
+				{
+					var payload = _textCommandService.DetermineType(textMessage.Text);
 
+					// A sender whose profile mobile number is unverified can't be identified, so commands
+					// can't be acted on — direct them to verify instead of replying "unknown command". HELP
+					// and STOP still work below: neither needs a trusted identity, and STOP must always opt out.
+					if (profile != null && profile.MobileNumberVerified != true
+						&& payload.Type != TextCommandTypes.Help && payload.Type != TextCommandTypes.Stop)
+					{
+						Framework.Logging.LogInfo($"[SignalWire SMS] Master number: sender {Framework.StringHelpers.MaskPhoneNumber(textMessage.Msisdn)} matched a profile but the mobile number is not verified; replying with verify-number message.");
+						messageEvent.Processed = true;
+						response = LaMLResponse.Message.Respond("Resgrid: This mobile number matches a Resgrid profile but hasn't been verified. Please verify your mobile number on your Resgrid profile page to use text commands.");
+					}
+					else
+					{
 						switch (payload.Type)
 						{
 							case TextCommandTypes.None:
-								await _communicationService.SendTextMessageAsync(profile.UserId, "Resgrid TCI Help", "Resgrid (https://resgrid.com) Automated Text System. Unknown command, text help for supported commands.", department.DepartmentId, textMessage.To, profile);
+								response = LaMLResponse.Message.Respond("Resgrid (https://resgrid.com) Automated Text System. Unknown command, text help for supported commands.");
 								break;
 							case TextCommandTypes.Help:
 								messageEvent.Processed = true;
@@ -287,18 +334,31 @@ namespace Resgrid.Web.Services.Controllers
 								help.Append("HELP: This help text" + Environment.NewLine);
 
 								response = LaMLResponse.Message.Respond(help.ToString());
-								//_communicationService.SendTextMessage(profile.UserId, "Resgrid TCI Help", help.ToString(), department.DepartmentId, textMessage.To, profile);
 
 								break;
 							case TextCommandTypes.Stop:
 								messageEvent.Processed = true;
+
+								if (profile == null)
+								{
+									response = LaMLResponse.Message.Respond("Unable to locate your profile. Please log in to Resgrid to manage your text message settings.");
+									break;
+								}
+
 								await _userProfileService.DisableTextMessagesForUserAsync(profile.UserId, cancellationToken);
 
 								response = LaMLResponse.Message.Respond("Text messages are now turned off for this user, to enable again log in to Resgrid and update your profile.");
-								//_communicationService.SendTextMessage(profile.UserId, "Resgrid TCI Help", "Text messages are now turned off for this user, to enable again log in to Resgrid and update your profile.", department.DepartmentId, textMessage.To, profile);
 								break;
 						}
 					}
+				}
+				else if (senderNumberUnverified)
+				{
+					// No department resolved and this isn't the master number, but the sender did match a
+					// profile with an unverified mobile number — tell them the actionable fix.
+					Framework.Logging.LogInfo($"[SignalWire SMS] No department resolved for sender {Framework.StringHelpers.MaskPhoneNumber(textMessage.Msisdn)} (unverified profile match); replying with verify-number message.");
+					messageEvent.Processed = true;
+					response = LaMLResponse.Message.Respond("Resgrid: This mobile number matches a Resgrid profile but hasn't been verified. Please verify your mobile number on your Resgrid profile page to use text commands.");
 				}
 
 				//return Ok(new StringContent(response, Encoding.UTF8, "application/xml"));
@@ -322,5 +382,112 @@ namespace Resgrid.Web.Services.Controllers
 			return Ok();
 		}
 
+		// Parity with TwilioController: the identified user's ACTIVE department failed the inbound-text
+		// plan gate. A SWITCH command is honored (the normal command path is unreachable while the active
+		// department is unsupported), any other text gets the switch options, and with no supported
+		// alternatives they get the plan message. Returns the LaML response body.
+		private async Task<string> HandleUnsupportedActiveDepartmentAsync(TextMessage textMessage, InboundMessageEvent messageEvent,
+			int departmentId, UserProfile profile, CancellationToken cancellationToken)
+		{
+			var supported = await _departmentsService.GetSmsSupportedMembershipsForUserAsync(profile.UserId);
+			if (supported.Count == 0)
+			{
+				Framework.Logging.LogInfo($"[SignalWire SMS] DepartmentId={departmentId} not authorized for inbound text (plan gate); user {profile.UserId} has no SMS-supported departments; replying with unsupported message.");
+				messageEvent.Processed = true;
+				return LaMLResponse.Message.Respond("Resgrid: Inbound text messaging isn't available on your department's current plan. Please upgrade to a paid plan to enable text commands.");
+			}
+
+			var payload = _textCommandService.DetermineType(textMessage.Text);
+			if (payload.Type == TextCommandTypes.SwitchDepartment)
+				return await HandleSwitchDepartmentCommandAsync(messageEvent, profile, payload.Data, cancellationToken);
+
+			Framework.Logging.LogInfo($"[SignalWire SMS] DepartmentId={departmentId} not authorized for inbound text (plan gate); user {profile.UserId} has {supported.Count} SMS-supported department(s); replying with switch options.");
+			messageEvent.Processed = true;
+			return LaMLResponse.Message.Respond(await BuildSwitchOptionsMessageAsync(supported,
+				"Resgrid: Your active department's plan doesn't include inbound text messaging, but you belong to other departments that do."));
+		}
+
+		// SWITCH [name/number]: changes the user's active department. Mirrors the TwilioController
+		// handler — same supported-department list and ordering so numeric picks stay stable across
+		// providers. Returns the LaML response body.
+		private async Task<string> HandleSwitchDepartmentCommandAsync(InboundMessageEvent messageEvent,
+			UserProfile profile, string departmentIdentifier, CancellationToken cancellationToken)
+		{
+			messageEvent.Processed = true;
+
+			var supported = await _departmentsService.GetSmsSupportedMembershipsForUserAsync(profile.UserId);
+			if (supported.Count == 0)
+				return LaMLResponse.Message.Respond("Resgrid: None of your departments' current plans include inbound text messaging. Please upgrade to a paid plan to enable text commands.");
+
+			if (string.IsNullOrWhiteSpace(departmentIdentifier))
+				return LaMLResponse.Message.Respond(await BuildSwitchOptionsMessageAsync(supported, "Resgrid: Your departments that support text messaging:"));
+
+			DepartmentMember target = null;
+			var trimmedId = departmentIdentifier.Trim();
+
+			// A small number is a pick from the displayed list; otherwise try a department id, then name/code.
+			if (int.TryParse(trimmedId, out var listIndex) && listIndex >= 1 && listIndex <= supported.Count)
+				target = supported[listIndex - 1];
+
+			if (target == null && int.TryParse(trimmedId, out var deptId))
+				target = supported.FirstOrDefault(m => m.DepartmentId == deptId);
+
+			if (target == null)
+			{
+				foreach (var membership in supported)
+				{
+					var dept = await _departmentsService.GetDepartmentByIdAsync(membership.DepartmentId);
+					if (dept == null)
+						continue;
+
+					if (string.Equals(dept.Name, trimmedId, StringComparison.OrdinalIgnoreCase)
+						|| string.Equals(dept.Code, trimmedId, StringComparison.OrdinalIgnoreCase))
+					{
+						target = membership;
+						break;
+					}
+
+					if (target == null && !string.IsNullOrWhiteSpace(dept.Name) && dept.Name.IndexOf(trimmedId, StringComparison.OrdinalIgnoreCase) >= 0)
+						target = membership;
+				}
+			}
+
+			if (target == null)
+				return LaMLResponse.Message.Respond(await BuildSwitchOptionsMessageAsync(supported, $"Resgrid: Couldn't find a department matching \"{trimmedId}\"."));
+
+			if (target.IsActive)
+			{
+				var alreadyActive = await _departmentsService.GetDepartmentByIdAsync(target.DepartmentId);
+				return LaMLResponse.Message.Respond($"Resgrid: {alreadyActive?.Name ?? "That department"} is already your active department.");
+			}
+
+			var identityUser = _usersService.GetUserById(profile.UserId);
+			var success = await _departmentsService.SetActiveDepartmentForUserAsync(profile.UserId, target.DepartmentId, identityUser, cancellationToken);
+
+			var targetDept = await _departmentsService.GetDepartmentByIdAsync(target.DepartmentId);
+			if (success)
+			{
+				Framework.Logging.LogInfo($"[SignalWire SMS] User {profile.UserId} switched active department to {target.DepartmentId} via text command.");
+				return LaMLResponse.Message.Respond($"Resgrid: Your active department is now {targetDept?.Name ?? ("department " + target.DepartmentId)}. Text commands now apply to this department.");
+			}
+
+			return LaMLResponse.Message.Respond("Resgrid: Unable to switch departments right now. Please try again later.");
+		}
+
+		private async Task<string> BuildSwitchOptionsMessageAsync(List<DepartmentMember> supported, string prefix)
+		{
+			var sb = new StringBuilder();
+			sb.Append(prefix + Environment.NewLine);
+
+			for (int i = 0; i < supported.Count; i++)
+			{
+				var dept = await _departmentsService.GetDepartmentByIdAsync(supported[i].DepartmentId);
+				var activeMarker = supported[i].IsActive ? " (active)" : "";
+				sb.Append($"{i + 1}: {dept?.Name ?? ("Department " + supported[i].DepartmentId)}{activeMarker}" + Environment.NewLine);
+			}
+
+			sb.Append("Reply SWITCH <number or name> to change your active department.");
+			return sb.ToString();
+		}
 	}
 }

--- a/Web/Resgrid.Web.Services/Controllers/SignalWireController.cs
+++ b/Web/Resgrid.Web.Services/Controllers/SignalWireController.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using Resgrid.Chatbot.Interfaces;
 using Resgrid.Chatbot.Models;
 using Resgrid.Model;
@@ -48,13 +48,15 @@ namespace Resgrid.Web.Services.Controllers
 		private readonly ICommunicationTestService _communicationTestService;
 	private readonly IChatbotIngressService _chatbotIngressService;
 	private readonly IUsersService _usersService;
+	private readonly ITextDepartmentSwitchService _textDepartmentSwitchService;
 
 	public SignalWireController(IDepartmentSettingsService departmentSettingsService, INumbersService numbersService,
 		ILimitsService limitsService, ICallsService callsService, IQueueService queueService, IDepartmentsService departmentsService,
 		IUserProfileService userProfileService, ITextCommandService textCommandService, IActionLogsService actionLogsService,
 		IUserStateService userStateService, ICommunicationService communicationService, IGeoLocationProvider geoLocationProvider,
 		IDepartmentGroupsService departmentGroupsService, ICustomStateService customStateService, IUnitsService unitsService,
-		ICommunicationTestService communicationTestService, IChatbotIngressService chatbotIngressService, IUsersService usersService)
+		ICommunicationTestService communicationTestService, IChatbotIngressService chatbotIngressService, IUsersService usersService,
+		ITextDepartmentSwitchService textDepartmentSwitchService)
 	{
 		_departmentSettingsService = departmentSettingsService;
 		_numbersService = numbersService;
@@ -74,6 +76,7 @@ namespace Resgrid.Web.Services.Controllers
 		_communicationTestService = communicationTestService;
 		_chatbotIngressService = chatbotIngressService;
 		_usersService = usersService;
+		_textDepartmentSwitchService = textDepartmentSwitchService;
 	}
 	#endregion Private Readonly Properties and Constructors
 
@@ -289,10 +292,12 @@ namespace Resgrid.Web.Services.Controllers
 					}
 					else if (profile != null)
 					{
-						// The user's ACTIVE department doesn't support inbound text. If they belong to other
-						// departments that do, process a SWITCH command or offer the switch options;
-						// otherwise fall through to the plan message.
-						response = await HandleUnsupportedActiveDepartmentAsync(textMessage, messageEvent, departmentId.Value, profile, cancellationToken);
+						// The user's ACTIVE department doesn't support inbound text. STOP is honored, a
+						// SWITCH command is processed, and other texts get the switch options (or the plan
+						// message when no supported alternatives exist). Shared with Twilio via the switch service.
+						messageEvent.Processed = true;
+						response = LaMLResponse.Message.Respond(await _textDepartmentSwitchService.BuildUnsupportedActiveDepartmentResponseAsync(
+							textMessage.Text, departmentId.Value, profile, "[SignalWire SMS]", cancellationToken));
 					}
 					else
 					{
@@ -382,112 +387,5 @@ namespace Resgrid.Web.Services.Controllers
 			return Ok();
 		}
 
-		// Parity with TwilioController: the identified user's ACTIVE department failed the inbound-text
-		// plan gate. A SWITCH command is honored (the normal command path is unreachable while the active
-		// department is unsupported), any other text gets the switch options, and with no supported
-		// alternatives they get the plan message. Returns the LaML response body.
-		private async Task<string> HandleUnsupportedActiveDepartmentAsync(TextMessage textMessage, InboundMessageEvent messageEvent,
-			int departmentId, UserProfile profile, CancellationToken cancellationToken)
-		{
-			var supported = await _departmentsService.GetSmsSupportedMembershipsForUserAsync(profile.UserId);
-			if (supported.Count == 0)
-			{
-				Framework.Logging.LogInfo($"[SignalWire SMS] DepartmentId={departmentId} not authorized for inbound text (plan gate); user {profile.UserId} has no SMS-supported departments; replying with unsupported message.");
-				messageEvent.Processed = true;
-				return LaMLResponse.Message.Respond("Resgrid: Inbound text messaging isn't available on your department's current plan. Please upgrade to a paid plan to enable text commands.");
-			}
-
-			var payload = _textCommandService.DetermineType(textMessage.Text);
-			if (payload.Type == TextCommandTypes.SwitchDepartment)
-				return await HandleSwitchDepartmentCommandAsync(messageEvent, profile, payload.Data, cancellationToken);
-
-			Framework.Logging.LogInfo($"[SignalWire SMS] DepartmentId={departmentId} not authorized for inbound text (plan gate); user {profile.UserId} has {supported.Count} SMS-supported department(s); replying with switch options.");
-			messageEvent.Processed = true;
-			return LaMLResponse.Message.Respond(await BuildSwitchOptionsMessageAsync(supported,
-				"Resgrid: Your active department's plan doesn't include inbound text messaging, but you belong to other departments that do."));
-		}
-
-		// SWITCH [name/number]: changes the user's active department. Mirrors the TwilioController
-		// handler — same supported-department list and ordering so numeric picks stay stable across
-		// providers. Returns the LaML response body.
-		private async Task<string> HandleSwitchDepartmentCommandAsync(InboundMessageEvent messageEvent,
-			UserProfile profile, string departmentIdentifier, CancellationToken cancellationToken)
-		{
-			messageEvent.Processed = true;
-
-			var supported = await _departmentsService.GetSmsSupportedMembershipsForUserAsync(profile.UserId);
-			if (supported.Count == 0)
-				return LaMLResponse.Message.Respond("Resgrid: None of your departments' current plans include inbound text messaging. Please upgrade to a paid plan to enable text commands.");
-
-			if (string.IsNullOrWhiteSpace(departmentIdentifier))
-				return LaMLResponse.Message.Respond(await BuildSwitchOptionsMessageAsync(supported, "Resgrid: Your departments that support text messaging:"));
-
-			DepartmentMember target = null;
-			var trimmedId = departmentIdentifier.Trim();
-
-			// A small number is a pick from the displayed list; otherwise try a department id, then name/code.
-			if (int.TryParse(trimmedId, out var listIndex) && listIndex >= 1 && listIndex <= supported.Count)
-				target = supported[listIndex - 1];
-
-			if (target == null && int.TryParse(trimmedId, out var deptId))
-				target = supported.FirstOrDefault(m => m.DepartmentId == deptId);
-
-			if (target == null)
-			{
-				foreach (var membership in supported)
-				{
-					var dept = await _departmentsService.GetDepartmentByIdAsync(membership.DepartmentId);
-					if (dept == null)
-						continue;
-
-					if (string.Equals(dept.Name, trimmedId, StringComparison.OrdinalIgnoreCase)
-						|| string.Equals(dept.Code, trimmedId, StringComparison.OrdinalIgnoreCase))
-					{
-						target = membership;
-						break;
-					}
-
-					if (target == null && !string.IsNullOrWhiteSpace(dept.Name) && dept.Name.IndexOf(trimmedId, StringComparison.OrdinalIgnoreCase) >= 0)
-						target = membership;
-				}
-			}
-
-			if (target == null)
-				return LaMLResponse.Message.Respond(await BuildSwitchOptionsMessageAsync(supported, $"Resgrid: Couldn't find a department matching \"{trimmedId}\"."));
-
-			if (target.IsActive)
-			{
-				var alreadyActive = await _departmentsService.GetDepartmentByIdAsync(target.DepartmentId);
-				return LaMLResponse.Message.Respond($"Resgrid: {alreadyActive?.Name ?? "That department"} is already your active department.");
-			}
-
-			var identityUser = _usersService.GetUserById(profile.UserId);
-			var success = await _departmentsService.SetActiveDepartmentForUserAsync(profile.UserId, target.DepartmentId, identityUser, cancellationToken);
-
-			var targetDept = await _departmentsService.GetDepartmentByIdAsync(target.DepartmentId);
-			if (success)
-			{
-				Framework.Logging.LogInfo($"[SignalWire SMS] User {profile.UserId} switched active department to {target.DepartmentId} via text command.");
-				return LaMLResponse.Message.Respond($"Resgrid: Your active department is now {targetDept?.Name ?? ("department " + target.DepartmentId)}. Text commands now apply to this department.");
-			}
-
-			return LaMLResponse.Message.Respond("Resgrid: Unable to switch departments right now. Please try again later.");
-		}
-
-		private async Task<string> BuildSwitchOptionsMessageAsync(List<DepartmentMember> supported, string prefix)
-		{
-			var sb = new StringBuilder();
-			sb.Append(prefix + Environment.NewLine);
-
-			for (int i = 0; i < supported.Count; i++)
-			{
-				var dept = await _departmentsService.GetDepartmentByIdAsync(supported[i].DepartmentId);
-				var activeMarker = supported[i].IsActive ? " (active)" : "";
-				sb.Append($"{i + 1}: {dept?.Name ?? ("Department " + supported[i].DepartmentId)}{activeMarker}" + Environment.NewLine);
-			}
-
-			sb.Append("Reply SWITCH <number or name> to change your active department.");
-			return sb.ToString();
-		}
 	}
 }

--- a/Web/Resgrid.Web.Services/Controllers/TwilioController.cs
+++ b/Web/Resgrid.Web.Services/Controllers/TwilioController.cs
@@ -55,6 +55,7 @@ namespace Resgrid.Web.Services.Controllers
 		private readonly IEncryptionService _encryptionService;
 	private readonly ITwilioVoiceResponseService _twilioVoiceResponseService;
 	private readonly IFeatureToggleService _featureToggleService;
+	private readonly ITextDepartmentSwitchService _textDepartmentSwitchService;
 
 	public TwilioController(IDepartmentSettingsService departmentSettingsService, INumbersService numbersService,
 		ILimitsService limitsService, ICallsService callsService, IQueueService queueService, IDepartmentsService departmentsService,
@@ -63,7 +64,7 @@ namespace Resgrid.Web.Services.Controllers
 		IDepartmentGroupsService departmentGroupsService, ICustomStateService customStateService, IUnitsService unitsService,
 		IUsersService usersService, ICalendarService calendarService, ICommunicationTestService communicationTestService,
 		IEncryptionService encryptionService, ITwilioVoiceResponseService twilioVoiceResponseService,
-		IFeatureToggleService featureToggleService)
+		IFeatureToggleService featureToggleService, ITextDepartmentSwitchService textDepartmentSwitchService)
 	{
 		_departmentSettingsService = departmentSettingsService;
 		_numbersService = numbersService;
@@ -86,6 +87,7 @@ namespace Resgrid.Web.Services.Controllers
 		_encryptionService = encryptionService;
 		_twilioVoiceResponseService = twilioVoiceResponseService;
 		_featureToggleService = featureToggleService;
+		_textDepartmentSwitchService = textDepartmentSwitchService;
 	}
 		#endregion Private Readonly Properties and Constructors
 
@@ -384,6 +386,7 @@ namespace Resgrid.Web.Services.Controllers
 									help.Append("CALLS: List active calls" + Environment.NewLine);
 									help.Append("C[CallId]: Get Call Detail i.e. C1445" + Environment.NewLine);
 									help.Append("UNITS: List unit statuses" + Environment.NewLine);
+									help.Append("SWITCH [name or number]: Change your active department" + Environment.NewLine);
 									help.Append("---------------------" + Environment.NewLine);
 									help.Append("Status or Action Commands" + Environment.NewLine);
 									help.Append("---------------------" + Environment.NewLine);
@@ -430,7 +433,8 @@ namespace Resgrid.Web.Services.Controllers
 									//_communicationService.SendTextMessage(profile.UserId, "Resgrid TCI Help", help.ToString(), department.DepartmentId, textMessage.To, profile);
 									break;
 								case TextCommandTypes.SwitchDepartment:
-									await HandleSwitchDepartmentCommandAsync(messageEvent, response, profile, payload.Data);
+									messageEvent.Processed = true;
+									response.Message(await _textDepartmentSwitchService.BuildSwitchCommandResponseAsync(profile, payload.Data, "[Twilio SMS]"));
 									break;
 								case TextCommandTypes.Action:
 									messageEvent.Processed = true;
@@ -585,10 +589,12 @@ namespace Resgrid.Web.Services.Controllers
 				}
 				else if (userProfile != null)
 				{
-					// The user's ACTIVE department doesn't support inbound text. If they belong to other
-					// departments that do, process a SWITCH command or offer the switch options; otherwise
-					// fall through to the plan message.
-					await HandleUnsupportedActiveDepartmentAsync(textMessage, messageEvent, response, departmentId.Value, userProfile);
+					// The user's ACTIVE department doesn't support inbound text. STOP is honored, a SWITCH
+					// command is processed, and other texts get the switch options (or the plan message
+					// when no supported alternatives exist). Shared with SignalWire via the switch service.
+					messageEvent.Processed = true;
+					response.Message(await _textDepartmentSwitchService.BuildUnsupportedActiveDepartmentResponseAsync(
+						textMessage.Text, departmentId.Value, userProfile, "[Twilio SMS]"));
 				}
 				else
 				{
@@ -659,130 +665,6 @@ namespace Resgrid.Web.Services.Controllers
 				messageEvent.Processed = true;
 				response.Message("Resgrid: This mobile number matches a Resgrid profile but hasn't been verified. Please verify your mobile number on your Resgrid profile page to use text commands.");
 			}
-		}
-
-		// The identified user's ACTIVE department failed the inbound-text plan gate. When they belong to
-		// other departments that do support it, a SWITCH command is honored (it must work here — the
-		// normal command path is unreachable while the active department is unsupported) and any other
-		// text gets the switch options; with no alternatives they get the plan message.
-		private async System.Threading.Tasks.Task HandleUnsupportedActiveDepartmentAsync(TextMessage textMessage, InboundMessageEvent messageEvent,
-			MessagingResponse response, int departmentId, UserProfile userProfile)
-		{
-			var supported = await _departmentsService.GetSmsSupportedMembershipsForUserAsync(userProfile.UserId);
-			if (supported.Count == 0)
-			{
-				Framework.Logging.LogInfo($"[Twilio SMS] DepartmentId={departmentId} not authorized for inbound text (plan gate); user {userProfile.UserId} has no SMS-supported departments; replying with unsupported message.");
-				messageEvent.Processed = true;
-				response.Message("Resgrid: Inbound text messaging isn't available on your department's current plan. Please upgrade to a paid plan to enable text commands.");
-				return;
-			}
-
-			var payload = _textCommandService.DetermineType(textMessage.Text);
-			if (payload.Type == TextCommandTypes.SwitchDepartment)
-			{
-				await HandleSwitchDepartmentCommandAsync(messageEvent, response, userProfile, payload.Data);
-				return;
-			}
-
-			Framework.Logging.LogInfo($"[Twilio SMS] DepartmentId={departmentId} not authorized for inbound text (plan gate); user {userProfile.UserId} has {supported.Count} SMS-supported department(s); replying with switch options.");
-			messageEvent.Processed = true;
-			response.Message(await BuildSwitchOptionsMessageAsync(supported,
-				"Resgrid: Your active department's plan doesn't include inbound text messaging, but you belong to other departments that do."));
-		}
-
-		// SWITCH [name/number]: changes the user's active department. Only departments whose plan
-		// supports SMS are offered/accepted — the list order matches BuildSwitchOptionsMessageAsync so a
-		// numeric reply maps to what the user was shown, even though each SMS is a stateless request.
-		private async System.Threading.Tasks.Task HandleSwitchDepartmentCommandAsync(InboundMessageEvent messageEvent,
-			MessagingResponse response, UserProfile userProfile, string departmentIdentifier)
-		{
-			messageEvent.Processed = true;
-
-			var supported = await _departmentsService.GetSmsSupportedMembershipsForUserAsync(userProfile.UserId);
-			if (supported.Count == 0)
-			{
-				response.Message("Resgrid: None of your departments' current plans include inbound text messaging. Please upgrade to a paid plan to enable text commands.");
-				return;
-			}
-
-			if (string.IsNullOrWhiteSpace(departmentIdentifier))
-			{
-				response.Message(await BuildSwitchOptionsMessageAsync(supported, "Resgrid: Your departments that support text messaging:"));
-				return;
-			}
-
-			DepartmentMember target = null;
-			var trimmedId = departmentIdentifier.Trim();
-
-			// A small number is a pick from the displayed list; otherwise try a department id, then name/code.
-			if (int.TryParse(trimmedId, out var listIndex) && listIndex >= 1 && listIndex <= supported.Count)
-				target = supported[listIndex - 1];
-
-			if (target == null && int.TryParse(trimmedId, out var deptId))
-				target = supported.FirstOrDefault(m => m.DepartmentId == deptId);
-
-			if (target == null)
-			{
-				foreach (var membership in supported)
-				{
-					var dept = await _departmentsService.GetDepartmentByIdAsync(membership.DepartmentId);
-					if (dept == null)
-						continue;
-
-					if (string.Equals(dept.Name, trimmedId, StringComparison.OrdinalIgnoreCase)
-						|| string.Equals(dept.Code, trimmedId, StringComparison.OrdinalIgnoreCase))
-					{
-						target = membership;
-						break;
-					}
-
-					if (target == null && !string.IsNullOrWhiteSpace(dept.Name) && dept.Name.IndexOf(trimmedId, StringComparison.OrdinalIgnoreCase) >= 0)
-						target = membership;
-				}
-			}
-
-			if (target == null)
-			{
-				response.Message(await BuildSwitchOptionsMessageAsync(supported, $"Resgrid: Couldn't find a department matching \"{trimmedId}\"."));
-				return;
-			}
-
-			if (target.IsActive)
-			{
-				var alreadyActive = await _departmentsService.GetDepartmentByIdAsync(target.DepartmentId);
-				response.Message($"Resgrid: {alreadyActive?.Name ?? "That department"} is already your active department.");
-				return;
-			}
-
-			var identityUser = _usersService.GetUserById(userProfile.UserId);
-			var success = await _departmentsService.SetActiveDepartmentForUserAsync(userProfile.UserId, target.DepartmentId, identityUser);
-
-			var targetDept = await _departmentsService.GetDepartmentByIdAsync(target.DepartmentId);
-			if (success)
-			{
-				Framework.Logging.LogInfo($"[Twilio SMS] User {userProfile.UserId} switched active department to {target.DepartmentId} via text command.");
-				response.Message($"Resgrid: Your active department is now {targetDept?.Name ?? ("department " + target.DepartmentId)}. Text commands now apply to this department.");
-			}
-			else
-			{
-				response.Message("Resgrid: Unable to switch departments right now. Please try again later.");
-			}
-		}
-
-		private async Task<string> BuildSwitchOptionsMessageAsync(List<DepartmentMember> supported, string prefix)
-		{
-			var sb = new StringBuilder();
-			sb.Append(prefix + Environment.NewLine);
-
-			for (int i = 0; i < supported.Count; i++)
-			{
-				var dept = await _departmentsService.GetDepartmentByIdAsync(supported[i].DepartmentId);
-				var activeMarker = supported[i].IsActive ? " (active)" : "";
-				sb.Append($"{i + 1}: {dept?.Name ?? ("Department " + supported[i].DepartmentId)}{activeMarker}" + Environment.NewLine);
-			}
-
-			sb.Append("Reply SWITCH <number or name> to change your active department.");
-			return sb.ToString();
 		}
 
 		[HttpGet("VoiceCall")]

--- a/Web/Resgrid.Web.Services/Controllers/TwilioController.cs
+++ b/Web/Resgrid.Web.Services/Controllers/TwilioController.cs
@@ -143,27 +143,32 @@ namespace Resgrid.Web.Services.Controllers
 				// inbound number fall back to resolving the department from that number.
 				UserProfile userProfile = await _userProfileService.GetProfileByMobileNumberAsync(textMessage.Msisdn);
 
-				// SECURITY: an unverified mobile number must never identify/act as the matched user —
-				// anyone can type someone else's number into a profile. Verification (MobileNumberVerified
-				// == true) is the bar for trusting an inbound sender.
+				// SECURITY: an unverified mobile number may be used for ROUTING (department resolution,
+				// plan gate, feature flag) so the sender lands in their real department, but it must never
+				// authorize ACTIONS — anyone can type someone else's number into a profile. Downstream
+				// handlers block commands for unverified senders and prompt them to verify. The single
+				// exception is STOP (handled below): opting out of messages must always work.
 				bool senderNumberUnverified = userProfile != null && userProfile.MobileNumberVerified != true;
 				if (senderNumberUnverified)
-				{
-					Framework.Logging.LogInfo($"[Twilio SMS] MessageSid={request.MessageSid} From={Framework.StringHelpers.MaskPhoneNumber(textMessage.Msisdn)} matched a profile but the mobile number is not verified; not linking sender to user.");
-					userProfile = null;
-				}
+					Framework.Logging.LogInfo($"[Twilio SMS] MessageSid={request.MessageSid} From={Framework.StringHelpers.MaskPhoneNumber(textMessage.Msisdn)} matched a profile but the mobile number is not verified; using profile for routing only, actions blocked until verified.");
 
 				int? departmentId = null;
 				if (userProfile != null)
 				{
+					// An identified user (verified or not) always operates in their ACTIVE department. The
+					// texted number must NOT override this — the TextToCallNumber mapping is a legacy path
+					// that can resolve a department the user isn't even a member of.
 					var department = await _departmentsService.GetActiveSmsDepartmentForUserAsync(userProfile.UserId);
 					if (department != null)
 						departmentId = department.DepartmentId;
 				}
-
-				// Legacy fallback: a per-department provisioned inbound number identifies the department directly.
-				if (!departmentId.HasValue)
+				else
+				{
+					// Legacy fallback for senders with no usable profile only (dispatch centers sending
+					// text-to-call imports, unknown numbers): the provisioned inbound number identifies the
+					// department directly.
 					departmentId = await _departmentSettingsService.GetDepartmentIdByTextToCallNumberAsync(textMessage.To);
+				}
 
 				// Carry the resolved department onto the inbound message event so chatbot-routed events
 				// retain the same department context the text-command path records.
@@ -172,6 +177,24 @@ namespace Resgrid.Web.Services.Controllers
 
 				// Diagnostic: did we resolve a department for this inbound text? If not, no reply is sent.
 				Framework.Logging.LogInfo($"[Twilio SMS] MessageSid={request.MessageSid} To={textMessage.To} From={Framework.StringHelpers.MaskPhoneNumber(textMessage.Msisdn)} resolved DepartmentId={(departmentId.HasValue ? departmentId.Value.ToString() : "none")}");
+
+				// STOP from an unverified sender: honor the opt-out immediately — turning off messages must
+				// always work, regardless of verification, plan or feature-flag state.
+				if (senderNumberUnverified && _textCommandService.DetermineType(textMessage.Text).Type == TextCommandTypes.Stop)
+				{
+					Framework.Logging.LogInfo($"[Twilio SMS] MessageSid={request.MessageSid} unverified sender texted STOP; disabling SMS messaging on the matched profile.");
+					await _userProfileService.DisableTextMessagesForUserAsync(userProfile.UserId);
+					messageEvent.Processed = true;
+					response.Message("Text messages are now turned off for this user, to enable again log in to Resgrid and update your profile.");
+
+					// The enclosing finally saves messageEvent and the shared tail returns the TwiML.
+					return new ContentResult
+					{
+						Content = response.ToString(),
+						ContentType = "application/xml",
+						StatusCode = 200
+					};
+				}
 
 				// Feature-flagged rollout: the chatbot ingress is the new path. When the flag is off
 				// (globally or for this department) fall back to the original text-command handling so
@@ -406,6 +429,9 @@ namespace Resgrid.Web.Services.Controllers
 
 									//_communicationService.SendTextMessage(profile.UserId, "Resgrid TCI Help", help.ToString(), department.DepartmentId, textMessage.To, profile);
 									break;
+								case TextCommandTypes.SwitchDepartment:
+									await HandleSwitchDepartmentCommandAsync(messageEvent, response, profile, payload.Data);
+									break;
 								case TextCommandTypes.Action:
 									messageEvent.Processed = true;
 									await _actionLogsService.SetUserActionAsync(profile.UserId, department.DepartmentId, (int)payload.GetActionType());
@@ -548,6 +574,22 @@ namespace Resgrid.Web.Services.Controllers
 						}
 					}
 				}
+				else if (senderNumberUnverified)
+				{
+					// Checked BEFORE the switch offer: switching departments is an action, and an unverified
+					// sender may not act as the matched user. Their profile routed them to the right
+					// department; verifying the number is the prerequisite for everything else.
+					Framework.Logging.LogInfo($"[Twilio SMS] DepartmentId={departmentId.Value} not authorized for inbound text (plan gate) and sender is unverified; replying with verify-number message.");
+					messageEvent.Processed = true;
+					response.Message("Resgrid: This mobile number matches a Resgrid profile but hasn't been verified. Please verify your mobile number on your Resgrid profile page to use text commands.");
+				}
+				else if (userProfile != null)
+				{
+					// The user's ACTIVE department doesn't support inbound text. If they belong to other
+					// departments that do, process a SWITCH command or offer the switch options; otherwise
+					// fall through to the plan message.
+					await HandleUnsupportedActiveDepartmentAsync(textMessage, messageEvent, response, departmentId.Value, userProfile);
+				}
 				else
 				{
 					// Department resolved but its plan doesn't include inbound text messaging (only the free
@@ -561,6 +603,18 @@ namespace Resgrid.Web.Services.Controllers
 			{
 				var profile = await _userProfileService.GetProfileByMobileNumberAsync(textMessage.Msisdn);
 				var payload = _textCommandService.DetermineType(textMessage.Text);
+
+				// A sender whose profile mobile number is unverified can't be identified, so commands can't
+				// be acted on — direct them to verify instead of replying "unknown command". HELP and STOP
+				// still work below: neither needs a trusted identity, and STOP must always opt out.
+				if (profile != null && profile.MobileNumberVerified != true
+					&& payload.Type != TextCommandTypes.Help && payload.Type != TextCommandTypes.Stop)
+				{
+					Framework.Logging.LogInfo($"[Twilio SMS] Master number: sender {Framework.StringHelpers.MaskPhoneNumber(textMessage.Msisdn)} matched a profile but the mobile number is not verified; replying with verify-number message.");
+					messageEvent.Processed = true;
+					response.Message("Resgrid: This mobile number matches a Resgrid profile but hasn't been verified. Please verify your mobile number on your Resgrid profile page to use text commands.");
+					return;
+				}
 
 				switch (payload.Type)
 				{
@@ -596,6 +650,139 @@ namespace Resgrid.Web.Services.Controllers
 						break;
 				}
 			}
+			else if (senderNumberUnverified)
+			{
+				// No department resolved and this isn't the master number, but the sender did match a
+				// profile with an unverified mobile number. Previously this was silence; tell them the
+				// actionable fix instead.
+				Framework.Logging.LogInfo($"[Twilio SMS] No department resolved for sender {Framework.StringHelpers.MaskPhoneNumber(textMessage.Msisdn)} (unverified profile match); replying with verify-number message.");
+				messageEvent.Processed = true;
+				response.Message("Resgrid: This mobile number matches a Resgrid profile but hasn't been verified. Please verify your mobile number on your Resgrid profile page to use text commands.");
+			}
+		}
+
+		// The identified user's ACTIVE department failed the inbound-text plan gate. When they belong to
+		// other departments that do support it, a SWITCH command is honored (it must work here — the
+		// normal command path is unreachable while the active department is unsupported) and any other
+		// text gets the switch options; with no alternatives they get the plan message.
+		private async System.Threading.Tasks.Task HandleUnsupportedActiveDepartmentAsync(TextMessage textMessage, InboundMessageEvent messageEvent,
+			MessagingResponse response, int departmentId, UserProfile userProfile)
+		{
+			var supported = await _departmentsService.GetSmsSupportedMembershipsForUserAsync(userProfile.UserId);
+			if (supported.Count == 0)
+			{
+				Framework.Logging.LogInfo($"[Twilio SMS] DepartmentId={departmentId} not authorized for inbound text (plan gate); user {userProfile.UserId} has no SMS-supported departments; replying with unsupported message.");
+				messageEvent.Processed = true;
+				response.Message("Resgrid: Inbound text messaging isn't available on your department's current plan. Please upgrade to a paid plan to enable text commands.");
+				return;
+			}
+
+			var payload = _textCommandService.DetermineType(textMessage.Text);
+			if (payload.Type == TextCommandTypes.SwitchDepartment)
+			{
+				await HandleSwitchDepartmentCommandAsync(messageEvent, response, userProfile, payload.Data);
+				return;
+			}
+
+			Framework.Logging.LogInfo($"[Twilio SMS] DepartmentId={departmentId} not authorized for inbound text (plan gate); user {userProfile.UserId} has {supported.Count} SMS-supported department(s); replying with switch options.");
+			messageEvent.Processed = true;
+			response.Message(await BuildSwitchOptionsMessageAsync(supported,
+				"Resgrid: Your active department's plan doesn't include inbound text messaging, but you belong to other departments that do."));
+		}
+
+		// SWITCH [name/number]: changes the user's active department. Only departments whose plan
+		// supports SMS are offered/accepted — the list order matches BuildSwitchOptionsMessageAsync so a
+		// numeric reply maps to what the user was shown, even though each SMS is a stateless request.
+		private async System.Threading.Tasks.Task HandleSwitchDepartmentCommandAsync(InboundMessageEvent messageEvent,
+			MessagingResponse response, UserProfile userProfile, string departmentIdentifier)
+		{
+			messageEvent.Processed = true;
+
+			var supported = await _departmentsService.GetSmsSupportedMembershipsForUserAsync(userProfile.UserId);
+			if (supported.Count == 0)
+			{
+				response.Message("Resgrid: None of your departments' current plans include inbound text messaging. Please upgrade to a paid plan to enable text commands.");
+				return;
+			}
+
+			if (string.IsNullOrWhiteSpace(departmentIdentifier))
+			{
+				response.Message(await BuildSwitchOptionsMessageAsync(supported, "Resgrid: Your departments that support text messaging:"));
+				return;
+			}
+
+			DepartmentMember target = null;
+			var trimmedId = departmentIdentifier.Trim();
+
+			// A small number is a pick from the displayed list; otherwise try a department id, then name/code.
+			if (int.TryParse(trimmedId, out var listIndex) && listIndex >= 1 && listIndex <= supported.Count)
+				target = supported[listIndex - 1];
+
+			if (target == null && int.TryParse(trimmedId, out var deptId))
+				target = supported.FirstOrDefault(m => m.DepartmentId == deptId);
+
+			if (target == null)
+			{
+				foreach (var membership in supported)
+				{
+					var dept = await _departmentsService.GetDepartmentByIdAsync(membership.DepartmentId);
+					if (dept == null)
+						continue;
+
+					if (string.Equals(dept.Name, trimmedId, StringComparison.OrdinalIgnoreCase)
+						|| string.Equals(dept.Code, trimmedId, StringComparison.OrdinalIgnoreCase))
+					{
+						target = membership;
+						break;
+					}
+
+					if (target == null && !string.IsNullOrWhiteSpace(dept.Name) && dept.Name.IndexOf(trimmedId, StringComparison.OrdinalIgnoreCase) >= 0)
+						target = membership;
+				}
+			}
+
+			if (target == null)
+			{
+				response.Message(await BuildSwitchOptionsMessageAsync(supported, $"Resgrid: Couldn't find a department matching \"{trimmedId}\"."));
+				return;
+			}
+
+			if (target.IsActive)
+			{
+				var alreadyActive = await _departmentsService.GetDepartmentByIdAsync(target.DepartmentId);
+				response.Message($"Resgrid: {alreadyActive?.Name ?? "That department"} is already your active department.");
+				return;
+			}
+
+			var identityUser = _usersService.GetUserById(userProfile.UserId);
+			var success = await _departmentsService.SetActiveDepartmentForUserAsync(userProfile.UserId, target.DepartmentId, identityUser);
+
+			var targetDept = await _departmentsService.GetDepartmentByIdAsync(target.DepartmentId);
+			if (success)
+			{
+				Framework.Logging.LogInfo($"[Twilio SMS] User {userProfile.UserId} switched active department to {target.DepartmentId} via text command.");
+				response.Message($"Resgrid: Your active department is now {targetDept?.Name ?? ("department " + target.DepartmentId)}. Text commands now apply to this department.");
+			}
+			else
+			{
+				response.Message("Resgrid: Unable to switch departments right now. Please try again later.");
+			}
+		}
+
+		private async Task<string> BuildSwitchOptionsMessageAsync(List<DepartmentMember> supported, string prefix)
+		{
+			var sb = new StringBuilder();
+			sb.Append(prefix + Environment.NewLine);
+
+			for (int i = 0; i < supported.Count; i++)
+			{
+				var dept = await _departmentsService.GetDepartmentByIdAsync(supported[i].DepartmentId);
+				var activeMarker = supported[i].IsActive ? " (active)" : "";
+				sb.Append($"{i + 1}: {dept?.Name ?? ("Department " + supported[i].DepartmentId)}{activeMarker}" + Environment.NewLine);
+			}
+
+			sb.Append("Reply SWITCH <number or name> to change your active department.");
+			return sb.ToString();
 		}
 
 		[HttpGet("VoiceCall")]

--- a/Web/Resgrid.Web/Areas/User/Views/Subscription/Index.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Subscription/Index.cshtml
@@ -237,276 +237,278 @@
 </div>
 
 <div class="row">
-    <div class="col-xs-12">
-        <div class="wrapper wrapper-content">
-            <div class="ibox float-e-margins">
-                <div class="ibox-content">
-                    <div class="row">
-                        <div class="col-md-8">
-                            <h3>
-                                @Model.Plan.Name
+<div class="col-xs-12">
+    <div class="wrapper wrapper-content">
+        <div class="ibox float-e-margins">
+            <div class="ibox-content">
+                <div class="row">
+                    <div class="col-md-8">
+                        <h3>
+                            @Model.Plan.Name
 
-                                @if (Model.Payment.Cancelled)
-                                {
-                                    <span class="label label-danger">@localizer["Canceled"]</span>
-                                }
-                                else
-                                {
-                                    <span class="label label-success">@localizer["Active"]</span>
-                                }
-                            </h3>
                             @if (Model.Payment.Cancelled)
                             {
-                                <span>@localizer["PlanExpires"]: @Model.Expires</span>
+                                <span class="label label-danger">@localizer["Canceled"]</span>
                             }
                             else
                             {
-                                <span>@localizer["PlanRenews"]: @Model.Expires</span>
+                                <span class="label label-success">@localizer["Active"]</span>
                             }
+                        </h3>
+                        @if (Model.Payment.Cancelled)
+                        {
+                            <span>@localizer["PlanExpires"]: @Model.Expires</span>
+                        }
+                        else
+                        {
+                            <span>@localizer["PlanRenews"]: @Model.Expires</span>
+                        }
+                    </div>
+                </div>
+                <div class="row" style="padding-bottom: 10px;">
+                    <div class="col-md-4">
+                        <h3 style="margin-bottom: 0;">
+                            @if (Model.Plan.Frequency == (int)PlanFrequency.Yearly)
+                            {
+                                <span>
+                                    @currencySymbol@Model.Plan.Cost.ToString("N2")<small>/@localizer["Year"]</small>
+                                </span>
+                            }
+                            else
+                            {
+                                <span>
+                                    @currencySymbol@Model.Plan.Cost.ToString("N2")<small>/@localizer["month"]</small>
+                                </span>
+                            }
+                        </h3>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-xs-12">
+                        <h3>
+                            <span class="">@Model.PersonnelCount</span>/@Model.PersonnelLimit
+                            <small>@localizer["Entities"]</small>
+                        </h3>
+                        <div class="progress">
+                            <div class="progress-bar @ViewBag.PersonnelBarStyle" style="width: @Model.PersonnelBarPrecent%"></div>
                         </div>
                     </div>
-                    <div class="row" style="padding-bottom: 10px;">
-                        <div class="col-md-4">
-                            <h3 style="margin-bottom: 0;">
-                                @if (Model.Plan.Frequency == (int)PlanFrequency.Yearly)
-                                {
-                                    <span>
-                                        @currencySymbol@Model.Plan.Cost.ToString("N2")<small>/@localizer["Year"]</small>
-                                    </span>
-                                }
-                                else
-                                {
-                                    <span>
-                                        @currencySymbol@Model.Plan.Cost.ToString("N2")<small>/@localizer["month"]</small>
-                                    </span>
-                                }
-                            </h3>
-                        </div>
-                    </div>
+                </div>
+
+                @if (ViewBag.SubscriptionErrorMessage != null)
+                {
                     <div class="row">
                         <div class="col-xs-12">
-                            <h3>
-                                <span class="">@Model.PersonnelCount</span>/@Model.PersonnelLimit
-                                <small>@localizer["Entities"]</small>
-                            </h3>
-                            <div class="progress">
-                                <div class="progress-bar @ViewBag.PersonnelBarStyle" style="width: @Model.PersonnelBarPrecent%"></div>
+                            <div class="alert alert-danger alert-block">
+                                <h4 class="alert alert-heading">@localizer["Warning"]</h4>
+                                @ViewBag.SubscriptionErrorMessage
                             </div>
                         </div>
                     </div>
+                }
+                <hr>
 
-                    @if (ViewBag.SubscriptionErrorMessage != null)
-                    {
-                        <div class="row">
-                            <div class="col-xs-12">
-                                <div class="alert alert-danger alert-block">
-                                    <h4 class="alert alert-heading">@localizer["Warning"]</h4>
-                                    @ViewBag.SubscriptionErrorMessage
+
+                <div class="row">
+                    <div class='col-sm-12'>
+                        <div class="panel blank-panel">
+                            <div class="panel-heading">
+                                <div class="panel-options">
+                                    <ul class="nav nav-tabs">
+                                        <li class="@Model.IsEntitiesTabActive()"><a href="#tab-1" data-toggle="tab" aria-expanded="false">Entities</a></li>
+
+                                        @if (Model.Plan != null && Model.Plan.PlanId < 36 && Model.Plan.PlanId != 1)
+                                        {
+                                            <li class="@Model.IsLegacyTabActive()"><a href="#tab-2" data-toggle="tab" aria-expanded="true">Legacy Plan</a></li>
+                                        }
+                                    </ul>
                                 </div>
                             </div>
-                        </div>
-                    }
-                    <hr>
+                            <div class="panel-body">
+                                <div class="tab-content">
+                                    <div class="tab-pane @Model.IsEntitiesTabActive()" id="tab-1">
 
+                                        @if (Model.Plan == null || Model.Plan.PlanId == 1)
+                                        {
+                                            <p>Select the number of Entities (Users + Units) you require using the slider or text box below.
+                                                @if (!isEU) { <text>Your first 10 entities are included at no charge — each</text> } else { <text>Each</text> }
+                                                additional pack of 10 entities is billed at the rate shown. Select "Buy Yearly" or "Buy Monthly" to proceed to checkout.</p>
 
-                    <div class="row">
-                        <div class='col-sm-12'>
-                            <div class="panel blank-panel">
-                                <div class="panel-heading">
-                                    <div class="panel-options">
-                                        <ul class="nav nav-tabs">
-                                            <li class="@Model.IsEntitiesTabActive()"><a href="#tab-1" data-toggle="tab" aria-expanded="false">Entities</a></li>
-
-                                            @if (Model.Plan != null && Model.Plan.PlanId < 36 && Model.Plan.PlanId != 1)
+                                            @if (isEU)
                                             {
-                                                <li class="@Model.IsLegacyTabActive()"><a href="#tab-2" data-toggle="tab" aria-expanded="true">Legacy Plan</a></li>
-                                            }
-                                        </ul>
-                                    </div>
-                                </div>
-                                <div class="panel-body">
-                                    <div class="tab-content">
-                                        <div class="tab-pane @Model.IsEntitiesTabActive()" id="tab-1">
-
-                                            @if (Model.Plan == null || Model.Plan.PlanId == 1)
-                                            {
-                                                <p>Select the number of Entities (Users + Units) you require using the slider or text box below.
-                                                    @if (!isEU) { <text>Your first 10 entities are included at no charge — each</text> } else { <text>Each</text> }
-                                                    additional pack of 10 entities is billed at the rate shown. Select "Buy Yearly" or "Buy Monthly" to proceed to checkout.</p>
-
-                                                @if (isEU)
-                                                {
-                                                    <div class="alert alert-info" style="font-size:13px;">
-                                                        <strong>European Region</strong> — Pricing includes GDPR-compliant data hosting. All prices shown in EUR (@currencySymbol) with a regional adjustment. No free tier is available.
-                                                    </div>
-                                                }
-
-                                                <div class="price-box">
-
-                                                    <form class="form-horizontal form-pricing" role="form">
-
-                                                        <div class="price-slider">
-                                                            <h4 class="great">Entities</h4>
-                                                            <span>Users or Units sold in packs of 10</span>
-                                                            <div class="col-sm-12">
-                                                                <div id="slider">
-                                                                    <div id="custom-handle" class="ui-slider-handle">
-                                                                        <i class="fa fa-chevron-left" aria-hidden="true"></i>
-                                                                        <span id="handle-text"></span>
-                                                                        <i class="fa fa-chevron-right" aria-hidden="true"></i>
-                                                                    </div>
-                                                                </div>
-                                                            </div>
-                                                        </div>
-
-                                                        <div class="price-form">
-                                                            <div class="form-group">
-                                                                <div class="col-sm-12 text-center">
-                                                                    <input id="amount-input" type="number" pattern="[0-9]" min="10" max="2000" step="10" value="10" /> <span>Entities</span>
-                                                                </div>
-                                                            </div>
-                                                            <div class="form-group">
-                                                                <label for="amount" class="col-sm-6 control-label">Monthly (@currencySymbol): </label>
-                                                                <span class="help-text">Monthly billing amount</span>
-                                                                <div class="col-sm-6">
-                                                                    <input type="hidden" id="amount" class="form-control">
-                                                                    <p class="price lead" id="monthly-label">0.00</p>
-                                                                </div>
-                                                            </div>
-                                                            <div class="form-group">
-                                                                <label for="duration" class="col-sm-6 control-label">Yearly (@currencySymbol): </label>
-                                                                <span class="help-text">Yearly (annual) billing amount</span>
-                                                                <div class="col-sm-6">
-                                                                    <input type="hidden" id="duration" class="form-control">
-                                                                    <p class="price lead" id="yearly-label">0.00</p>
-                                                                </div>
-                                                            </div>
-                                                            <hr class="style">
-                                                            <div class="form-group total">
-                                                                <div class="col-sm-6 text-center">
-                                                                    @if (Model.IsPaddleDepartment) {
-                                                                        <a id="buyYearlyButton" title="@localizer["BuyYearly"]" class="btn btn-primary" href="#" onclick="paddleCheckout(36);">@localizer["BuyYearly"]</a>
-                                                                    } else {
-                                                                        <a id="buyYearlyButton" title="@localizer["BuyYearly"]" class="btn btn-primary" href="#" onclick="stripeCheckout(36);">@localizer["BuyYearly"]</a>
-                                                                    }
-                                                                </div>
-                                                                <div class="col-sm-6 text-center">
-                                                                    @if (Model.IsPaddleDepartment) {
-                                                                        <a id="buyMonthlyButton" title="@localizer["BuyMonthly"]" class="btn btn-primary" href="#" onclick="paddleCheckout(37);">@localizer["BuyMonthly"]</a>
-                                                                    } else {
-                                                                        <a id="buyMonthlyButton" title="@localizer["BuyMonthly"]" class="btn btn-primary" href="#" onclick="stripeCheckout(37);">@localizer["BuyMonthly"]</a>
-                                                                    }
-                                                                </div>
-                                                            </div>
-
-                                                        </div>
-
-                                                    </form>
-
+                                                <div class="alert alert-info" style="font-size:13px;">
+                                                    <strong>European Region</strong> — Pricing includes GDPR-compliant data hosting. All prices shown in EUR (@currencySymbol) with a regional adjustment. No free tier is available.
                                                 </div>
                                             }
-                                            else if (Model.Plan.PlanId >= 36)
-                                            {
-                                                <div class="alert alert-info alert-block">
-                                                    <h4 class="alert alert-heading">Active Subscription</h4>
-                                                    You currently have an activate subscription, thank you! To update the amount of entities you need, update your billing information, or cancel your subscription please use the "Manage Your Subscription" button. If you are a Invoice customer, please contact us to update your subscription.
+
+                                            <div class="price-box">
+
+                                                <form class="form-horizontal form-pricing" role="form">
+
+                                                    <div class="price-slider">
+                                                        <h4 class="great">Entities</h4>
+                                                        <span>Users or Units sold in packs of 10</span>
+                                                        <div class="col-sm-12">
+                                                            <div id="slider">
+                                                                <div id="custom-handle" class="ui-slider-handle">
+                                                                    <i class="fa fa-chevron-left" aria-hidden="true"></i>
+                                                                    <span id="handle-text"></span>
+                                                                    <i class="fa fa-chevron-right" aria-hidden="true"></i>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+
+                                                    <div class="price-form">
+                                                        <div class="form-group">
+                                                            <div class="col-sm-12 text-center">
+                                                                <input id="amount-input" type="number" pattern="[0-9]" min="10" max="2000" step="10" value="10" /> <span>Entities</span>
+                                                            </div>
+                                                        </div>
+                                                        <div class="form-group">
+                                                            <label for="amount" class="col-sm-6 control-label">Monthly (@currencySymbol): </label>
+                                                            <span class="help-text">Monthly billing amount</span>
+                                                            <div class="col-sm-6">
+                                                                <input type="hidden" id="amount" class="form-control">
+                                                                <p class="price lead" id="monthly-label">0.00</p>
+                                                            </div>
+                                                        </div>
+                                                        <div class="form-group">
+                                                            <label for="duration" class="col-sm-6 control-label">Yearly (@currencySymbol): </label>
+                                                            <span class="help-text">Yearly (annual) billing amount</span>
+                                                            <div class="col-sm-6">
+                                                                <input type="hidden" id="duration" class="form-control">
+                                                                <p class="price lead" id="yearly-label">0.00</p>
+                                                            </div>
+                                                        </div>
+                                                        <hr class="style">
+                                                        <div class="form-group total">
+                                                            <div class="col-sm-6 text-center">
+                                                                @if (Model.IsPaddleDepartment) {
+                                                                    <a id="buyYearlyButton" title="@localizer["BuyYearly"]" class="btn btn-primary" href="#" onclick="paddleCheckout(36);">@localizer["BuyYearly"]</a>
+                                                                } else {
+                                                                    <a id="buyYearlyButton" title="@localizer["BuyYearly"]" class="btn btn-primary" href="#" onclick="stripeCheckout(36);">@localizer["BuyYearly"]</a>
+                                                                }
+                                                            </div>
+                                                            <div class="col-sm-6 text-center">
+                                                                @if (Model.IsPaddleDepartment) {
+                                                                    <a id="buyMonthlyButton" title="@localizer["BuyMonthly"]" class="btn btn-primary" href="#" onclick="paddleCheckout(37);">@localizer["BuyMonthly"]</a>
+                                                                } else {
+                                                                    <a id="buyMonthlyButton" title="@localizer["BuyMonthly"]" class="btn btn-primary" href="#" onclick="stripeCheckout(37);">@localizer["BuyMonthly"]</a>
+                                                                }
+                                                            </div>
+                                                        </div>
+
+                                                    </div>
+
+                                                </form>
+
+                                            </div>
+                                        }
+                                        else if (Model.Plan.PlanId >= 36)
+                                        {
+                                            <div class="alert alert-info alert-block">
+                                                <h4 class="alert alert-heading">Active Subscription</h4>
+                                                You currently have an activate subscription, thank you! To update the amount of entities you need, update your billing information, or cancel your subscription please use the "Manage Your Subscription" button. If you are a Invoice customer, please contact us to update your subscription.
+                                            </div>
+
+                                            <div class="text-center">
+                                                @if (Model.IsPaddleDepartment)
+                                                {
+                                                    <a title="Cancel" class="btn btn-danger" href="@Url.Action("Cancel", "Subscription", new { Area = "User" })">@localizer["CancelSub"]</a>
+                                                }
+                                                else if (!string.IsNullOrWhiteSpace(Model.StripeCustomer))
+                                                {
+                                                    <a title="Manage Your Sub" class="btn btn-info" href="@Model.StripeCustomerPortalUrl">@localizer["ManageYourSubscription"]</a>
+                                                }
+                                            </div>
+                                        }
+                                        else if (Model.Plan.PlanId != 1)
+                                        {
+                                            <div class="alert alert-info alert-block">
+                                                <h4 class="alert alert-heading">Active Legacy Subscription</h4>
+                                                You currently have an active legacy subscription. To change over to the Entity based subscription, please cancel your current subscription and then sign up for a new one. If you are a Invoice customer, please contact us to update your subscription. Click on the "Legacy Plan" tab to see more information about your current plan.
+                                            </div>
+                                        }
+                                    </div>
+                                    <div class="tab-pane @Model.IsLegacyTabActive()" id="tab-2">
+                                        <div class="row">
+                                            <div class="col-xs-12">
+                                                <div class="alert alert-danger alert-block">
+                                                    <h4 class="alert alert-heading">@localizer["Warning"]</h4>
+                                                    You are on a Legacy Plan. We do not offer these plans anymore. You can stay on this plan as long as you wish, but you will not be able to upgrade or downgrade your plan. If you wish to change your plan, you will need to cancel your current plan and then sign up for a new plan. We do not raise prices on departments with active billing relationships, so you can stay on this plan as long as you wish, you will need to use the "Change Billing Info" button below if you are using a Credit Card to pay. If you bill via Invoice your cost will stay the same if you renew.
                                                 </div>
 
                                                 <div class="text-center">
-                                                    @if (Model.IsPaddleDepartment)
+                                                    @if (!string.IsNullOrWhiteSpace(Model.StripeCustomer))
                                                     {
+                                                        <a title="Update or Change Billing Info" class="btn btn-success" href="#" onclick="stripeUpdate();">@localizer["ChangeBillingInfo"]</a>
                                                         <a title="Cancel" class="btn btn-danger" href="@Url.Action("Cancel", "Subscription", new { Area = "User" })">@localizer["CancelSub"]</a>
                                                     }
-                                                    else if (!string.IsNullOrWhiteSpace(Model.StripeCustomer))
-                                                    {
-                                                        <a title="Manage Your Sub" class="btn btn-info" href="@Model.StripeCustomerPortalUrl">@localizer["ManageYourSubscription"]</a>
-                                                    }
-                                                </div>
-                                            }
-                                            else if (Model.Plan.PlanId != 1)
-                                            {
-                                                <div class="alert alert-info alert-block">
-                                                    <h4 class="alert alert-heading">Active Legacy Subscription</h4>
-                                                    You currently have an active legacy subscription. To change over to the Entity based subscription, please cancel your current subscription and then sign up for a new one. If you are a Invoice customer, please contact us to update your subscription. Click on the "Legacy Plan" tab to see more information about your current plan.
-                                                </div>
-                                            }
-                                        </div>
-                                        <div class="tab-pane @Model.IsLegacyTabActive()" id="tab-2">
-                                            <div class="row">
-                                                <div class="col-xs-12">
-                                                    <div class="alert alert-danger alert-block">
-                                                        <h4 class="alert alert-heading">@localizer["Warning"]</h4>
-                                                        You are on a Legacy Plan. We do not offer these plans anymore. You can stay on this plan as long as you wish, but you will not be able to upgrade or downgrade your plan. If you wish to change your plan, you will need to cancel your current plan and then sign up for a new plan. We do not raise prices on departments with active billing relationships, so you can stay on this plan as long as you wish, you will need to use the "Change Billing Info" button below if you are using a Credit Card to pay. If you bill via Invoice your cost will stay the same if you renew.
-                                                    </div>
-
-                                                    <div class="text-center">
-                                                        @if (!string.IsNullOrWhiteSpace(Model.StripeCustomer))
-                                                        {
-                                                            <a title="Update or Change Billing Info" class="btn btn-success" href="#" onclick="stripeUpdate();">@localizer["ChangeBillingInfo"]</a>
-                                                            <a title="Cancel" class="btn btn-danger" href="@Url.Action("Cancel", "Subscription", new { Area = "User" })">@localizer["CancelSub"]</a>
-                                                        }
-                                                    </div>
                                                 </div>
                                             </div>
                                         </div>
+                                    </div>
 
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                @if (Model.HasActiveSubscription)
+                {
+                    <div class="row">
+                        <div class='col-sm-12'>
+                            <div class="pricing-tables">
+                                <div class='row'>
+                                    <div class="col-sm-8 col-md-8 col-sm-offset-2">
+                                        <div class="plan" style="margin: 0; padding-bottom: 0;">
+                                            <div class="head">
+                                                <h2>Push-To-Talk Addon</h2>
+                                            </div>
+                                            <div class="row" style="margin-left: 0;">
+                                                <div class="col-sm-4 col-md-4">
+                                                    <div style="padding-top: 10px;">
+                                                        <ul class="item-list" style="padding: 0;">
+                                                            <li>Two-Way IP Voice Communications</li>
+                                                            <li>Up to 50 Channels</li>
+                                                            <li>Radios with worldwide reach</li>
+                                                            <li>Real-Time Voice, Push-To-Talk</li>
+                                                            <li>Android, iOS and Web</li>
+                                                        </ul>
+                                                    </div>
+                                                </div>
+                                                <div class="col-sm-3 col-md-3" style="text-align: center;">
+                                                    <span class="price" style="border-top: 0; margin-bottom: 5px; padding-top: 25px">
+                                                        <h3 style="font-size: 36px;"><span class="symbol" style="font-size: 36px; vertical-align: top;">$</span>35<small>/mo</small></h3><span style="font-size: 12px;">per 10 user pack</span>
+                                                    </span>
+                                                </div>
+                                                <div class="col-sm-5 col-md-5">
+                                                    <p style="color: #676a6c; padding-top: 10px;">The Push-To-Talk Addon is only available on paid plans. You can buy as many 10 user packs as you wish, and they are billed monthly separately from your Resgrid bill. Allowing you to size up and down as you need. You can have up to 50 active people per channel. Push-To-Talk requires devices with an active Internet (data) connection and uses VOIP technology.</p>
+                                                    @if (Model.IsPaddleDepartment)
+                                                    {
+                                                        <a asp-controller="Subscription" asp-action="ManagePaddlePTTAddon" asp-route-area="User" class="btn btn-sm btn-primary">Manage PTT</a>
+                                                    }
+                                                    else
+                                                    {
+                                                        <a asp-controller="Subscription" asp-action="ManagePTTAddon" asp-route-area="User" class="btn btn-sm btn-primary">Manage PTT</a>
+                                                    }
+                                                </div>
+                                            </div>
+                                        </div>
                                     </div>
                                 </div>
                             </div>
                         </div>
                     </div>
+                }
 
-                    @if (Model.HasActiveSubscription)
-                    {
-                        <div class="row">
-                            <div class='col-sm-12'>
-                                <div class="pricing-tables">
-                                    <div class='row'>
-                                        <div class="col-sm-8 col-md-8 col-sm-offset-2">
-                                            <div class="plan" style="margin: 0; padding-bottom: 0;">
-                                                <div class="head">
-                                                    <h2>Push-To-Talk Addon</h2>
-                                                </div>
-                                                <div class="row" style="margin-left: 0;">
-                                                    <div class="col-sm-4 col-md-4">
-                                                        <div style="padding-top: 10px;">
-                                                            <ul class="item-list" style="padding: 0;">
-                                                                <li>Two-Way IP Voice Communications</li>
-                                                                <li>Up to 50 Channels</li>
-                                                                <li>Radios with worldwide reach</li>
-                                                                <li>Real-Time Voice, Push-To-Talk</li>
-                                                                <li>Android, iOS and Web</li>
-                                                            </ul>
-                                                        </div>
-                                                    </div>
-                                                    <div class="col-sm-3 col-md-3" style="text-align: center;">
-                                                        <span class="price" style="border-top: 0; margin-bottom: 5px; padding-top: 25px">
-                                                            <h3 style="font-size: 36px;"><span class="symbol" style="font-size: 36px; vertical-align: top;">$</span>35<small>/mo</small></h3><span style="font-size: 12px;">per 10 user pack</span>
-                                                        </span>
-                                                    </div>
-                                                    <div class="col-sm-5 col-md-5">
-                                                        <p style="color: #676a6c; padding-top: 10px;">The Push-To-Talk Addon is only available on paid plans. You can buy as many 10 user packs as you wish, and they are billed monthly separately from your Resgrid bill. Allowing you to size up and down as you need. You can have up to 50 active people per channel. Push-To-Talk requires devices with an active Internet (data) connection and uses VOIP technology.</p>
-                                                        @if (Model.IsPaddleDepartment)
-                                                        {
-                                                            <a asp-controller="Subscription" asp-action="ManagePaddlePTTAddon" asp-route-area="User" class="btn btn-sm btn-primary">Manage PTT</a>
-                                                        }
-                                                        else
-                                                        {
-                                                            <a asp-controller="Subscription" asp-action="ManagePTTAddon" asp-route-area="User" class="btn btn-sm btn-primary">Manage PTT</a>
-                                                        }
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    }
-
-                </div>
             </div>
         </div>
+    </div>
+</div>
+</div>
 
         <div class="alert alert-success">
             <strong>
@@ -522,7 +524,7 @@
 
             <script>
                 @if (!Model.IsPaddleDepartment) {
-                    <text>var stripe = Stripe('@Model.StripeKey');</text>
+                    @:var stripe = Stripe('@Model.StripeKey');
                 }
                 var paddleReady = @(Model.CanInitializePaddleCheckout ? "true" : "false");
                 var paddleEnvironment = @paddleEnvironmentJson;


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Pull Request Description

This PR introduces several fixes and improvements to the chatbot/SMS text command system, primarily around department switching and unverified mobile number handling.

### Key Changes

**1. Department Switching via SMS ("SWITCH" command)**
- Added a new `SwitchDepartment` text command type that allows users to change their active department by texting `SWITCH <number or name>`
- Implemented in both TwilioController and SignalWireController with parity: users can switch by list number, department ID, name, code, or partial name match
- The text command parser now checks for SWITCH before custom staffing commands to prevent conflicts

**2. Restricted Mode for Unsupported Departments**
- Previously, if a user's active department was on a plan that doesn't support chatbot/SMS features, they were hard-blocked with an error
- Now, if the user belongs to other departments that DO support these features, they enter a "restricted mode" where only department list, switch, and active department queries are honored — guiding them to switch to a supported department
- Only when no supported alternatives exist does the user receive the upgrade prompt

**3. Unverified Mobile Number Handling**
- Changed the security model for unverified mobile numbers: they are now used for **routing** (department resolution, plan gating) but never for **actions**
- Unverified senders receive a clear prompt to verify their number instead of being silently ignored or receiving "unknown command" responses
- STOP/opt-out always works regardless of verification status

**4. No More Silent Department Auto-Picking**
- `GetActiveSmsDepartmentForUserAsync` no longer silently auto-switches users to an SMS-capable department; it respects the user's actual active department and lets downstream logic handle unsupported plans

**5. Centralized SMS-Supported Department List**
- Created a shared `GetSmsSupportedMembershipsForUserAsync` method to ensure consistent ordering and filtering across all surfaces (chatbot, Twilio, SignalWire) so numeric picks remain stable across stateless SMS requests

**6. Subscription View Fix**
- Fixed indentation issues in the Subscription page Razor view and corrected a Stripe JavaScript initialization syntax (`<text>` to `@:`)
<!-- kody-pr-summary:end -->