### PR TITLE
RG-T117 Fixing autofac dep issue

### DIFF
--- a/Providers/Resgrid.Providers.Chatbot/Services/ChatbotAdapterRegistry.cs
+++ b/Providers/Resgrid.Providers.Chatbot/Services/ChatbotAdapterRegistry.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Resgrid.Chatbot.Models;
@@ -11,17 +12,22 @@ namespace Resgrid.Providers.Chatbot.Services
 	/// </summary>
 	public class ChatbotAdapterRegistry : IChatbotAdapterRegistry
 	{
-		private readonly Dictionary<ChatbotPlatform, IChatbotPlatformAdapter> _adapters;
+		// Adapters are resolved lazily: WebChatAdapter's notifier pulls in the chat services, which
+		// reach AuthorizationService -> CallsService -> CommunicationService -> ChatbotOutboundService
+		// and back into this registry. Deferring adapter activation until first GetAdapter call keeps
+		// that loop out of the container's constructor chain (Autofac circular dependency exception).
+		private readonly Lazy<Dictionary<ChatbotPlatform, IChatbotPlatformAdapter>> _adapters;
 
-		public ChatbotAdapterRegistry(IEnumerable<IChatbotPlatformAdapter> adapters)
+		public ChatbotAdapterRegistry(Lazy<IEnumerable<IChatbotPlatformAdapter>> adapters)
 		{
-			_adapters = (adapters ?? Enumerable.Empty<IChatbotPlatformAdapter>())
-				.GroupBy(a => a.Platform)
-				.ToDictionary(g => g.Key, g => g.First());
+			_adapters = new Lazy<Dictionary<ChatbotPlatform, IChatbotPlatformAdapter>>(() =>
+				(adapters?.Value ?? Enumerable.Empty<IChatbotPlatformAdapter>())
+					.GroupBy(a => a.Platform)
+					.ToDictionary(g => g.Key, g => g.First()));
 		}
 
 		public IChatbotPlatformAdapter GetAdapter(ChatbotPlatform platform)
-			=> _adapters.TryGetValue(platform, out var adapter) ? adapter : null;
+			=> _adapters.Value.TryGetValue(platform, out var adapter) ? adapter : null;
 
 		/// <summary>
 		/// Whether the bot may send an un-prompted message on this platform. SMS is delivered by the

--- a/Tests/Resgrid.Tests/Chatbot/ChatbotOutboundTests.cs
+++ b/Tests/Resgrid.Tests/Chatbot/ChatbotOutboundTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -30,7 +31,7 @@ namespace Resgrid.Tests.Chatbot
 		[Test]
 		public void Registry_CanInitiateProactively_ReflectsPlatformConstraints()
 		{
-			var registry = new ChatbotAdapterRegistry(new List<IChatbotPlatformAdapter>());
+			var registry = new ChatbotAdapterRegistry(new Lazy<IEnumerable<IChatbotPlatformAdapter>>(() => new List<IChatbotPlatformAdapter>()));
 
 			registry.CanInitiateProactively(ChatbotPlatform.Slack).Should().BeTrue();
 			registry.CanInitiateProactively(ChatbotPlatform.WebChat).Should().BeTrue();
@@ -47,10 +48,28 @@ namespace Resgrid.Tests.Chatbot
 		public void Registry_GetAdapter_ResolvesByPlatform()
 		{
 			var slack = new SlackBotAdapter();
-			var registry = new ChatbotAdapterRegistry(new List<IChatbotPlatformAdapter> { slack });
+			var registry = new ChatbotAdapterRegistry(new Lazy<IEnumerable<IChatbotPlatformAdapter>>(() => new List<IChatbotPlatformAdapter> { slack }));
 
 			registry.GetAdapter(ChatbotPlatform.Slack).Should().BeSameAs(slack);
 			registry.GetAdapter(ChatbotPlatform.Discord).Should().BeNull();
+		}
+
+		[Test]
+		public void Registry_DoesNotResolveAdaptersUntilFirstGetAdapter()
+		{
+			// Guards the circular-dependency fix: constructing the registry (which happens inside the
+			// CommunicationService -> ChatbotOutboundService activation chain) must not materialize the
+			// adapters, because WebChatAdapter's dependency graph loops back through CallsService.
+			var resolved = false;
+			var registry = new ChatbotAdapterRegistry(new Lazy<IEnumerable<IChatbotPlatformAdapter>>(() =>
+			{
+				resolved = true;
+				return new List<IChatbotPlatformAdapter>();
+			}));
+
+			resolved.Should().BeFalse();
+			registry.GetAdapter(ChatbotPlatform.Slack);
+			resolved.Should().BeTrue();
 		}
 
 		// ---- ChatbotOutboundService ----


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
# Pull Request Description

## Summary

Fixes an Autofac circular dependency exception (RG-T117) in the chatbot adapter registry by deferring adapter resolution until first use.

## Problem

The `ChatbotAdapterRegistry` eagerly resolved all chatbot platform adapters in its constructor. This triggered a circular dependency chain: `WebChatAdapter`'s notifier depends on chat services, which in turn reach `AuthorizationService → CallsService → CommunicationService → ChatbotOutboundService`, which loops back into `ChatbotAdapterRegistry`. This cycle caused Autofac to throw a circular dependency exception during container activation.

## Changes

- **ChatbotAdapterRegistry**: Changed the constructor parameter from `IEnumerable<IChatbotPlatformAdapter>` to `Lazy<IEnumerable<IChatbotPlatformAdapter>>`, and wrapped the adapter dictionary in a `Lazy<>`. Adapters are now only materialized on the first call to `GetAdapter`, keeping the circular dependency out of the container's constructor chain.
- **Tests**: Updated existing tests to use the new constructor signature and added a new test (`Registry_DoesNotResolveAdaptersUntilFirstGetAdapter`) verifying that adapters are not resolved until `GetAdapter` is first invoked.

## Impact

Resolves a runtime dependency injection failure that prevented the chatbot subsystem (and its dependents in the communication/calls chain) from initializing correctly.
<!-- kody-pr-summary:end -->