### PR TITLE
RG-T117 View call fix

### DIFF
--- a/Web/Resgrid.Web/Areas/User/Views/Dispatch/ViewCall.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Dispatch/ViewCall.cshtml
@@ -975,15 +975,34 @@
         } catch (e) { }
 
         if (Array.isArray(callFormFields)) {
+            // form-render inserts label/option/description content as HTML and its sanitizer is a
+            // no-op unless DOMPurify is loaded (it isn't). CallFormData is API-writable, so escape
+            // the HTML-rendered props and show them as plain text.
+            var escapeHtml = function (value) {
+                return typeof value === 'string'
+                    ? value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;')
+                    : value;
+            };
+            callFormFields.forEach(function (field) {
+                if (!field || typeof field !== 'object') return;
+                field.label = escapeHtml(field.label);
+                field.description = escapeHtml(field.description);
+                if (Array.isArray(field.values)) {
+                    field.values.forEach(function (option) {
+                        if (option && typeof option === 'object') option.label = escapeHtml(option.label);
+                    });
+                }
+            });
+
             var newCallForm = $('#fb-template').formRender({
                 dataType: 'json',
-                formData: callFormData,
+                formData: JSON.stringify(callFormFields),
                 notify: {
                     error: function(message) {
 
                     },
                     success: function(message) {
-                        $('input, textarea, select', '.rendered-form').attr('readonly', true).attr('disabled', true)
+                        $('input, textarea, select, button', '#fb-template .rendered-form').attr('readonly', true).attr('disabled', true)
                     },
                     warning: function(message) {
 

--- a/Web/Resgrid.Web/Areas/User/Views/Dispatch/ViewCall.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Dispatch/ViewCall.cshtml
@@ -964,22 +964,36 @@
     <script type="text/javascript">
         var callId = @(Model.Call.CallId);
 
-        var newCallForm = $('#fb-template').formRender({
-            dataType: 'json',
-            formData: '@Html.Raw(Model.Call.CallFormData)',
-            notify: {
-                error: function(message) {
+        var callFormData = @Html.Raw(Newtonsoft.Json.JsonConvert.SerializeObject(Model.Call.CallFormData ?? string.Empty, new Newtonsoft.Json.JsonSerializerSettings { StringEscapeHandling = Newtonsoft.Json.StringEscapeHandling.EscapeHtml }));
 
-                },
-                success: function(message) {
-                    $('input, textarea, select', '.rendered-form').attr('readonly', true).attr('disabled', true)
-                },
-                warning: function(message) {
+        // CallFormData is API-writable free text; older/external clients stored plain text
+        // (e.g. "Submitted ...") which formRender's JSON.parse can't handle. Only render the
+        // form for valid formBuilder data, otherwise show the raw text read-only.
+        var callFormFields = null;
+        try {
+            callFormFields = JSON.parse(callFormData);
+        } catch (e) { }
 
+        if (Array.isArray(callFormFields)) {
+            var newCallForm = $('#fb-template').formRender({
+                dataType: 'json',
+                formData: callFormData,
+                notify: {
+                    error: function(message) {
+
+                    },
+                    success: function(message) {
+                        $('input, textarea, select', '.rendered-form').attr('readonly', true).attr('disabled', true)
+                    },
+                    warning: function(message) {
+
+                    }
                 }
-            }
 
-        });
+            });
+        } else if (callFormData) {
+            $('#fb-template').text(callFormData);
+        }
     </script>
 
     <script src="~/js/app/common/signalr/resgrid.common.signalr.js" type="text/javascript"></script>


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## PR Description

**Fixes the "View Call" page to gracefully handle non-formBuilder call form data**

Previously, the View Call page always passed `CallFormData` directly to the `formRender` plugin expecting valid formBuilder JSON. When the field contained plain text (e.g., from older or external API clients that wrote free text such as a "Submitted..." message), `formRender` would fail because it could not parse the data as JSON.

### Changes
- **Proper serialization**: `CallFormData` is now serialized via JSON.NET with HTML-escape handling and safely null-coalesced to an empty string, rather than being embedded raw inside a JavaScript string literal (which was vulnerable to quote/character escaping issues).
- **JSON validation before rendering**: The code attempts to parse the value as JSON and only invokes `formRender` when the result is a valid JSON array (proper formBuilder data).
- **Fallback display**: If `CallFormData` is not valid formBuilder JSON but still contains text, it is now displayed as plain read-only text inside the container instead of causing a rendering error.

### Functional Impact
Users can now reliably view calls whose form data was authored by older or third-party clients that stored plain text rather than structured form definitions, eliminating the form-rendering failure on the View Call screen.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved call form rendering by safely handling both current JSON data and legacy content.
  * Invalid or unsupported form data now appears as read-only text instead of preventing the call from rendering.
  * Valid form fields continue to display as disabled fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->