### PR TITLE
RG-T127 Fixing TrackerGateway docker build

### DIFF
--- a/Workers/Resgrid.TrackerGateway/Dockerfile
+++ b/Workers/Resgrid.TrackerGateway/Dockerfile
@@ -50,7 +50,8 @@ ADD --checksum=sha256:2241be671073520e028b2f12df1e9ef0419014cffb5670b7a80b208080
 # LocalXpose CLI (https://localxpose.io) used to expose the TCP/UDP ingest ports; checksum tracks the current linux/amd64 artifact.
 ADD --checksum=sha256:b13e6914288e6c7d66744578e68b4eeacab5d629cd8fe3fb13863665d0a1ac95 https://api.localxpose.io/api/downloads/loclx-linux-amd64.zip /tmp/loclx.zip
 RUN DEBIAN_FRONTEND=noninteractive apt-get update \
-    && apt-get install -y --no-install-recommends unzip \
+    && apt-get install -y --reinstall --no-install-recommends dash unzip \
+    && test -f /usr/bin/dash \
     && unzip /tmp/loclx.zip -d /app/publish \
     && rm -f /tmp/loclx.zip \
     && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## PR Description

**Fixes Docker build for TrackerGateway by ensuring `dash` shell is installed**

This PR fixes a build issue (RG-T127) in the TrackerGateway Docker image where the LocalXpose CLI integration step was failing. The change:

- Adds `dash` (the lightweight POSIX shell, default `/bin/sh` on Debian/Ubuntu) to the package installation step with the `--reinstall` flag to ensure it's present even if already in the base image
- Adds a verification check (`test -f /usr/bin/dash`) to confirm the shell binary exists before proceeding to unzip the LocalXpose CLI

The fix ensures the required shell interpreter is available so the loclx binary can execute properly during the Docker build process.
<!-- kody-pr-summary:end -->