### PR TITLE
RG-T129 Delete Repo bug

### DIFF
--- a/Repositories/Resgrid.Repositories.DataRepository/DeleteRepository.cs
+++ b/Repositories/Resgrid.Repositories.DataRepository/DeleteRepository.cs
@@ -24,8 +24,10 @@ namespace Resgrid.Repositories.DataRepository
 
 			if (Config.DataConfig.DatabaseType == DatabaseTypes.SqlServer)
 			{
-				using (IDbConnection db = new SqlConnection(DataConfig.CoreConnectionString))
+				using (var db = new SqlConnection(DataConfig.CoreConnectionString))
 				{
+					await db.OpenAsync();
+
 					using (var transaction = db.BeginTransaction())
 					{
 						var result = await db.ExecuteAsync(@"
@@ -171,13 +173,13 @@ namespace Resgrid.Repositories.DataRepository
 								DELETE FROM [dbo].[AspNetUsersExt] WHERE UserId = @ManagingUserId
 								DELETE FROM [dbo].[AspNetUsers] WHERE Id = @ManagingUserId
 						",
-							new { DepartmentId = departmentId });
+							new { DepartmentId = departmentId }, transaction);
 
 						transaction.Commit();
 					}
 				}
 
-				return false;
+				return true;
 			}
 
 			return false;


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
# Pull Request Description: RG-T129 Delete Repo bug

## Summary

This PR fixes multiple bugs in the department deletion repository that prevented departments from being properly deleted in SQL Server environments.

## Changes

**File:** `Repositories/Resgrid.Repositories.DataRepository/DeleteRepository.cs`

Three critical fixes were applied to the `DeleteDepartmentAndUsersAsync` method:

1. **Transaction parameter missing** — The SQL delete operations were not being executed within the transaction. The `transaction` object was created but never passed to `db.ExecuteAsync()`, meaning the delete commands ran outside the transaction scope (or failed silently).

2. **Connection not opened before transaction** — Added an explicit `await db.OpenAsync()` call before `BeginTransaction()` to ensure the connection is in an open state prior to creating the transaction.

3. **Incorrect return value** — The method always returned `false` even after a successful deletion. This was corrected to return `true` upon successful completion of the SQL Server deletion block.

## Functional Impact

Prior to this fix, deleting a department and its associated users would not work correctly on SQL Server deployments — the delete operations were effectively non-functional due to the missing transaction binding, and the method incorrectly reported failure regardless of outcome. Departments and their related data (users, messages, etc.) will now be properly and reliably deleted within a transactional context.
<!-- kody-pr-summary:end -->