### PR TITLE
Develop

### DIFF
--- a/Core/Resgrid.Model/CommandBoards/CommandBoardTemplate.cs
+++ b/Core/Resgrid.Model/CommandBoards/CommandBoardTemplate.cs
@@ -88,6 +88,8 @@ namespace Resgrid.Model.CommandBoards
 					MaxUnitPersonnel = lane.MaxUnitPersonnel,
 					MinTimeInRole = lane.MinTimeInRole,
 					MaxTimeInRole = lane.MaxTimeInRole,
+					WorkTimeAmberMinutes = lane.WorkTimeAmberMinutes,
+					WorkTimeRedMinutes = lane.WorkTimeRedMinutes,
 					RequiredUnitTypes = matchedUnitTypes,
 					RequiredRoles = matchedPersonnelRoles,
 					ForceRequirements = lane.ForceRequirements && (matchedUnitTypes.Count > 0 || matchedPersonnelRoles.Count > 0)

--- a/Core/Resgrid.Model/CommandBoards/CommandBoardTemplateCatalog.cs
+++ b/Core/Resgrid.Model/CommandBoards/CommandBoardTemplateCatalog.cs
@@ -41,7 +41,8 @@ namespace Resgrid.Model.CommandBoards
 
 		private static CommandBoardTemplateLane L(string name, CommandNodeType laneType, string description,
 			string[] unitTypes = null, string[] personnelRoles = null, bool forceRequirements = false,
-			int minUnits = 0, int maxUnits = 0, int minUnitPersonnel = 0, int maxUnitPersonnel = 0, int minTimeInRole = 0, int maxTimeInRole = 0)
+			int minUnits = 0, int maxUnits = 0, int minUnitPersonnel = 0, int maxUnitPersonnel = 0, int minTimeInRole = 0, int maxTimeInRole = 0,
+			int workTimeAmberMinutes = 20, int workTimeRedMinutes = 40)
 		{
 			return new CommandBoardTemplateLane
 			{
@@ -56,7 +57,9 @@ namespace Resgrid.Model.CommandBoards
 				MinUnitPersonnel = minUnitPersonnel,
 				MaxUnitPersonnel = maxUnitPersonnel,
 				MinTimeInRole = minTimeInRole,
-				MaxTimeInRole = maxTimeInRole
+				MaxTimeInRole = maxTimeInRole,
+				WorkTimeAmberMinutes = workTimeAmberMinutes,
+				WorkTimeRedMinutes = workTimeRedMinutes
 			};
 		}
 

--- a/Core/Resgrid.Model/CommandBoards/CommandBoardTemplateLane.cs
+++ b/Core/Resgrid.Model/CommandBoards/CommandBoardTemplateLane.cs
@@ -47,5 +47,11 @@ namespace Resgrid.Model.CommandBoards
 
 		/// <summary>Minutes before an assigned resource shows rotation-due (0 = none).</summary>
 		public int MaxTimeInRole { get; set; }
+
+		/// <summary>Minutes before the lane work-time indicator turns amber (0 = disabled; default 20).</summary>
+		public int WorkTimeAmberMinutes { get; set; } = 20;
+
+		/// <summary>Minutes before the lane work-time indicator turns red (0 = disabled; default 40).</summary>
+		public int WorkTimeRedMinutes { get; set; } = 40;
 	}
 }

--- a/Core/Resgrid.Model/CommandDefinitionRole.cs
+++ b/Core/Resgrid.Model/CommandDefinitionRole.cs
@@ -35,6 +35,12 @@ namespace Resgrid.Model
 
 		public int MaxTimeInRole { get; set; }
 
+		/// <summary>Minutes on the lane before the work-time indicator turns amber (0 = disabled; seeded onto runtime nodes).</summary>
+		public int WorkTimeAmberMinutes { get; set; }
+
+		/// <summary>Minutes on the lane before the work-time indicator turns red (0 = disabled; seeded onto runtime nodes).</summary>
+		public int WorkTimeRedMinutes { get; set; }
+
 		public bool ForceRequirements { get; set; }
 
 		/// <summary>

--- a/Core/Resgrid.Model/IncidentCommand/CommandStructureNode.cs
+++ b/Core/Resgrid.Model/IncidentCommand/CommandStructureNode.cs
@@ -57,6 +57,12 @@ namespace Resgrid.Model
 		/// <summary>Maximum minutes a resource should work this lane before rotation (0 = none; surfaced as rotation-due).</summary>
 		public int MaxTimeInRole { get; set; }
 
+		/// <summary>Minutes on this lane before the work-time indicator turns amber (0 = disabled; client defaults to 20).</summary>
+		public int WorkTimeAmberMinutes { get; set; }
+
+		/// <summary>Minutes on this lane before the work-time indicator turns red (0 = disabled; client defaults to 40).</summary>
+		public int WorkTimeRedMinutes { get; set; }
+
 		/// <summary>When true, unmet lane requirements block assignment instead of warning. Seeded from the template role.</summary>
 		public bool ForceRequirements { get; set; }
 

--- a/Core/Resgrid.Services/IncidentCommandService.cs
+++ b/Core/Resgrid.Services/IncidentCommandService.cs
@@ -215,6 +215,8 @@ namespace Resgrid.Services
 						MaxUnits = role.MaxUnits,
 						MinTimeInRole = role.MinTimeInRole,
 						MaxTimeInRole = role.MaxTimeInRole,
+						WorkTimeAmberMinutes = role.WorkTimeAmberMinutes,
+						WorkTimeRedMinutes = role.WorkTimeRedMinutes,
 						ForceRequirements = role.ForceRequirements
 					};
 

--- a/Providers/Resgrid.Providers.Migrations/Migrations/M0103_AddLaneWorkTimeThresholds.cs
+++ b/Providers/Resgrid.Providers.Migrations/Migrations/M0103_AddLaneWorkTimeThresholds.cs
@@ -1,0 +1,61 @@
+using FluentMigrator;
+
+namespace Resgrid.Providers.Migrations.Migrations
+{
+	/// <summary>
+	/// Per-lane work-time (crew fatigue) indicator thresholds: minutes before the lane work light
+	/// turns amber/red (0 = disabled; clients fall back to their own defaults). Denormalized onto
+	/// runtime nodes from the template role at seeding, like the other lane limits.
+	/// </summary>
+	[Migration(103)]
+	public class M0103_AddLaneWorkTimeThresholds : Migration
+	{
+		public override void Up()
+		{
+			if (Schema.Table("CommandStructureNodes").Exists())
+			{
+				foreach (var column in new[] { "WorkTimeAmberMinutes", "WorkTimeRedMinutes" })
+				{
+					if (!Schema.Table("CommandStructureNodes").Column(column).Exists())
+					{
+						Alter.Table("CommandStructureNodes")
+							.AddColumn(column).AsInt32().NotNullable().WithDefaultValue(0);
+					}
+				}
+			}
+
+			if (Schema.Table("CommandDefinitionRoles").Exists())
+			{
+				foreach (var column in new[] { "WorkTimeAmberMinutes", "WorkTimeRedMinutes" })
+				{
+					if (!Schema.Table("CommandDefinitionRoles").Column(column).Exists())
+					{
+						Alter.Table("CommandDefinitionRoles")
+							.AddColumn(column).AsInt32().NotNullable().WithDefaultValue(0);
+					}
+				}
+			}
+		}
+
+		public override void Down()
+		{
+			if (Schema.Table("CommandStructureNodes").Exists())
+			{
+				foreach (var column in new[] { "WorkTimeAmberMinutes", "WorkTimeRedMinutes" })
+				{
+					if (Schema.Table("CommandStructureNodes").Column(column).Exists())
+						Delete.Column(column).FromTable("CommandStructureNodes");
+				}
+			}
+
+			if (Schema.Table("CommandDefinitionRoles").Exists())
+			{
+				foreach (var column in new[] { "WorkTimeAmberMinutes", "WorkTimeRedMinutes" })
+				{
+					if (Schema.Table("CommandDefinitionRoles").Column(column).Exists())
+						Delete.Column(column).FromTable("CommandDefinitionRoles");
+				}
+			}
+		}
+	}
+}

--- a/Providers/Resgrid.Providers.MigrationsPg/Migrations/M0103_AddLaneWorkTimeThresholdsPg.cs
+++ b/Providers/Resgrid.Providers.MigrationsPg/Migrations/M0103_AddLaneWorkTimeThresholdsPg.cs
@@ -1,0 +1,61 @@
+using FluentMigrator;
+
+namespace Resgrid.Providers.MigrationsPg.Migrations
+{
+	/// <summary>
+	/// Per-lane work-time (crew fatigue) indicator thresholds: minutes before the lane work light
+	/// turns amber/red (0 = disabled; clients fall back to their own defaults). Denormalized onto
+	/// runtime nodes from the template role at seeding, like the other lane limits.
+	/// </summary>
+	[Migration(103)]
+	public class M0103_AddLaneWorkTimeThresholdsPg : Migration
+	{
+		public override void Up()
+		{
+			if (Schema.Table("commandstructurenodes").Exists())
+			{
+				foreach (var column in new[] { "worktimeamberminutes", "worktimeredminutes" })
+				{
+					if (!Schema.Table("commandstructurenodes").Column(column).Exists())
+					{
+						Alter.Table("commandstructurenodes")
+							.AddColumn(column).AsInt32().NotNullable().WithDefaultValue(0);
+					}
+				}
+			}
+
+			if (Schema.Table("commanddefinitionroles").Exists())
+			{
+				foreach (var column in new[] { "worktimeamberminutes", "worktimeredminutes" })
+				{
+					if (!Schema.Table("commanddefinitionroles").Column(column).Exists())
+					{
+						Alter.Table("commanddefinitionroles")
+							.AddColumn(column).AsInt32().NotNullable().WithDefaultValue(0);
+					}
+				}
+			}
+		}
+
+		public override void Down()
+		{
+			if (Schema.Table("commandstructurenodes").Exists())
+			{
+				foreach (var column in new[] { "worktimeamberminutes", "worktimeredminutes" })
+				{
+					if (Schema.Table("commandstructurenodes").Column(column).Exists())
+						Delete.Column(column).FromTable("commandstructurenodes");
+				}
+			}
+
+			if (Schema.Table("commanddefinitionroles").Exists())
+			{
+				foreach (var column in new[] { "worktimeamberminutes", "worktimeredminutes" })
+				{
+					if (Schema.Table("commanddefinitionroles").Column(column).Exists())
+						Delete.Column(column).FromTable("commanddefinitionroles");
+				}
+			}
+		}
+	}
+}

--- a/Web/Resgrid.Web.Services/Controllers/v4/CommandsController.cs
+++ b/Web/Resgrid.Web.Services/Controllers/v4/CommandsController.cs
@@ -173,6 +173,8 @@ namespace Resgrid.Web.Services.Controllers.v4
 						MaxUnits = lane.MaxUnits,
 						MinTimeInRole = lane.MinTimeInRole,
 						MaxTimeInRole = lane.MaxTimeInRole,
+						WorkTimeAmberMinutes = lane.WorkTimeAmberMinutes,
+						WorkTimeRedMinutes = lane.WorkTimeRedMinutes,
 						ForceRequirements = lane.ForceRequirements
 					};
 
@@ -253,6 +255,8 @@ namespace Resgrid.Web.Services.Controllers.v4
 						MaxUnits = lane.MaxUnits,
 						MinTimeInRole = lane.MinTimeInRole,
 						MaxTimeInRole = lane.MaxTimeInRole,
+						WorkTimeAmberMinutes = lane.WorkTimeAmberMinutes,
+						WorkTimeRedMinutes = lane.WorkTimeRedMinutes,
 						ForceRequirements = lane.ForceRequirements,
 						RequiredUnitTypes = lane.RequiredUnitTypes?.Select(x => x.UnitTypeId).ToList() ?? new List<int>(),
 						RequiredPersonnelRoles = lane.RequiredRoles?.Select(x => x.PersonnelRoleId).ToList() ?? new List<int>()

--- a/Web/Resgrid.Web.Services/Models/v4/Commands/CommandModels.cs
+++ b/Web/Resgrid.Web.Services/Models/v4/Commands/CommandModels.cs
@@ -46,6 +46,8 @@ namespace Resgrid.Web.Services.Models.v4.Commands
 		public int MaxUnits { get; set; }
 		public int MinTimeInRole { get; set; }
 		public int MaxTimeInRole { get; set; }
+		public int WorkTimeAmberMinutes { get; set; }
+		public int WorkTimeRedMinutes { get; set; }
 
 		/// <summary>Lane identification color (hex, e.g. "#e74c3c"); null = default styling.</summary>
 		public string Color { get; set; }
@@ -110,6 +112,8 @@ namespace Resgrid.Web.Services.Models.v4.Commands
 		public int MaxUnits { get; set; }
 		public int MinTimeInRole { get; set; }
 		public int MaxTimeInRole { get; set; }
+		public int WorkTimeAmberMinutes { get; set; }
+		public int WorkTimeRedMinutes { get; set; }
 
 		/// <summary>Lane identification color (hex, e.g. "#e74c3c"); null = default styling.</summary>
 		public string Color { get; set; }


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Pull Request Description

This PR adds configurable per-lane work-time (crew fatigue) indicator thresholds to command board lanes. Each lane can now specify when its work-time indicator turns **amber** (warning) and **red** (critical) based on minutes resources have been assigned to that lane.

### Changes

- **New data fields** (`WorkTimeAmberMinutes` and `WorkTimeRedMinutes`) added to:
  - `CommandBoardTemplateLane` (template definition, with defaults of 20 and 40 minutes)
  - `CommandDefinitionRole` (command definition role)
  - `CommandStructureNode` (runtime node)
  - v4 API models (`CommandRoleResultData` and `SaveCommandLaneInput`)

- **Data propagation**: Updated the template-to-definition creation, command seeding service, and the save/convert logic in `CommandsController` to flow these values through all layers.

- **Database migrations** (Migration 103) for both SQL Server and PostgreSQL, adding the two new integer columns to the `CommandStructureNodes` and `CommandDefinitionRoles` tables with a default value of 0 (disabled).

A value of `0` disables the indicator, allowing clients to fall back to their own defaults. These thresholds are denormalized onto runtime nodes from the template role at seeding, consistent with how the existing lane limits (e.g., min/max time in role) are handled.
<!-- kody-pr-summary:end -->