### PR TITLE
RG-T117 Chatbox fixes

### DIFF
--- a/Core/Resgrid.Chatbot/Services/ChatbotDepartmentConfigService.cs
+++ b/Core/Resgrid.Chatbot/Services/ChatbotDepartmentConfigService.cs
@@ -157,20 +157,22 @@ namespace Resgrid.Chatbot.Services
 		/// Guards against SQL truncation (error 8152) by validating string fields against the
 		/// ChatbotDepartmentConfigs column sizes (M0068/M0070) before hitting the database.
 		/// LlmApiKey is checked post-encryption since the ciphertext is what gets stored.
+		/// Throws ArgumentException so API callers can map the failure to a 400 response;
+		/// messages are caller-safe (no parameter-name suffix).
 		/// </summary>
 		private static void ValidateColumnLengths(ChatbotDepartmentConfig config)
 		{
 			if (config.AllowedPlatforms != null && config.AllowedPlatforms.Length > 500)
-				throw new ArgumentException("AllowedPlatforms cannot exceed 500 characters.", nameof(config));
+				throw new ArgumentException("AllowedPlatforms cannot exceed 500 characters.");
 
 			if (config.LlmApiEndpoint != null && config.LlmApiEndpoint.Length > 500)
-				throw new ArgumentException("LlmApiEndpoint cannot exceed 500 characters.", nameof(config));
+				throw new ArgumentException("LlmApiEndpoint cannot exceed 500 characters.");
 
 			if (config.LlmModelName != null && config.LlmModelName.Length > 200)
-				throw new ArgumentException("LlmModelName cannot exceed 200 characters.", nameof(config));
+				throw new ArgumentException("LlmModelName cannot exceed 200 characters.");
 
 			if (config.LlmApiKey != null && config.LlmApiKey.Length > 1000)
-				throw new ArgumentException("Encrypted LlmApiKey cannot exceed 1000 characters; supply a shorter API key.", nameof(config));
+				throw new ArgumentException("Encrypted LlmApiKey cannot exceed 1000 characters; supply a shorter API key.");
 		}
 
 		private static string CacheKey(int departmentId) => $"ChatbotDeptConfig_{departmentId}";

--- a/Core/Resgrid.Chatbot/Services/ChatbotDepartmentConfigService.cs
+++ b/Core/Resgrid.Chatbot/Services/ChatbotDepartmentConfigService.cs
@@ -121,6 +121,8 @@ namespace Resgrid.Chatbot.Services
 			else
 				config.LlmApiKey = _encryptionService.Encrypt(newPlaintextLlmKey);
 
+			ValidateColumnLengths(config);
+
 			if (existing == null)
 			{
 				config.Id = Guid.NewGuid().ToString("N");
@@ -149,6 +151,26 @@ namespace Resgrid.Chatbot.Services
 			{
 				Logging.LogException(ex);
 			}
+		}
+
+		/// <summary>
+		/// Guards against SQL truncation (error 8152) by validating string fields against the
+		/// ChatbotDepartmentConfigs column sizes (M0068/M0070) before hitting the database.
+		/// LlmApiKey is checked post-encryption since the ciphertext is what gets stored.
+		/// </summary>
+		private static void ValidateColumnLengths(ChatbotDepartmentConfig config)
+		{
+			if (config.AllowedPlatforms != null && config.AllowedPlatforms.Length > 500)
+				throw new ArgumentException("AllowedPlatforms cannot exceed 500 characters.", nameof(config));
+
+			if (config.LlmApiEndpoint != null && config.LlmApiEndpoint.Length > 500)
+				throw new ArgumentException("LlmApiEndpoint cannot exceed 500 characters.", nameof(config));
+
+			if (config.LlmModelName != null && config.LlmModelName.Length > 200)
+				throw new ArgumentException("LlmModelName cannot exceed 200 characters.", nameof(config));
+
+			if (config.LlmApiKey != null && config.LlmApiKey.Length > 1000)
+				throw new ArgumentException("Encrypted LlmApiKey cannot exceed 1000 characters; supply a shorter API key.", nameof(config));
 		}
 
 		private static string CacheKey(int departmentId) => $"ChatbotDeptConfig_{departmentId}";

--- a/Web/Resgrid.Web.Services/Controllers/v4/CallsController.cs
+++ b/Web/Resgrid.Web.Services/Controllers/v4/CallsController.cs
@@ -1701,9 +1701,19 @@ namespace Resgrid.Web.Services.Controllers.v4
 		/// <returns>Array of CallResult objects for each call in the department within the range</returns>
 		[HttpGet("GetCalls")]
 		[ProducesResponseType(StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status400BadRequest)]
 		[Authorize(Policy = ResgridResources.Call_View)]
 		public async Task<ActionResult<ActiveCallsResult>> GetCalls(DateTime startDate, DateTime endDate)
 		{
+			// Missing query params bind to DateTime.MinValue (0001-01-01), which is below the SQL
+			// Server datetime floor (1753-01-01) and throws SqlDateTime overflow at the repository.
+			var sqlMinDate = new DateTime(1753, 1, 1);
+			if (startDate < sqlMinDate || endDate < sqlMinDate)
+				return BadRequest("startDate and endDate are required and must be valid dates (on or after 1753-01-01).");
+
+			if (endDate < startDate)
+				return BadRequest("endDate must be on or after startDate.");
+
 			var result = new ActiveCallsResult();
 
 			var calls = (await _callsService.GetAllCallsByDepartmentDateRangeAsync(DepartmentId, startDate, endDate)).OrderByDescending(x => x.LoggedOn);

--- a/Web/Resgrid.Web.Services/Controllers/v4/ChatbotController.cs
+++ b/Web/Resgrid.Web.Services/Controllers/v4/ChatbotController.cs
@@ -266,6 +266,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 		/// </summary>
 		[HttpPut("Config")]
 		[ProducesResponseType(StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status400BadRequest)]
 		public async Task<IActionResult> UpdateConfig([FromBody] ChatbotConfigRequest request)
 		{
 			try
@@ -300,6 +301,11 @@ namespace Resgrid.Web.Services.Controllers.v4
 				await _departmentConfigService.SaveConfigAsync(config, request.LlmApiKey);
 
 				return Ok(new { success = true });
+			}
+			catch (ArgumentException ex)
+			{
+				// Field-length (column size) validation from the config service.
+				return BadRequest(new { error = ex.Message });
 			}
 			catch (Exception ex)
 			{

--- a/Web/Resgrid.Web/Areas/User/Controllers/ChatbotSettingsController.cs
+++ b/Web/Resgrid.Web/Areas/User/Controllers/ChatbotSettingsController.cs
@@ -55,6 +55,14 @@ namespace Resgrid.Web.Areas.User.Controllers
 			if (!await _authorizationService.CanUserModifyDepartmentAsync(UserId, DepartmentId))
 				return Unauthorized();
 
+			if (!ModelState.IsValid)
+			{
+				var existing = await _chatbotConfigService.GetConfigAsync(DepartmentId);
+				model.HasLlmApiKey = !string.IsNullOrWhiteSpace(existing?.LlmApiKey);
+				model.LlmApiKey = null;
+				return View(model);
+			}
+
 			try
 			{
 				var config = new ChatbotDepartmentConfig

--- a/Web/Resgrid.Web/Areas/User/Controllers/ChatbotSettingsController.cs
+++ b/Web/Resgrid.Web/Areas/User/Controllers/ChatbotSettingsController.cs
@@ -55,6 +55,11 @@ namespace Resgrid.Web.Areas.User.Controllers
 			if (!await _authorizationService.CanUserModifyDepartmentAsync(UserId, DepartmentId))
 				return Unauthorized();
 
+			// Same SSRF guard as the v4 API config writer (ChatbotController.UpdateConfig).
+			if (!string.IsNullOrWhiteSpace(model.LlmApiEndpoint) &&
+				!Resgrid.Chatbot.NLU.LlmEndpointValidator.IsValid(model.LlmApiEndpoint, out var llmEndpointError))
+				ModelState.AddModelError(nameof(model.LlmApiEndpoint), llmEndpointError);
+
 			if (!ModelState.IsValid)
 			{
 				var existing = await _chatbotConfigService.GetConfigAsync(DepartmentId);

--- a/Web/Resgrid.Web/Areas/User/Models/ChatbotSettingsModel.cs
+++ b/Web/Resgrid.Web/Areas/User/Models/ChatbotSettingsModel.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using Resgrid.Web.Attributes;
 
 namespace Resgrid.Web.Areas.User.Models
 {
@@ -35,9 +36,11 @@ namespace Resgrid.Web.Areas.User.Models
 
 		/// <summary>
 		/// Write-only: a new API key to store. Never populated on read (see HasLlmApiKey).
-		/// Cap is 700 so the AES+base64 ciphertext fits the 1000-char LlmApiKey column.
+		/// Cap is 700 UTF-8 bytes (encryption operates on bytes) so the AES+base64 ciphertext
+		/// fits the 1000-char LlmApiKey column; StringLength adds the client-side char cap.
 		/// </summary>
 		[StringLength(700, ErrorMessage = "API key cannot exceed 700 characters.")]
+		[MaxUtf8Bytes(700, ErrorMessage = "API key cannot exceed 700 bytes when UTF-8 encoded (non-ASCII characters count as multiple bytes).")]
 		public string LlmApiKey { get; set; }
 
 		/// <summary>True when an LLM API key is already stored (so the UI can indicate it without exposing it).</summary>

--- a/Web/Resgrid.Web/Areas/User/Models/ChatbotSettingsModel.cs
+++ b/Web/Resgrid.Web/Areas/User/Models/ChatbotSettingsModel.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace Resgrid.Web.Areas.User.Models
 {
 	public class ChatbotSettingsModel : BaseUserModel
@@ -8,6 +10,7 @@ namespace Resgrid.Web.Areas.User.Models
 		public bool IsEnabled { get; set; }
 
 		/// <summary>Comma-separated platform names allowed for this department, or "*" for all.</summary>
+		[StringLength(500, ErrorMessage = "Allowed platforms cannot exceed 500 characters.")]
 		public string AllowedPlatforms { get; set; } = "*";
 
 		public bool AllowDispatchViaChatbot { get; set; }
@@ -24,10 +27,17 @@ namespace Resgrid.Web.Areas.User.Models
 
 		// Department's own LLM/AI provider (optional). When set, the chatbot keeps this department's
 		// processing with their provider instead of the Resgrid system LLM.
+		[StringLength(500, ErrorMessage = "API endpoint cannot exceed 500 characters.")]
 		public string LlmApiEndpoint { get; set; }
+
+		[StringLength(200, ErrorMessage = "Model name cannot exceed 200 characters.")]
 		public string LlmModelName { get; set; }
 
-		/// <summary>Write-only: a new API key to store. Never populated on read (see HasLlmApiKey).</summary>
+		/// <summary>
+		/// Write-only: a new API key to store. Never populated on read (see HasLlmApiKey).
+		/// Cap is 700 so the AES+base64 ciphertext fits the 1000-char LlmApiKey column.
+		/// </summary>
+		[StringLength(700, ErrorMessage = "API key cannot exceed 700 characters.")]
 		public string LlmApiKey { get; set; }
 
 		/// <summary>True when an LLM API key is already stored (so the UI can indicate it without exposing it).</summary>

--- a/Web/Resgrid.Web/Areas/User/Views/ChatbotSettings/Index.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/ChatbotSettings/Index.cshtml
@@ -53,7 +53,8 @@
                         <div class="form-group">
                             <label class="col-sm-3 control-label">@localizer["ChatbotAllowedPlatforms"]</label>
                             <div class="col-sm-9">
-                                <input type="text" class="form-control" asp-for="AllowedPlatforms" placeholder="*">
+                                <input type="text" class="form-control" asp-for="AllowedPlatforms" placeholder="*" maxlength="500">
+                                <span asp-validation-for="AllowedPlatforms" class="text-danger"></span>
                                 <span class="help-block m-b-none">@localizer["ChatbotAllowedPlatformsHelp"]</span>
                             </div>
                         </div>
@@ -118,21 +119,24 @@
                         <div class="form-group">
                             <label class="col-sm-3 control-label">@localizer["ChatbotLlmEndpoint"]</label>
                             <div class="col-sm-9">
-                                <input type="text" class="form-control" asp-for="LlmApiEndpoint" placeholder="https://api.your-provider.com/v1/chat/completions">
+                                <input type="text" class="form-control" asp-for="LlmApiEndpoint" placeholder="https://api.your-provider.com/v1/chat/completions" maxlength="500">
+                                <span asp-validation-for="LlmApiEndpoint" class="text-danger"></span>
                             </div>
                         </div>
 
                         <div class="form-group">
                             <label class="col-sm-3 control-label">@localizer["ChatbotLlmModel"]</label>
                             <div class="col-sm-9">
-                                <input type="text" class="form-control" asp-for="LlmModelName" placeholder="gpt-4o, deepseek-chat, ...">
+                                <input type="text" class="form-control" asp-for="LlmModelName" placeholder="gpt-4o, deepseek-chat, ..." maxlength="200">
+                                <span asp-validation-for="LlmModelName" class="text-danger"></span>
                             </div>
                         </div>
 
                         <div class="form-group">
                             <label class="col-sm-3 control-label">@localizer["ChatbotLlmApiKey"]</label>
                             <div class="col-sm-9">
-                                <input type="password" class="form-control" asp-for="LlmApiKey" autocomplete="new-password">
+                                <input type="password" class="form-control" asp-for="LlmApiKey" autocomplete="new-password" maxlength="700">
+                                <span asp-validation-for="LlmApiKey" class="text-danger"></span>
                                 <span class="help-block m-b-none">
                                     @if (Model.HasLlmApiKey)
                                     {

--- a/Web/Resgrid.Web/Attributes/MaxUtf8BytesAttribute.cs
+++ b/Web/Resgrid.Web/Attributes/MaxUtf8BytesAttribute.cs
@@ -1,0 +1,30 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text;
+
+namespace Resgrid.Web.Attributes
+{
+	/// <summary>
+	/// Validates that a string's UTF-8 encoded byte count does not exceed a maximum. Use when the
+	/// stored representation depends on byte length (e.g. values encrypted before persisting), where
+	/// a character-count check (StringLength) would pass multi-byte Unicode input that overflows a
+	/// fixed-size column.
+	/// </summary>
+	public sealed class MaxUtf8BytesAttribute : ValidationAttribute
+	{
+		private readonly int _maxBytes;
+
+		public MaxUtf8BytesAttribute(int maxBytes)
+			: base($"Cannot exceed {maxBytes} bytes when UTF-8 encoded.")
+		{
+			_maxBytes = maxBytes;
+		}
+
+		public override bool IsValid(object value)
+		{
+			if (value is null)
+				return true;
+
+			return value is string s && Encoding.UTF8.GetByteCount(s) <= _maxBytes;
+		}
+	}
+}

--- a/Web/Resgrid.Web/Resgrid.Web.csproj
+++ b/Web/Resgrid.Web/Resgrid.Web.csproj
@@ -156,6 +156,7 @@
     <ProjectReference Include="..\..\Core\Resgrid.Model\Resgrid.Model.csproj" />
     <ProjectReference Include="..\..\Core\Resgrid.Services\Resgrid.Services.csproj" />
     <ProjectReference Include="..\..\Core\Resgrid.Chatbot\Resgrid.Chatbot.csproj" />
+    <ProjectReference Include="..\..\Core\Resgrid.Chatbot.NLU\Resgrid.Chatbot.NLU.csproj" />
     <ProjectReference Include="..\..\Providers\Resgrid.Providers.AddressVerification\Resgrid.Providers.AddressVerification.csproj" />
     <ProjectReference Include="..\..\Providers\Resgrid.Providers.Bus.Rabbit\Resgrid.Providers.Bus.Rabbit.csproj" />
     <ProjectReference Include="..\..\Providers\Resgrid.Providers.Bus\Resgrid.Providers.Bus.csproj" />


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
# Pull Request Description

## RG-T117: Chatbox Fixes

This PR addresses data validation and input handling issues in the Chatbox feature that were causing database errors, along with a related date validation fix in the Calls API.

### Changes

**Chatbot Settings Input Validation**
- Added server-side length validation in `ChatbotDepartmentConfigService` that checks string fields against database column sizes before saving, preventing SQL truncation errors (error 8152)
- Added `StringLength` data annotation validators to the `ChatbotSettingsModel` for `AllowedPlatforms`, `LlmApiEndpoint`, `LlmModelName`, and `LlmApiKey` fields
- Added `maxlength` attributes and inline validation message spans to the chatbot settings form inputs for immediate client-side feedback
- Updated the `ChatbotSettingsController` to properly handle invalid model state by re-loading the existing API key indicator before returning the view with errors

**Calls API Date Validation**
- Added input validation to the `GetCalls` endpoint to reject missing or invalid date parameters that bind to `DateTime.MinValue`, which falls below SQL Server's datetime floor (1753-01-01) and causes a `SqlDateTime` overflow exception at the repository layer
- Added validation ensuring `endDate` is not earlier than `startDate`
- Returns a `400 BadRequest` with a descriptive message when validation fails

### Impact
These changes prevent unhandled database exceptions when users submit chatbot configuration with overly long values or when API consumers omit date parameters, replacing them with clear, user-friendly validation errors.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for chatbot settings, including platform, endpoint, model, and API key length limits.
  * Blocked invalid or unsafe LLM endpoints and prevented saving invalid configurations.
  * Improved API responses for invalid chatbot settings with descriptive errors.
  * Added validation for call date ranges and unsupported dates, returning clear bad-request messages.
  * Preserved API key status when chatbot settings contain validation errors.
  * Added field-level validation messages and input limits to the chatbot settings form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->