### PR TITLE
RG-T117 Chatbot fixes

### DIFF
--- a/Core/Resgrid.Chatbot/Handlers/DispatchCallHandler.cs
+++ b/Core/Resgrid.Chatbot/Handlers/DispatchCallHandler.cs
@@ -44,7 +44,7 @@ namespace Resgrid.Chatbot.Handlers
 				if (config != null && !config.AllowDispatchViaChatbot)
 					return new ChatbotResponse
 					{
-						Text = "Creating calls through the chatbot is disabled for this department.",
+						Text = "Creating calls through the assistant is disabled for this department.",
 						Processed = false
 					};
 

--- a/Core/Resgrid.Chatbot/Handlers/HelpActionHandler.cs
+++ b/Core/Resgrid.Chatbot/Handlers/HelpActionHandler.cs
@@ -60,7 +60,7 @@ namespace Resgrid.Chatbot.Handlers
 
 		private static string BuildTopicMenu()
 		{
-			return "Resgrid Chatbot. Text a command, or HELP <topic> for details.\n"
+			return "Resgrid Assistant. Text a command, or HELP <topic> for details.\n"
 				+ "Topics: STATUS, STAFFING, CALLS, MESSAGES, UNITS, SHIFTS, CALENDAR, PERSONNEL, DEPARTMENTS, STOP";
 		}
 

--- a/Core/Resgrid.Chatbot/Handlers/MessageSendHandler.cs
+++ b/Core/Resgrid.Chatbot/Handlers/MessageSendHandler.cs
@@ -45,7 +45,7 @@ namespace Resgrid.Chatbot.Handlers
 
 				var msg = new Message
 				{
-					Subject = "Message via chatbot",
+					Subject = "Message via assistant",
 					Body = body.Truncate(4000),
 					SendingUserId = session.UserId,
 					SentOn = DateTime.UtcNow,

--- a/Core/Resgrid.Chatbot/Handlers/PollCreateHandler.cs
+++ b/Core/Resgrid.Chatbot/Handlers/PollCreateHandler.cs
@@ -79,7 +79,7 @@ namespace Resgrid.Chatbot.Handlers
 				}
 
 				var profile = await _userProfileService.GetProfileByUserIdAsync(session.UserId);
-				var senderName = profile?.FullName?.AsFirstNameLastName ?? "Chatbot";
+				var senderName = profile?.FullName?.AsFirstNameLastName ?? "Assistant";
 
 				var msg = new Message
 				{

--- a/Core/Resgrid.Chatbot/Services/ChatbotIngressService.cs
+++ b/Core/Resgrid.Chatbot/Services/ChatbotIngressService.cs
@@ -190,7 +190,7 @@ namespace Resgrid.Chatbot.Services
 					if (switchableDepartments.Count == 0)
 					{
 						return await _templateRenderer.RenderResponseAsync("error",
-							new Services.ErrorModel { Message = "Your department's plan does not support chatbot features. Please upgrade your plan." },
+							new Services.ErrorModel { Message = "Your department's plan does not support assistant features. Please upgrade your plan." },
 							message.Platform, new ChatbotIntent { Type = ChatbotIntentType.Unknown });
 					}
 				}
@@ -205,14 +205,14 @@ namespace Resgrid.Chatbot.Services
 					if (!deptConfig.IsEnabled)
 					{
 						return await _templateRenderer.RenderResponseAsync("error",
-							new Services.ErrorModel { Message = "The chatbot is not enabled for your department. Please contact your administrator." },
+							new Services.ErrorModel { Message = "The assistant is not enabled for your department. Please contact your administrator." },
 							message.Platform, new ChatbotIntent { Type = ChatbotIntentType.Unknown });
 					}
 
 					if (!IsPlatformAllowed(deptConfig.AllowedPlatforms, message.Platform))
 					{
 						return await _templateRenderer.RenderResponseAsync("error",
-							new Services.ErrorModel { Message = "This channel isn't enabled for your department's chatbot." },
+							new Services.ErrorModel { Message = "This channel isn't enabled for your department's assistant." },
 							message.Platform, new ChatbotIntent { Type = ChatbotIntentType.Unknown });
 					}
 				}
@@ -310,7 +310,7 @@ namespace Resgrid.Chatbot.Services
 					}
 
 					var optionsBuilder = new System.Text.StringBuilder();
-					optionsBuilder.AppendLine("Your active department's plan does not support chatbot features, but you belong to other departments that do:");
+					optionsBuilder.AppendLine("Your active department's plan does not support assistant features, but you belong to other departments that do:");
 					for (int i = 0; i < switchableDepartments.Count; i++)
 					{
 						var switchableDept = await _departmentsService.GetDepartmentByIdAsync(switchableDepartments[i].DepartmentId);

--- a/Core/Resgrid.Chatbot/Services/CodeLinkingService.cs
+++ b/Core/Resgrid.Chatbot/Services/CodeLinkingService.cs
@@ -119,7 +119,7 @@ namespace Resgrid.Chatbot.Services
 				"code",
 				code);
 
-			return LinkResult.Ok("Account linked successfully! You can now use all chatbot features.", identity);
+			return LinkResult.Ok("Account linked successfully! You can now use all assistant features.", identity);
 		}
 
 		private static string GenerateRandomCode()

--- a/Core/Resgrid.Localization/Areas/User/Department/Department.ar.resx
+++ b/Core/Resgrid.Localization/Areas/User/Department/Department.ar.resx
@@ -637,19 +637,19 @@
     <value>حفظ الإعدادات العامة</value>
   </data>
   <data name="ChatbotSettingsHeader" xml:space="preserve">
-    <value>إعدادات روبوت الدردشة</value>
+    <value>إعدادات المساعد</value>
   </data>
   <data name="ChatbotSettingsNav" xml:space="preserve">
-    <value>روبوت الدردشة</value>
+    <value>المساعد</value>
   </data>
   <data name="ChatbotConfiguration" xml:space="preserve">
-    <value>تكوين روبوت الدردشة</value>
+    <value>تكوين المساعد</value>
   </data>
   <data name="ChatbotEnable" xml:space="preserve">
-    <value>تفعيل روبوت الدردشة</value>
+    <value>تفعيل المساعد</value>
   </data>
   <data name="ChatbotEnableHelp" xml:space="preserve">
-    <value>السماح لأعضاء هذا القسم بالتفاعل مع روبوت الدردشة.</value>
+    <value>السماح لأعضاء هذا القسم بالتفاعل مع المساعد.</value>
   </data>
   <data name="ChatbotAllowedPlatforms" xml:space="preserve">
     <value>المنصات المسموح بها</value>
@@ -658,10 +658,10 @@
     <value>أسماء المنصات مفصولة بفواصل المسموح بها لهذا القسم، أو * للكل. الأسماء الصالحة: SmsTwilio, SmsSignalWire, Discord, Slack, Telegram, WhatsApp, Teams, Signal, WebChat.</value>
   </data>
   <data name="ChatbotAllowDispatch" xml:space="preserve">
-    <value>السماح بالإرسال عبر روبوت الدردشة</value>
+    <value>السماح بالإرسال عبر المساعد</value>
   </data>
   <data name="ChatbotAllowDispatchHelp" xml:space="preserve">
-    <value>السماح للمستخدمين المصرّح لهم بإنشاء أو إرسال المكالمات عبر روبوت الدردشة.</value>
+    <value>السماح للمستخدمين المصرّح لهم بإنشاء أو إرسال المكالمات عبر المساعد.</value>
   </data>
   <data name="ChatbotConfirmStatusChanges" xml:space="preserve">
     <value>تأكيد تغييرات الحالة</value>
@@ -679,7 +679,7 @@
     <value>الإشعارات الاستباقية</value>
   </data>
   <data name="ChatbotProactiveNotificationsHelp" xml:space="preserve">
-    <value>السماح لروبوت الدردشة بإرسال إشعارات استباقية (مكالمات، تذكيرات) إلى المستخدمين المرتبطين.</value>
+    <value>السماح للمساعد بإرسال إشعارات استباقية (مكالمات، تذكيرات) إلى المستخدمين المرتبطين.</value>
   </data>
   <data name="ChatbotMessagesPerUser" xml:space="preserve">
     <value>الرسائل / المستخدم / الدقيقة</value>
@@ -697,7 +697,7 @@
     <value>مزوّد الذكاء الاصطناعي / LLM للقسم (اختياري)</value>
   </data>
   <data name="ChatbotLlmIntro" xml:space="preserve">
-    <value>اترك هذه الحقول فارغة لاستخدام مزوّد الذكاء الاصطناعي لنظام Resgrid. للإبقاء على معالجة روبوت الدردشة لدى مزوّدك الخاص، أدخل نقطة نهاية متوافقة مع OpenAI ونموذجًا ومفتاح API.</value>
+    <value>اترك هذه الحقول فارغة لاستخدام مزوّد الذكاء الاصطناعي لنظام Resgrid. للإبقاء على معالجة المساعد لدى مزوّدك الخاص، أدخل نقطة نهاية متوافقة مع OpenAI ونموذجًا ومفتاح API.</value>
   </data>
   <data name="ChatbotLlmEndpoint" xml:space="preserve">
     <value>نقطة نهاية LLM</value>
@@ -721,10 +721,10 @@
     <value>إلغاء</value>
   </data>
   <data name="ChatbotSaved" xml:space="preserve">
-    <value>تم حفظ إعدادات روبوت الدردشة.</value>
+    <value>تم حفظ إعدادات المساعد.</value>
   </data>
   <data name="ChatbotSaveError" xml:space="preserve">
-    <value>حدث خطأ أثناء حفظ إعدادات روبوت الدردشة.</value>
+    <value>حدث خطأ أثناء حفظ إعدادات المساعد.</value>
   </data>
   <data name="EnableModernNotifications" xml:space="preserve">
     <value>Enable Modern Notifications</value>
@@ -736,6 +736,6 @@
     <value>طلب رمز PIN الأمان</value>
   </data>
   <data name="ForceChatbotSecurityPinHelp" xml:space="preserve">
-    <value>يتطلب من كل عضو تأكيد الإجراءات الخطرة أو على مستوى القسم عبر روبوت الدردشة/الرسائل النصية باستخدام رمز PIN الأمان الشخصي المكون من 4 أرقام. يحصل الأعضاء الذين ليس لديهم رمز PIN على رمز يتم إنشاؤه عشوائيًا (يمكن عرضه في صفحة ملفهم الشخصي).</value>
+    <value>يتطلب من كل عضو تأكيد الإجراءات الخطرة أو على مستوى القسم عبر المساعد/الرسائل النصية باستخدام رمز PIN الأمان الشخصي المكون من 4 أرقام. يحصل الأعضاء الذين ليس لديهم رمز PIN على رمز يتم إنشاؤه عشوائيًا (يمكن عرضه في صفحة ملفهم الشخصي).</value>
   </data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Department/Department.de.resx
+++ b/Core/Resgrid.Localization/Areas/User/Department/Department.de.resx
@@ -588,19 +588,19 @@
     <value>Allgemeine Einstellungen speichern</value>
   </data>
   <data name="ChatbotSettingsHeader" xml:space="preserve">
-    <value>Chatbot-Einstellungen</value>
+    <value>Assistenten-Einstellungen</value>
   </data>
   <data name="ChatbotSettingsNav" xml:space="preserve">
-    <value>Chatbot</value>
+    <value>Assistent</value>
   </data>
   <data name="ChatbotConfiguration" xml:space="preserve">
-    <value>Chatbot-Konfiguration</value>
+    <value>Assistenten-Konfiguration</value>
   </data>
   <data name="ChatbotEnable" xml:space="preserve">
-    <value>Chatbot aktivieren</value>
+    <value>Assistenten aktivieren</value>
   </data>
   <data name="ChatbotEnableHelp" xml:space="preserve">
-    <value>Mitgliedern dieser Abteilung erlauben, mit dem Chatbot zu interagieren.</value>
+    <value>Mitgliedern dieser Abteilung erlauben, mit dem Assistenten zu interagieren.</value>
   </data>
   <data name="ChatbotAllowedPlatforms" xml:space="preserve">
     <value>Zugelassene Plattformen</value>
@@ -609,10 +609,10 @@
     <value>Durch Kommas getrennte Plattformnamen, die diese Abteilung zulässt, oder * für alle. Gültige Namen: SmsTwilio, SmsSignalWire, Discord, Slack, Telegram, WhatsApp, Teams, Signal, WebChat.</value>
   </data>
   <data name="ChatbotAllowDispatch" xml:space="preserve">
-    <value>Disposition über den Chatbot zulassen</value>
+    <value>Disposition über den Assistenten zulassen</value>
   </data>
   <data name="ChatbotAllowDispatchHelp" xml:space="preserve">
-    <value>Berechtigten Benutzern erlauben, über den Chatbot Einsätze zu erstellen oder zu disponieren.</value>
+    <value>Berechtigten Benutzern erlauben, über den Assistenten Einsätze zu erstellen oder zu disponieren.</value>
   </data>
   <data name="ChatbotConfirmStatusChanges" xml:space="preserve">
     <value>Statusänderungen bestätigen</value>
@@ -630,7 +630,7 @@
     <value>Proaktive Benachrichtigungen</value>
   </data>
   <data name="ChatbotProactiveNotificationsHelp" xml:space="preserve">
-    <value>Dem Chatbot erlauben, proaktive Benachrichtigungen (Einsätze, Erinnerungen) an verknüpfte Benutzer zu senden.</value>
+    <value>Dem Assistenten erlauben, proaktive Benachrichtigungen (Einsätze, Erinnerungen) an verknüpfte Benutzer zu senden.</value>
   </data>
   <data name="ChatbotMessagesPerUser" xml:space="preserve">
     <value>Nachrichten / Benutzer / Minute</value>
@@ -648,7 +648,7 @@
     <value>KI-/LLM-Anbieter der Abteilung (optional)</value>
   </data>
   <data name="ChatbotLlmIntro" xml:space="preserve">
-    <value>Leer lassen, um den KI-Anbieter des Resgrid-Systems zu verwenden. Um die Verarbeitung Ihres Chatbots bei Ihrem eigenen Anbieter zu belassen, geben Sie einen OpenAI-kompatiblen Endpunkt, ein Modell und einen API-Schlüssel ein.</value>
+    <value>Leer lassen, um den KI-Anbieter des Resgrid-Systems zu verwenden. Um die Verarbeitung Ihres Assistenten bei Ihrem eigenen Anbieter zu belassen, geben Sie einen OpenAI-kompatiblen Endpunkt, ein Modell und einen API-Schlüssel ein.</value>
   </data>
   <data name="ChatbotLlmEndpoint" xml:space="preserve">
     <value>LLM-Endpunkt</value>
@@ -672,10 +672,10 @@
     <value>Abbrechen</value>
   </data>
   <data name="ChatbotSaved" xml:space="preserve">
-    <value>Chatbot-Einstellungen gespeichert.</value>
+    <value>Assistenten-Einstellungen gespeichert.</value>
   </data>
   <data name="ChatbotSaveError" xml:space="preserve">
-    <value>Beim Speichern Ihrer Chatbot-Einstellungen ist ein Fehler aufgetreten.</value>
+    <value>Beim Speichern Ihrer Assistenten-Einstellungen ist ein Fehler aufgetreten.</value>
   </data>
   <data name="EnableModernNotifications" xml:space="preserve">
     <value>Enable Modern Notifications</value>
@@ -687,6 +687,6 @@
     <value>Sicherheits-PIN erforderlich</value>
   </data>
   <data name="ForceChatbotSecurityPinHelp" xml:space="preserve">
-    <value>Verlangt, dass jedes Mitglied gefährliche oder abteilungsweite Chatbot-/SMS-Aktionen mit seiner persönlichen 4-stelligen Sicherheits-PIN bestätigt. Mitglieder ohne PIN erhalten eine zufällig generierte (einsehbar auf ihrer Profilseite).</value>
+    <value>Verlangt, dass jedes Mitglied gefährliche oder abteilungsweite Assistenten-/SMS-Aktionen mit seiner persönlichen 4-stelligen Sicherheits-PIN bestätigt. Mitglieder ohne PIN erhalten eine zufällig generierte (einsehbar auf ihrer Profilseite).</value>
   </data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Department/Department.en.resx
+++ b/Core/Resgrid.Localization/Areas/User/Department/Department.en.resx
@@ -667,19 +667,19 @@
     <value>Select the eSpeak-NG language or dialect to use for this department's voice prompts.</value>
   </data>
   <data name="ChatbotSettingsHeader" xml:space="preserve">
-    <value>Chatbot Settings</value>
+    <value>Assistant Settings</value>
   </data>
   <data name="ChatbotSettingsNav" xml:space="preserve">
-    <value>Chatbot</value>
+    <value>Assistant</value>
   </data>
   <data name="ChatbotConfiguration" xml:space="preserve">
-    <value>Chatbot Configuration</value>
+    <value>Assistant Configuration</value>
   </data>
   <data name="ChatbotEnable" xml:space="preserve">
-    <value>Enable Chatbot</value>
+    <value>Enable Assistant</value>
   </data>
   <data name="ChatbotEnableHelp" xml:space="preserve">
-    <value>Allow members of this department to interact with the chatbot.</value>
+    <value>Allow members of this department to interact with the assistant.</value>
   </data>
   <data name="ChatbotAllowedPlatforms" xml:space="preserve">
     <value>Allowed Platforms</value>
@@ -688,10 +688,10 @@
     <value>Comma-separated platform names this department allows, or * for all. Valid names: SmsTwilio, SmsSignalWire, Discord, Slack, Telegram, WhatsApp, Teams, Signal, WebChat.</value>
   </data>
   <data name="ChatbotAllowDispatch" xml:space="preserve">
-    <value>Allow Dispatch via Chatbot</value>
+    <value>Allow Dispatch via Assistant</value>
   </data>
   <data name="ChatbotAllowDispatchHelp" xml:space="preserve">
-    <value>Allow authorized users to create or dispatch calls through the chatbot.</value>
+    <value>Allow authorized users to create or dispatch calls through the assistant.</value>
   </data>
   <data name="ChatbotConfirmStatusChanges" xml:space="preserve">
     <value>Confirm Status Changes</value>
@@ -709,7 +709,7 @@
     <value>Proactive Notifications</value>
   </data>
   <data name="ChatbotProactiveNotificationsHelp" xml:space="preserve">
-    <value>Allow the chatbot to push proactive notifications (calls, reminders) to linked users.</value>
+    <value>Allow the assistant to push proactive notifications (calls, reminders) to linked users.</value>
   </data>
   <data name="ChatbotMessagesPerUser" xml:space="preserve">
     <value>Messages / User / Minute</value>
@@ -727,7 +727,7 @@
     <value>Department AI / LLM Provider (optional)</value>
   </data>
   <data name="ChatbotLlmIntro" xml:space="preserve">
-    <value>Leave these blank to use the Resgrid system AI provider. To keep your chatbot processing with your own provider, enter an OpenAI-compatible endpoint, model, and API key.</value>
+    <value>Leave these blank to use the Resgrid system AI provider. To keep your assistant processing with your own provider, enter an OpenAI-compatible endpoint, model, and API key.</value>
   </data>
   <data name="ChatbotLlmEndpoint" xml:space="preserve">
     <value>LLM Endpoint</value>
@@ -751,10 +751,10 @@
     <value>Cancel</value>
   </data>
   <data name="ChatbotSaved" xml:space="preserve">
-    <value>Chatbot settings saved.</value>
+    <value>Assistant settings saved.</value>
   </data>
   <data name="ChatbotSaveError" xml:space="preserve">
-    <value>An error occurred saving your chatbot settings.</value>
+    <value>An error occurred saving your assistant settings.</value>
   </data>
   <data name="EnableModernNotifications" xml:space="preserve">
     <value>Enable Modern Notifications</value>
@@ -766,6 +766,6 @@
     <value>Require Security PIN</value>
   </data>
   <data name="ForceChatbotSecurityPinHelp" xml:space="preserve">
-    <value>Require every member to confirm dangerous or department-wide chatbot/text actions with their personal 4-digit security PIN. Members without a PIN get a randomly generated one (viewable on their profile page).</value>
+    <value>Require every member to confirm dangerous or department-wide assistant/text actions with their personal 4-digit security PIN. Members without a PIN get a randomly generated one (viewable on their profile page).</value>
   </data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Department/Department.es.resx
+++ b/Core/Resgrid.Localization/Areas/User/Department/Department.es.resx
@@ -523,19 +523,19 @@
     <value>Guardar Configuraciones Generales</value>
   </data>
   <data name="ChatbotSettingsHeader" xml:space="preserve">
-    <value>Ajustes del chatbot</value>
+    <value>Ajustes del asistente</value>
   </data>
   <data name="ChatbotSettingsNav" xml:space="preserve">
-    <value>Chatbot</value>
+    <value>Asistente</value>
   </data>
   <data name="ChatbotConfiguration" xml:space="preserve">
-    <value>Configuración del chatbot</value>
+    <value>Configuración del asistente</value>
   </data>
   <data name="ChatbotEnable" xml:space="preserve">
-    <value>Activar el chatbot</value>
+    <value>Activar el asistente</value>
   </data>
   <data name="ChatbotEnableHelp" xml:space="preserve">
-    <value>Permitir que los miembros de este departamento interactúen con el chatbot.</value>
+    <value>Permitir que los miembros de este departamento interactúen con el asistente.</value>
   </data>
   <data name="ChatbotAllowedPlatforms" xml:space="preserve">
     <value>Plataformas permitidas</value>
@@ -544,10 +544,10 @@
     <value>Nombres de plataformas separados por comas permitidos para este departamento, o * para todas. Nombres válidos: SmsTwilio, SmsSignalWire, Discord, Slack, Telegram, WhatsApp, Teams, Signal, WebChat.</value>
   </data>
   <data name="ChatbotAllowDispatch" xml:space="preserve">
-    <value>Permitir despacho mediante el chatbot</value>
+    <value>Permitir despacho mediante el asistente</value>
   </data>
   <data name="ChatbotAllowDispatchHelp" xml:space="preserve">
-    <value>Permitir que los usuarios autorizados creen o despachen llamadas mediante el chatbot.</value>
+    <value>Permitir que los usuarios autorizados creen o despachen llamadas mediante el asistente.</value>
   </data>
   <data name="ChatbotConfirmStatusChanges" xml:space="preserve">
     <value>Confirmar cambios de estado</value>
@@ -565,7 +565,7 @@
     <value>Notificaciones proactivas</value>
   </data>
   <data name="ChatbotProactiveNotificationsHelp" xml:space="preserve">
-    <value>Permitir que el chatbot envíe notificaciones proactivas (llamadas, recordatorios) a los usuarios vinculados.</value>
+    <value>Permitir que el asistente envíe notificaciones proactivas (llamadas, recordatorios) a los usuarios vinculados.</value>
   </data>
   <data name="ChatbotMessagesPerUser" xml:space="preserve">
     <value>Mensajes / usuario / minuto</value>
@@ -583,7 +583,7 @@
     <value>Proveedor de IA / LLM del departamento (opcional)</value>
   </data>
   <data name="ChatbotLlmIntro" xml:space="preserve">
-    <value>Deje estos campos en blanco para usar el proveedor de IA del sistema de Resgrid. Para mantener el procesamiento de su chatbot con su propio proveedor, introduzca un endpoint compatible con OpenAI, un modelo y una clave API.</value>
+    <value>Deje estos campos en blanco para usar el proveedor de IA del sistema de Resgrid. Para mantener el procesamiento de su asistente con su propio proveedor, introduzca un endpoint compatible con OpenAI, un modelo y una clave API.</value>
   </data>
   <data name="ChatbotLlmEndpoint" xml:space="preserve">
     <value>Endpoint de LLM</value>
@@ -607,10 +607,10 @@
     <value>Cancelar</value>
   </data>
   <data name="ChatbotSaved" xml:space="preserve">
-    <value>Configuración del chatbot guardada.</value>
+    <value>Configuración del asistente guardada.</value>
   </data>
   <data name="ChatbotSaveError" xml:space="preserve">
-    <value>Se produjo un error al guardar la configuración del chatbot.</value>
+    <value>Se produjo un error al guardar la configuración del asistente.</value>
   </data>
   <data name="EnableModernNotifications" xml:space="preserve">
     <value>Enable Modern Notifications</value>
@@ -622,6 +622,6 @@
     <value>Requerir PIN de seguridad</value>
   </data>
   <data name="ForceChatbotSecurityPinHelp" xml:space="preserve">
-    <value>Exige que cada miembro confirme las acciones peligrosas o de todo el departamento del chatbot/mensajes de texto con su PIN de seguridad personal de 4 dígitos. Los miembros sin PIN reciben uno generado aleatoriamente (visible en su página de perfil).</value>
+    <value>Exige que cada miembro confirme las acciones peligrosas o de todo el departamento del asistente/mensajes de texto con su PIN de seguridad personal de 4 dígitos. Los miembros sin PIN reciben uno generado aleatoriamente (visible en su página de perfil).</value>
   </data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Department/Department.fr.resx
+++ b/Core/Resgrid.Localization/Areas/User/Department/Department.fr.resx
@@ -588,19 +588,19 @@
     <value>Enregistrer les Param&#xE8;tres G&#xE9;n&#xE9;raux</value>
   </data>
   <data name="ChatbotSettingsHeader" xml:space="preserve">
-    <value>Paramètres du chatbot</value>
+    <value>Paramètres de l'assistant</value>
   </data>
   <data name="ChatbotSettingsNav" xml:space="preserve">
-    <value>Chatbot</value>
+    <value>Assistant</value>
   </data>
   <data name="ChatbotConfiguration" xml:space="preserve">
-    <value>Configuration du chatbot</value>
+    <value>Configuration de l'assistant</value>
   </data>
   <data name="ChatbotEnable" xml:space="preserve">
-    <value>Activer le chatbot</value>
+    <value>Activer l'assistant</value>
   </data>
   <data name="ChatbotEnableHelp" xml:space="preserve">
-    <value>Autoriser les membres de ce service à interagir avec le chatbot.</value>
+    <value>Autoriser les membres de ce service à interagir avec l'assistant.</value>
   </data>
   <data name="ChatbotAllowedPlatforms" xml:space="preserve">
     <value>Plateformes autorisées</value>
@@ -609,10 +609,10 @@
     <value>Noms de plateformes séparés par des virgules autorisés pour ce service, ou * pour toutes. Noms valides : SmsTwilio, SmsSignalWire, Discord, Slack, Telegram, WhatsApp, Teams, Signal, WebChat.</value>
   </data>
   <data name="ChatbotAllowDispatch" xml:space="preserve">
-    <value>Autoriser la répartition via le chatbot</value>
+    <value>Autoriser la répartition via l'assistant</value>
   </data>
   <data name="ChatbotAllowDispatchHelp" xml:space="preserve">
-    <value>Autoriser les utilisateurs habilités à créer ou répartir des appels via le chatbot.</value>
+    <value>Autoriser les utilisateurs habilités à créer ou répartir des appels via l'assistant.</value>
   </data>
   <data name="ChatbotConfirmStatusChanges" xml:space="preserve">
     <value>Confirmer les changements de statut</value>
@@ -630,7 +630,7 @@
     <value>Notifications proactives</value>
   </data>
   <data name="ChatbotProactiveNotificationsHelp" xml:space="preserve">
-    <value>Autoriser le chatbot à envoyer des notifications proactives (appels, rappels) aux utilisateurs liés.</value>
+    <value>Autoriser l'assistant à envoyer des notifications proactives (appels, rappels) aux utilisateurs liés.</value>
   </data>
   <data name="ChatbotMessagesPerUser" xml:space="preserve">
     <value>Messages / utilisateur / minute</value>
@@ -648,7 +648,7 @@
     <value>Fournisseur d'IA / LLM du service (facultatif)</value>
   </data>
   <data name="ChatbotLlmIntro" xml:space="preserve">
-    <value>Laissez ces champs vides pour utiliser le fournisseur d'IA système de Resgrid. Pour conserver le traitement de votre chatbot chez votre propre fournisseur, saisissez un point de terminaison compatible OpenAI, un modèle et une clé API.</value>
+    <value>Laissez ces champs vides pour utiliser le fournisseur d'IA système de Resgrid. Pour conserver le traitement de votre assistant chez votre propre fournisseur, saisissez un point de terminaison compatible OpenAI, un modèle et une clé API.</value>
   </data>
   <data name="ChatbotLlmEndpoint" xml:space="preserve">
     <value>Point de terminaison LLM</value>
@@ -672,10 +672,10 @@
     <value>Annuler</value>
   </data>
   <data name="ChatbotSaved" xml:space="preserve">
-    <value>Paramètres du chatbot enregistrés.</value>
+    <value>Paramètres de l'assistant enregistrés.</value>
   </data>
   <data name="ChatbotSaveError" xml:space="preserve">
-    <value>Une erreur s'est produite lors de l'enregistrement des paramètres du chatbot.</value>
+    <value>Une erreur s'est produite lors de l'enregistrement des paramètres de l'assistant.</value>
   </data>
   <data name="EnableModernNotifications" xml:space="preserve">
     <value>Enable Modern Notifications</value>
@@ -687,6 +687,6 @@
     <value>Exiger le code PIN de sécurité</value>
   </data>
   <data name="ForceChatbotSecurityPinHelp" xml:space="preserve">
-    <value>Exige que chaque membre confirme les actions dangereuses ou à l'échelle du service du chatbot/SMS avec son code PIN de sécurité personnel à 4 chiffres. Les membres sans PIN en reçoivent un généré aléatoirement (visible sur leur page de profil).</value>
+    <value>Exige que chaque membre confirme les actions dangereuses ou à l'échelle du service de l'assistant/SMS avec son code PIN de sécurité personnel à 4 chiffres. Les membres sans PIN en reçoivent un généré aléatoirement (visible sur leur page de profil).</value>
   </data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Department/Department.it.resx
+++ b/Core/Resgrid.Localization/Areas/User/Department/Department.it.resx
@@ -588,19 +588,19 @@
     <value>Salva Impostazioni Generali</value>
   </data>
   <data name="ChatbotSettingsHeader" xml:space="preserve">
-    <value>Impostazioni del chatbot</value>
+    <value>Impostazioni dell'assistente</value>
   </data>
   <data name="ChatbotSettingsNav" xml:space="preserve">
-    <value>Chatbot</value>
+    <value>Assistente</value>
   </data>
   <data name="ChatbotConfiguration" xml:space="preserve">
-    <value>Configurazione del chatbot</value>
+    <value>Configurazione dell'assistente</value>
   </data>
   <data name="ChatbotEnable" xml:space="preserve">
-    <value>Abilita il chatbot</value>
+    <value>Abilita l'assistente</value>
   </data>
   <data name="ChatbotEnableHelp" xml:space="preserve">
-    <value>Consenti ai membri di questo dipartimento di interagire con il chatbot.</value>
+    <value>Consenti ai membri di questo dipartimento di interagire con l'assistente.</value>
   </data>
   <data name="ChatbotAllowedPlatforms" xml:space="preserve">
     <value>Piattaforme consentite</value>
@@ -609,10 +609,10 @@
     <value>Nomi di piattaforme separati da virgole consentiti per questo dipartimento, oppure * per tutte. Nomi validi: SmsTwilio, SmsSignalWire, Discord, Slack, Telegram, WhatsApp, Teams, Signal, WebChat.</value>
   </data>
   <data name="ChatbotAllowDispatch" xml:space="preserve">
-    <value>Consenti l'invio di chiamate tramite il chatbot</value>
+    <value>Consenti l'invio di chiamate tramite l'assistente</value>
   </data>
   <data name="ChatbotAllowDispatchHelp" xml:space="preserve">
-    <value>Consenti agli utenti autorizzati di creare o inviare chiamate tramite il chatbot.</value>
+    <value>Consenti agli utenti autorizzati di creare o inviare chiamate tramite l'assistente.</value>
   </data>
   <data name="ChatbotConfirmStatusChanges" xml:space="preserve">
     <value>Conferma le modifiche di stato</value>
@@ -630,7 +630,7 @@
     <value>Notifiche proattive</value>
   </data>
   <data name="ChatbotProactiveNotificationsHelp" xml:space="preserve">
-    <value>Consenti al chatbot di inviare notifiche proattive (chiamate, promemoria) agli utenti collegati.</value>
+    <value>Consenti all'assistente di inviare notifiche proattive (chiamate, promemoria) agli utenti collegati.</value>
   </data>
   <data name="ChatbotMessagesPerUser" xml:space="preserve">
     <value>Messaggi / utente / minuto</value>
@@ -648,7 +648,7 @@
     <value>Provider IA / LLM del dipartimento (facoltativo)</value>
   </data>
   <data name="ChatbotLlmIntro" xml:space="preserve">
-    <value>Lascia questi campi vuoti per usare il provider IA di sistema di Resgrid. Per mantenere l'elaborazione del tuo chatbot presso il tuo provider, inserisci un endpoint compatibile con OpenAI, un modello e una chiave API.</value>
+    <value>Lascia questi campi vuoti per usare il provider IA di sistema di Resgrid. Per mantenere l'elaborazione del tuo assistente presso il tuo provider, inserisci un endpoint compatibile con OpenAI, un modello e una chiave API.</value>
   </data>
   <data name="ChatbotLlmEndpoint" xml:space="preserve">
     <value>Endpoint LLM</value>
@@ -672,10 +672,10 @@
     <value>Annulla</value>
   </data>
   <data name="ChatbotSaved" xml:space="preserve">
-    <value>Impostazioni del chatbot salvate.</value>
+    <value>Impostazioni dell'assistente salvate.</value>
   </data>
   <data name="ChatbotSaveError" xml:space="preserve">
-    <value>Si è verificato un errore durante il salvataggio delle impostazioni del chatbot.</value>
+    <value>Si è verificato un errore durante il salvataggio delle impostazioni dell'assistente.</value>
   </data>
   <data name="EnableModernNotifications" xml:space="preserve">
     <value>Enable Modern Notifications</value>
@@ -687,6 +687,6 @@
     <value>Richiedi PIN di sicurezza</value>
   </data>
   <data name="ForceChatbotSecurityPinHelp" xml:space="preserve">
-    <value>Richiede che ogni membro confermi le azioni pericolose o a livello di dipartimento del chatbot/SMS con il proprio PIN di sicurezza personale a 4 cifre. I membri senza PIN ne ricevono uno generato casualmente (visibile nella pagina del profilo).</value>
+    <value>Richiede che ogni membro confermi le azioni pericolose o a livello di dipartimento dell'assistente/SMS con il proprio PIN di sicurezza personale a 4 cifre. I membri senza PIN ne ricevono uno generato casualmente (visibile nella pagina del profilo).</value>
   </data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Department/Department.pl.resx
+++ b/Core/Resgrid.Localization/Areas/User/Department/Department.pl.resx
@@ -588,19 +588,19 @@
     <value>Zapisz Ustawienia Og&#xF3;lne</value>
   </data>
   <data name="ChatbotSettingsHeader" xml:space="preserve">
-    <value>Ustawienia chatbota</value>
+    <value>Ustawienia asystenta</value>
   </data>
   <data name="ChatbotSettingsNav" xml:space="preserve">
-    <value>Chatbot</value>
+    <value>Asystent</value>
   </data>
   <data name="ChatbotConfiguration" xml:space="preserve">
-    <value>Konfiguracja chatbota</value>
+    <value>Konfiguracja asystenta</value>
   </data>
   <data name="ChatbotEnable" xml:space="preserve">
-    <value>Włącz chatbota</value>
+    <value>Włącz asystenta</value>
   </data>
   <data name="ChatbotEnableHelp" xml:space="preserve">
-    <value>Zezwól członkom tego działu na interakcję z chatbotem.</value>
+    <value>Zezwól członkom tego działu na interakcję z asystentem.</value>
   </data>
   <data name="ChatbotAllowedPlatforms" xml:space="preserve">
     <value>Dozwolone platformy</value>
@@ -609,10 +609,10 @@
     <value>Nazwy platform oddzielone przecinkami dozwolone dla tego działu lub * dla wszystkich. Prawidłowe nazwy: SmsTwilio, SmsSignalWire, Discord, Slack, Telegram, WhatsApp, Teams, Signal, WebChat.</value>
   </data>
   <data name="ChatbotAllowDispatch" xml:space="preserve">
-    <value>Zezwól na dysponowanie przez chatbota</value>
+    <value>Zezwól na dysponowanie przez asystenta</value>
   </data>
   <data name="ChatbotAllowDispatchHelp" xml:space="preserve">
-    <value>Zezwól uprawnionym użytkownikom na tworzenie lub dysponowanie zgłoszeniami przez chatbota.</value>
+    <value>Zezwól uprawnionym użytkownikom na tworzenie lub dysponowanie zgłoszeniami przez asystenta.</value>
   </data>
   <data name="ChatbotConfirmStatusChanges" xml:space="preserve">
     <value>Potwierdzaj zmiany statusu</value>
@@ -630,7 +630,7 @@
     <value>Powiadomienia proaktywne</value>
   </data>
   <data name="ChatbotProactiveNotificationsHelp" xml:space="preserve">
-    <value>Zezwól chatbotowi na wysyłanie proaktywnych powiadomień (zgłoszenia, przypomnienia) do powiązanych użytkowników.</value>
+    <value>Zezwól asystentowi na wysyłanie proaktywnych powiadomień (zgłoszenia, przypomnienia) do powiązanych użytkowników.</value>
   </data>
   <data name="ChatbotMessagesPerUser" xml:space="preserve">
     <value>Wiadomości / użytkownik / minuta</value>
@@ -648,7 +648,7 @@
     <value>Dostawca AI / LLM działu (opcjonalnie)</value>
   </data>
   <data name="ChatbotLlmIntro" xml:space="preserve">
-    <value>Pozostaw te pola puste, aby użyć systemowego dostawcy AI Resgrid. Aby przetwarzanie chatbota pozostało u własnego dostawcy, podaj punkt końcowy zgodny z OpenAI, model i klucz API.</value>
+    <value>Pozostaw te pola puste, aby użyć systemowego dostawcy AI Resgrid. Aby przetwarzanie asystenta pozostało u własnego dostawcy, podaj punkt końcowy zgodny z OpenAI, model i klucz API.</value>
   </data>
   <data name="ChatbotLlmEndpoint" xml:space="preserve">
     <value>Punkt końcowy LLM</value>
@@ -672,10 +672,10 @@
     <value>Anuluj</value>
   </data>
   <data name="ChatbotSaved" xml:space="preserve">
-    <value>Zapisano ustawienia chatbota.</value>
+    <value>Zapisano ustawienia asystenta.</value>
   </data>
   <data name="ChatbotSaveError" xml:space="preserve">
-    <value>Wystąpił błąd podczas zapisywania ustawień chatbota.</value>
+    <value>Wystąpił błąd podczas zapisywania ustawień asystenta.</value>
   </data>
   <data name="EnableModernNotifications" xml:space="preserve">
     <value>Enable Modern Notifications</value>
@@ -687,6 +687,6 @@
     <value>Wymagaj kodu PIN bezpieczeństwa</value>
   </data>
   <data name="ForceChatbotSecurityPinHelp" xml:space="preserve">
-    <value>Wymaga, aby każdy członek potwierdzał niebezpieczne lub obejmujące cały wydział akcje chatbota/SMS swoim osobistym 4-cyfrowym kodem PIN bezpieczeństwa. Członkowie bez kodu PIN otrzymują losowo wygenerowany (widoczny na stronie profilu).</value>
+    <value>Wymaga, aby każdy członek potwierdzał niebezpieczne lub obejmujące cały wydział akcje asystenta/SMS swoim osobistym 4-cyfrowym kodem PIN bezpieczeństwa. Członkowie bez kodu PIN otrzymują losowo wygenerowany (widoczny na stronie profilu).</value>
   </data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Department/Department.resx
+++ b/Core/Resgrid.Localization/Areas/User/Department/Department.resx
@@ -361,6 +361,6 @@
     <value>Require Security PIN</value>
   </data>
   <data name="ForceChatbotSecurityPinHelp" xml:space="preserve">
-    <value>Require every member to confirm dangerous or department-wide chatbot/text actions with their personal 4-digit security PIN. Members without a PIN get a randomly generated one (viewable on their profile page).</value>
+    <value>Require every member to confirm dangerous or department-wide assistant/text actions with their personal 4-digit security PIN. Members without a PIN get a randomly generated one (viewable on their profile page).</value>
   </data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Department/Department.sv.resx
+++ b/Core/Resgrid.Localization/Areas/User/Department/Department.sv.resx
@@ -588,19 +588,19 @@
     <value>Spara Allmänna Inställningar</value>
   </data>
   <data name="ChatbotSettingsHeader" xml:space="preserve">
-    <value>Chatbot-inställningar</value>
+    <value>Assistentinställningar</value>
   </data>
   <data name="ChatbotSettingsNav" xml:space="preserve">
-    <value>Chatbot</value>
+    <value>Assistent</value>
   </data>
   <data name="ChatbotConfiguration" xml:space="preserve">
-    <value>Chatbot-konfiguration</value>
+    <value>Assistentkonfiguration</value>
   </data>
   <data name="ChatbotEnable" xml:space="preserve">
-    <value>Aktivera chatbot</value>
+    <value>Aktivera assistent</value>
   </data>
   <data name="ChatbotEnableHelp" xml:space="preserve">
-    <value>Tillåt medlemmar i denna avdelning att interagera med chatboten.</value>
+    <value>Tillåt medlemmar i denna avdelning att interagera med assistenten.</value>
   </data>
   <data name="ChatbotAllowedPlatforms" xml:space="preserve">
     <value>Tillåtna plattformar</value>
@@ -609,10 +609,10 @@
     <value>Kommaseparerade plattformsnamn som denna avdelning tillåter, eller * för alla. Giltiga namn: SmsTwilio, SmsSignalWire, Discord, Slack, Telegram, WhatsApp, Teams, Signal, WebChat.</value>
   </data>
   <data name="ChatbotAllowDispatch" xml:space="preserve">
-    <value>Tillåt utlarmning via chatboten</value>
+    <value>Tillåt utlarmning via assistenten</value>
   </data>
   <data name="ChatbotAllowDispatchHelp" xml:space="preserve">
-    <value>Tillåt behöriga användare att skapa eller larma ut ärenden via chatboten.</value>
+    <value>Tillåt behöriga användare att skapa eller larma ut ärenden via assistenten.</value>
   </data>
   <data name="ChatbotConfirmStatusChanges" xml:space="preserve">
     <value>Bekräfta statusändringar</value>
@@ -630,7 +630,7 @@
     <value>Proaktiva aviseringar</value>
   </data>
   <data name="ChatbotProactiveNotificationsHelp" xml:space="preserve">
-    <value>Tillåt chatboten att skicka proaktiva aviseringar (ärenden, påminnelser) till kopplade användare.</value>
+    <value>Tillåt assistenten att skicka proaktiva aviseringar (ärenden, påminnelser) till kopplade användare.</value>
   </data>
   <data name="ChatbotMessagesPerUser" xml:space="preserve">
     <value>Meddelanden / användare / minut</value>
@@ -648,7 +648,7 @@
     <value>Avdelningens AI-/LLM-leverantör (valfritt)</value>
   </data>
   <data name="ChatbotLlmIntro" xml:space="preserve">
-    <value>Lämna dessa tomma för att använda Resgrids system-AI-leverantör. För att behålla din chatbots bearbetning hos din egen leverantör, ange en OpenAI-kompatibel slutpunkt, modell och API-nyckel.</value>
+    <value>Lämna dessa tomma för att använda Resgrids system-AI-leverantör. För att behålla din assistents bearbetning hos din egen leverantör, ange en OpenAI-kompatibel slutpunkt, modell och API-nyckel.</value>
   </data>
   <data name="ChatbotLlmEndpoint" xml:space="preserve">
     <value>LLM-slutpunkt</value>
@@ -672,10 +672,10 @@
     <value>Avbryt</value>
   </data>
   <data name="ChatbotSaved" xml:space="preserve">
-    <value>Chatbot-inställningarna sparades.</value>
+    <value>Assistentinställningarna sparades.</value>
   </data>
   <data name="ChatbotSaveError" xml:space="preserve">
-    <value>Ett fel uppstod när dina chatbot-inställningar skulle sparas.</value>
+    <value>Ett fel uppstod när dina assistentinställningar skulle sparas.</value>
   </data>
   <data name="EnableModernNotifications" xml:space="preserve">
     <value>Enable Modern Notifications</value>
@@ -687,6 +687,6 @@
     <value>Kräv säkerhets-PIN</value>
   </data>
   <data name="ForceChatbotSecurityPinHelp" xml:space="preserve">
-    <value>Kräver att varje medlem bekräftar farliga eller avdelningsövergripande chatbot-/SMS-åtgärder med sin personliga 4-siffriga säkerhets-PIN. Medlemmar utan PIN får en slumpmässigt genererad (visas på deras profilsida).</value>
+    <value>Kräver att varje medlem bekräftar farliga eller avdelningsövergripande assistent-/SMS-åtgärder med sin personliga 4-siffriga säkerhets-PIN. Medlemmar utan PIN får en slumpmässigt genererad (visas på deras profilsida).</value>
   </data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Department/Department.uk.resx
+++ b/Core/Resgrid.Localization/Areas/User/Department/Department.uk.resx
@@ -588,19 +588,19 @@
     <value>Зберегти Загальні Налаштування</value>
   </data>
   <data name="ChatbotSettingsHeader" xml:space="preserve">
-    <value>Налаштування чат-бота</value>
+    <value>Налаштування асистента</value>
   </data>
   <data name="ChatbotSettingsNav" xml:space="preserve">
-    <value>Чат-бот</value>
+    <value>Асистент</value>
   </data>
   <data name="ChatbotConfiguration" xml:space="preserve">
-    <value>Конфігурація чат-бота</value>
+    <value>Конфігурація асистента</value>
   </data>
   <data name="ChatbotEnable" xml:space="preserve">
-    <value>Увімкнути чат-бота</value>
+    <value>Увімкнути асистента</value>
   </data>
   <data name="ChatbotEnableHelp" xml:space="preserve">
-    <value>Дозволити учасникам цього підрозділу взаємодіяти з чат-ботом.</value>
+    <value>Дозволити учасникам цього підрозділу взаємодіяти з асистентом.</value>
   </data>
   <data name="ChatbotAllowedPlatforms" xml:space="preserve">
     <value>Дозволені платформи</value>
@@ -609,10 +609,10 @@
     <value>Назви платформ, розділені комами, дозволені для цього підрозділу, або * для всіх. Дійсні назви: SmsTwilio, SmsSignalWire, Discord, Slack, Telegram, WhatsApp, Teams, Signal, WebChat.</value>
   </data>
   <data name="ChatbotAllowDispatch" xml:space="preserve">
-    <value>Дозволити диспетчеризацію через чат-бот</value>
+    <value>Дозволити диспетчеризацію через асистент</value>
   </data>
   <data name="ChatbotAllowDispatchHelp" xml:space="preserve">
-    <value>Дозволити уповноваженим користувачам створювати або диспетчеризувати виклики через чат-бот.</value>
+    <value>Дозволити уповноваженим користувачам створювати або диспетчеризувати виклики через асистент.</value>
   </data>
   <data name="ChatbotConfirmStatusChanges" xml:space="preserve">
     <value>Підтверджувати зміни статусу</value>
@@ -630,7 +630,7 @@
     <value>Проактивні сповіщення</value>
   </data>
   <data name="ChatbotProactiveNotificationsHelp" xml:space="preserve">
-    <value>Дозволити чат-боту надсилати проактивні сповіщення (виклики, нагадування) прив'язаним користувачам.</value>
+    <value>Дозволити асистенту надсилати проактивні сповіщення (виклики, нагадування) прив'язаним користувачам.</value>
   </data>
   <data name="ChatbotMessagesPerUser" xml:space="preserve">
     <value>Повідомлення / користувач / хвилина</value>
@@ -648,7 +648,7 @@
     <value>Постачальник ШІ / LLM підрозділу (необов'язково)</value>
   </data>
   <data name="ChatbotLlmIntro" xml:space="preserve">
-    <value>Залиште ці поля порожніми, щоб використовувати системного постачальника ШІ Resgrid. Щоб обробка вашого чат-бота залишалася у вашого власного постачальника, введіть сумісну з OpenAI кінцеву точку, модель і ключ API.</value>
+    <value>Залиште ці поля порожніми, щоб використовувати системного постачальника ШІ Resgrid. Щоб обробка вашого асистента залишалася у вашого власного постачальника, введіть сумісну з OpenAI кінцеву точку, модель і ключ API.</value>
   </data>
   <data name="ChatbotLlmEndpoint" xml:space="preserve">
     <value>Кінцева точка LLM</value>
@@ -672,10 +672,10 @@
     <value>Скасувати</value>
   </data>
   <data name="ChatbotSaved" xml:space="preserve">
-    <value>Налаштування чат-бота збережено.</value>
+    <value>Налаштування асистента збережено.</value>
   </data>
   <data name="ChatbotSaveError" xml:space="preserve">
-    <value>Під час збереження налаштувань чат-бота сталася помилка.</value>
+    <value>Під час збереження налаштувань асистента сталася помилка.</value>
   </data>
   <data name="EnableModernNotifications" xml:space="preserve">
     <value>Enable Modern Notifications</value>
@@ -687,6 +687,6 @@
     <value>Вимагати PIN-код безпеки</value>
   </data>
   <data name="ForceChatbotSecurityPinHelp" xml:space="preserve">
-    <value>Вимагає, щоб кожен учасник підтверджував небезпечні або загальновідомчі дії чат-бота/SMS своїм особистим 4-значним PIN-кодом безпеки. Учасники без PIN-коду отримують випадково згенерований (доступний на сторінці профілю).</value>
+    <value>Вимагає, щоб кожен учасник підтверджував небезпечні або загальновідомчі дії асистента/SMS своїм особистим 4-значним PIN-кодом безпеки. Учасники без PIN-коду отримують випадково згенерований (доступний на сторінці профілю).</value>
   </data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Home/EditProfile.ar.resx
+++ b/Core/Resgrid.Localization/Areas/User/Home/EditProfile.ar.resx
@@ -113,16 +113,16 @@
   <data name="PasswordRequirementsDigit" xml:space="preserve"><value>رقم واحد على الأقل</value></data>
   <data name="PasswordRequirementsCase" xml:space="preserve"><value>حرف كبير وحرف صغير على الأقل</value></data>
   <data name="SecurityPinEnabledHelp" xml:space="preserve">
-    <value>عند التفعيل، تطلب الإجراءات الخطرة عبر روبوت الدردشة/الرسائل النصية رمز PIN كخطوة أمان إضافية. إذا فعّلت هذا بدون رمز PIN، يتم إنشاء رمز عشوائي لك.</value>
+    <value>عند التفعيل، تطلب الإجراءات الخطرة عبر المساعد/الرسائل النصية رمز PIN كخطوة أمان إضافية. إذا فعّلت هذا بدون رمز PIN، يتم إنشاء رمز عشوائي لك.</value>
   </data>
   <data name="SecurityPinEnabledLabel" xml:space="preserve">
     <value>طلب رمز PIN الأمان</value>
   </data>
   <data name="SecurityPinForcedHelp" xml:space="preserve">
-    <value>يتطلب قسمك رمز PIN الأمان للإجراءات الخطرة عبر روبوت الدردشة/الرسائل النصية، لذلك يكون هذا الخيار مفعلاً دائمًا.</value>
+    <value>يتطلب قسمك رمز PIN الأمان للإجراءات الخطرة عبر المساعد/الرسائل النصية، لذلك يكون هذا الخيار مفعلاً دائمًا.</value>
   </data>
   <data name="SecurityPinHelp" xml:space="preserve">
-    <value>يؤكد رمز PIN الأمان المكون من 4 أرقام الإجراءات الخطرة أو على مستوى القسم التي تتم عبر الرسائل النصية أو روبوت الدردشة. تجنب الأرقام المتكررة (0000) والمتسلسلة (1234، 4321). اتركه فارغًا للاحتفاظ برمز PIN الحالي.</value>
+    <value>يؤكد رمز PIN الأمان المكون من 4 أرقام الإجراءات الخطرة أو على مستوى القسم التي تتم عبر الرسائل النصية أو المساعد. تجنب الأرقام المتكررة (0000) والمتسلسلة (1234، 4321). اتركه فارغًا للاحتفاظ برمز PIN الحالي.</value>
   </data>
   <data name="SecurityPinLabel" xml:space="preserve">
     <value>رمز PIN الأمان</value>

--- a/Core/Resgrid.Localization/Areas/User/Home/EditProfile.de.resx
+++ b/Core/Resgrid.Localization/Areas/User/Home/EditProfile.de.resx
@@ -381,16 +381,16 @@
   <data name="PasswordRequirementsDigit" xml:space="preserve"><value>Mindestens eine Ziffer (Zahl)</value></data>
   <data name="PasswordRequirementsCase" xml:space="preserve"><value>Mindestens ein Groß- und ein Kleinbuchstabe</value></data>
   <data name="SecurityPinEnabledHelp" xml:space="preserve">
-    <value>Wenn aktiviert, fragen gefährliche Chatbot-/SMS-Aktionen Ihre PIN als zusätzlichen Sicherheitsschritt ab. Wenn Sie dies ohne PIN aktivieren, wird eine zufällige PIN für Sie generiert.</value>
+    <value>Wenn aktiviert, fragen gefährliche Assistenten-/SMS-Aktionen Ihre PIN als zusätzlichen Sicherheitsschritt ab. Wenn Sie dies ohne PIN aktivieren, wird eine zufällige PIN für Sie generiert.</value>
   </data>
   <data name="SecurityPinEnabledLabel" xml:space="preserve">
     <value>Sicherheits-PIN erforderlich</value>
   </data>
   <data name="SecurityPinForcedHelp" xml:space="preserve">
-    <value>Ihre Abteilung verlangt eine Sicherheits-PIN für gefährliche Chatbot-/SMS-Aktionen, daher ist diese Option immer aktiviert.</value>
+    <value>Ihre Abteilung verlangt eine Sicherheits-PIN für gefährliche Assistenten-/SMS-Aktionen, daher ist diese Option immer aktiviert.</value>
   </data>
   <data name="SecurityPinHelp" xml:space="preserve">
-    <value>Ihre 4-stellige Sicherheits-PIN bestätigt gefährliche oder abteilungsweite Aktionen per SMS oder Chatbot. Vermeiden Sie wiederholte Ziffern (0000) und Folgen (1234, 4321). Leer lassen, um Ihre aktuelle PIN zu behalten.</value>
+    <value>Ihre 4-stellige Sicherheits-PIN bestätigt gefährliche oder abteilungsweite Aktionen per SMS oder Assistenten. Vermeiden Sie wiederholte Ziffern (0000) und Folgen (1234, 4321). Leer lassen, um Ihre aktuelle PIN zu behalten.</value>
   </data>
   <data name="SecurityPinLabel" xml:space="preserve">
     <value>Sicherheits-PIN</value>

--- a/Core/Resgrid.Localization/Areas/User/Home/EditProfile.en.resx
+++ b/Core/Resgrid.Localization/Areas/User/Home/EditProfile.en.resx
@@ -436,16 +436,16 @@
   <data name="PasswordRequirementsDigit" xml:space="preserve"><value>At least one digit (number)</value></data>
   <data name="PasswordRequirementsCase" xml:space="preserve"><value>At least one uppercase and one lowercase letter</value></data>
   <data name="SecurityPinEnabledHelp" xml:space="preserve">
-    <value>When enabled, dangerous chatbot/text actions ask for your PIN as an extra security step. If you enable this without a PIN a random one is generated for you.</value>
+    <value>When enabled, dangerous assistant/text actions ask for your PIN as an extra security step. If you enable this without a PIN a random one is generated for you.</value>
   </data>
   <data name="SecurityPinEnabledLabel" xml:space="preserve">
     <value>Require Security PIN</value>
   </data>
   <data name="SecurityPinForcedHelp" xml:space="preserve">
-    <value>Your department requires a security PIN for dangerous chatbot/text actions, so this option is always on.</value>
+    <value>Your department requires a security PIN for dangerous assistant/text actions, so this option is always on.</value>
   </data>
   <data name="SecurityPinHelp" xml:space="preserve">
-    <value>Your 4-digit security PIN confirms dangerous or department-wide actions performed over text message or chatbot. Avoid repeated digits (0000) and sequences (1234, 4321). Leave blank to keep your current PIN.</value>
+    <value>Your 4-digit security PIN confirms dangerous or department-wide actions performed over text message or assistant. Avoid repeated digits (0000) and sequences (1234, 4321). Leave blank to keep your current PIN.</value>
   </data>
   <data name="SecurityPinLabel" xml:space="preserve">
     <value>Security PIN</value>

--- a/Core/Resgrid.Localization/Areas/User/Home/EditProfile.es.resx
+++ b/Core/Resgrid.Localization/Areas/User/Home/EditProfile.es.resx
@@ -427,16 +427,16 @@
   <data name="PasswordRequirementsDigit" xml:space="preserve"><value>Al menos un dígito (número)</value></data>
   <data name="PasswordRequirementsCase" xml:space="preserve"><value>Al menos una letra mayúscula y una minúscula</value></data>
   <data name="SecurityPinEnabledHelp" xml:space="preserve">
-    <value>Cuando está activado, las acciones peligrosas de chatbot/mensajes de texto solicitan su PIN como paso de seguridad adicional. Si lo activa sin un PIN, se genera uno aleatorio para usted.</value>
+    <value>Cuando está activado, las acciones peligrosas de asistente/mensajes de texto solicitan su PIN como paso de seguridad adicional. Si lo activa sin un PIN, se genera uno aleatorio para usted.</value>
   </data>
   <data name="SecurityPinEnabledLabel" xml:space="preserve">
     <value>Requerir PIN de seguridad</value>
   </data>
   <data name="SecurityPinForcedHelp" xml:space="preserve">
-    <value>Su departamento requiere un PIN de seguridad para acciones peligrosas de chatbot/mensajes de texto, por lo que esta opción está siempre activada.</value>
+    <value>Su departamento requiere un PIN de seguridad para acciones peligrosas de asistente/mensajes de texto, por lo que esta opción está siempre activada.</value>
   </data>
   <data name="SecurityPinHelp" xml:space="preserve">
-    <value>Su PIN de seguridad de 4 dígitos confirma acciones peligrosas o de todo el departamento realizadas por mensaje de texto o chatbot. Evite dígitos repetidos (0000) y secuencias (1234, 4321). Déjelo en blanco para conservar su PIN actual.</value>
+    <value>Su PIN de seguridad de 4 dígitos confirma acciones peligrosas o de todo el departamento realizadas por mensaje de texto o asistente. Evite dígitos repetidos (0000) y secuencias (1234, 4321). Déjelo en blanco para conservar su PIN actual.</value>
   </data>
   <data name="SecurityPinLabel" xml:space="preserve">
     <value>PIN de seguridad</value>

--- a/Core/Resgrid.Localization/Areas/User/Home/EditProfile.fr.resx
+++ b/Core/Resgrid.Localization/Areas/User/Home/EditProfile.fr.resx
@@ -381,16 +381,16 @@
   <data name="PasswordRequirementsDigit" xml:space="preserve"><value>Au moins un chiffre</value></data>
   <data name="PasswordRequirementsCase" xml:space="preserve"><value>Au moins une lettre majuscule et une minuscule</value></data>
   <data name="SecurityPinEnabledHelp" xml:space="preserve">
-    <value>Lorsqu'elle est activée, les actions dangereuses du chatbot/SMS demandent votre PIN comme étape de sécurité supplémentaire. Si vous l'activez sans PIN, un code aléatoire est généré pour vous.</value>
+    <value>Lorsqu'elle est activée, les actions dangereuses de l'assistant/SMS demandent votre PIN comme étape de sécurité supplémentaire. Si vous l'activez sans PIN, un code aléatoire est généré pour vous.</value>
   </data>
   <data name="SecurityPinEnabledLabel" xml:space="preserve">
     <value>Exiger le code PIN de sécurité</value>
   </data>
   <data name="SecurityPinForcedHelp" xml:space="preserve">
-    <value>Votre service exige un code PIN de sécurité pour les actions dangereuses du chatbot/SMS, cette option est donc toujours activée.</value>
+    <value>Votre service exige un code PIN de sécurité pour les actions dangereuses de l'assistant/SMS, cette option est donc toujours activée.</value>
   </data>
   <data name="SecurityPinHelp" xml:space="preserve">
-    <value>Votre code PIN de sécurité à 4 chiffres confirme les actions dangereuses ou à l'échelle du service effectuées par SMS ou chatbot. Évitez les chiffres répétés (0000) et les séquences (1234, 4321). Laissez vide pour conserver votre PIN actuel.</value>
+    <value>Votre code PIN de sécurité à 4 chiffres confirme les actions dangereuses ou à l'échelle du service effectuées par SMS ou assistant. Évitez les chiffres répétés (0000) et les séquences (1234, 4321). Laissez vide pour conserver votre PIN actuel.</value>
   </data>
   <data name="SecurityPinLabel" xml:space="preserve">
     <value>Code PIN de sécurité</value>

--- a/Core/Resgrid.Localization/Areas/User/Home/EditProfile.it.resx
+++ b/Core/Resgrid.Localization/Areas/User/Home/EditProfile.it.resx
@@ -381,16 +381,16 @@
   <data name="PasswordRequirementsDigit" xml:space="preserve"><value>Almeno una cifra (numero)</value></data>
   <data name="PasswordRequirementsCase" xml:space="preserve"><value>Almeno una lettera maiuscola e una minuscola</value></data>
   <data name="SecurityPinEnabledHelp" xml:space="preserve">
-    <value>Se attivato, le azioni pericolose di chatbot/SMS richiedono il tuo PIN come passaggio di sicurezza aggiuntivo. Se lo attivi senza un PIN, ne viene generato uno casuale per te.</value>
+    <value>Se attivato, le azioni pericolose dell'assistente/SMS richiedono il tuo PIN come passaggio di sicurezza aggiuntivo. Se lo attivi senza un PIN, ne viene generato uno casuale per te.</value>
   </data>
   <data name="SecurityPinEnabledLabel" xml:space="preserve">
     <value>Richiedi PIN di sicurezza</value>
   </data>
   <data name="SecurityPinForcedHelp" xml:space="preserve">
-    <value>Il tuo dipartimento richiede un PIN di sicurezza per le azioni pericolose di chatbot/SMS, quindi questa opzione è sempre attiva.</value>
+    <value>Il tuo dipartimento richiede un PIN di sicurezza per le azioni pericolose dell'assistente/SMS, quindi questa opzione è sempre attiva.</value>
   </data>
   <data name="SecurityPinHelp" xml:space="preserve">
-    <value>Il tuo PIN di sicurezza a 4 cifre conferma le azioni pericolose o a livello di dipartimento eseguite tramite SMS o chatbot. Evita cifre ripetute (0000) e sequenze (1234, 4321). Lascia vuoto per mantenere il PIN attuale.</value>
+    <value>Il tuo PIN di sicurezza a 4 cifre conferma le azioni pericolose o a livello di dipartimento eseguite tramite SMS o assistente. Evita cifre ripetute (0000) e sequenze (1234, 4321). Lascia vuoto per mantenere il PIN attuale.</value>
   </data>
   <data name="SecurityPinLabel" xml:space="preserve">
     <value>PIN di sicurezza</value>

--- a/Core/Resgrid.Localization/Areas/User/Home/EditProfile.pl.resx
+++ b/Core/Resgrid.Localization/Areas/User/Home/EditProfile.pl.resx
@@ -381,16 +381,16 @@
   <data name="PasswordRequirementsDigit" xml:space="preserve"><value>Co najmniej jedna cyfra</value></data>
   <data name="PasswordRequirementsCase" xml:space="preserve"><value>Co najmniej jedna wielka i jedna mała litera</value></data>
   <data name="SecurityPinEnabledHelp" xml:space="preserve">
-    <value>Po włączeniu niebezpieczne akcje chatbota/SMS wymagają podania kodu PIN jako dodatkowego zabezpieczenia. Jeśli włączysz tę opcję bez kodu PIN, zostanie wygenerowany losowy.</value>
+    <value>Po włączeniu niebezpieczne akcje asystenta/SMS wymagają podania kodu PIN jako dodatkowego zabezpieczenia. Jeśli włączysz tę opcję bez kodu PIN, zostanie wygenerowany losowy.</value>
   </data>
   <data name="SecurityPinEnabledLabel" xml:space="preserve">
     <value>Wymagaj kodu PIN bezpieczeństwa</value>
   </data>
   <data name="SecurityPinForcedHelp" xml:space="preserve">
-    <value>Twój wydział wymaga kodu PIN bezpieczeństwa dla niebezpiecznych akcji chatbota/SMS, więc ta opcja jest zawsze włączona.</value>
+    <value>Twój wydział wymaga kodu PIN bezpieczeństwa dla niebezpiecznych akcji asystenta/SMS, więc ta opcja jest zawsze włączona.</value>
   </data>
   <data name="SecurityPinHelp" xml:space="preserve">
-    <value>Twój 4-cyfrowy kod PIN bezpieczeństwa potwierdza niebezpieczne lub obejmujące cały wydział akcje wykonywane przez SMS lub chatbota. Unikaj powtarzających się cyfr (0000) i sekwencji (1234, 4321). Pozostaw puste, aby zachować obecny PIN.</value>
+    <value>Twój 4-cyfrowy kod PIN bezpieczeństwa potwierdza niebezpieczne lub obejmujące cały wydział akcje wykonywane przez SMS lub asystenta. Unikaj powtarzających się cyfr (0000) i sekwencji (1234, 4321). Pozostaw puste, aby zachować obecny PIN.</value>
   </data>
   <data name="SecurityPinLabel" xml:space="preserve">
     <value>Kod PIN bezpieczeństwa</value>

--- a/Core/Resgrid.Localization/Areas/User/Home/EditProfile.sv.resx
+++ b/Core/Resgrid.Localization/Areas/User/Home/EditProfile.sv.resx
@@ -381,16 +381,16 @@
   <data name="PasswordRequirementsDigit" xml:space="preserve"><value>Minst en siffra</value></data>
   <data name="PasswordRequirementsCase" xml:space="preserve"><value>Minst en stor och en liten bokstav</value></data>
   <data name="SecurityPinEnabledHelp" xml:space="preserve">
-    <value>När det är aktiverat begär farliga chatbot-/SMS-åtgärder din PIN som ett extra säkerhetssteg. Om du aktiverar detta utan PIN genereras en slumpmässig åt dig.</value>
+    <value>När det är aktiverat begär farliga assistent-/SMS-åtgärder din PIN som ett extra säkerhetssteg. Om du aktiverar detta utan PIN genereras en slumpmässig åt dig.</value>
   </data>
   <data name="SecurityPinEnabledLabel" xml:space="preserve">
     <value>Kräv säkerhets-PIN</value>
   </data>
   <data name="SecurityPinForcedHelp" xml:space="preserve">
-    <value>Din avdelning kräver en säkerhets-PIN för farliga chatbot-/SMS-åtgärder, så det här alternativet är alltid på.</value>
+    <value>Din avdelning kräver en säkerhets-PIN för farliga assistent-/SMS-åtgärder, så det här alternativet är alltid på.</value>
   </data>
   <data name="SecurityPinHelp" xml:space="preserve">
-    <value>Din 4-siffriga säkerhets-PIN bekräftar farliga eller avdelningsövergripande åtgärder som utförs via SMS eller chatbot. Undvik upprepade siffror (0000) och sekvenser (1234, 4321). Lämna tomt för att behålla din nuvarande PIN.</value>
+    <value>Din 4-siffriga säkerhets-PIN bekräftar farliga eller avdelningsövergripande åtgärder som utförs via SMS eller assistent. Undvik upprepade siffror (0000) och sekvenser (1234, 4321). Lämna tomt för att behålla din nuvarande PIN.</value>
   </data>
   <data name="SecurityPinLabel" xml:space="preserve">
     <value>Säkerhets-PIN</value>

--- a/Core/Resgrid.Localization/Areas/User/Home/EditProfile.uk.resx
+++ b/Core/Resgrid.Localization/Areas/User/Home/EditProfile.uk.resx
@@ -381,16 +381,16 @@
   <data name="PasswordRequirementsDigit" xml:space="preserve"><value>Щонайменше одна цифра</value></data>
   <data name="PasswordRequirementsCase" xml:space="preserve"><value>Щонайменше одна велика та одна мала літера</value></data>
   <data name="SecurityPinEnabledHelp" xml:space="preserve">
-    <value>Якщо ввімкнено, небезпечні дії чат-бота/SMS запитують ваш PIN як додатковий крок безпеки. Якщо ви ввімкнете це без PIN-коду, для вас буде згенеровано випадковий.</value>
+    <value>Якщо ввімкнено, небезпечні дії асистента/SMS запитують ваш PIN як додатковий крок безпеки. Якщо ви ввімкнете це без PIN-коду, для вас буде згенеровано випадковий.</value>
   </data>
   <data name="SecurityPinEnabledLabel" xml:space="preserve">
     <value>Вимагати PIN-код безпеки</value>
   </data>
   <data name="SecurityPinForcedHelp" xml:space="preserve">
-    <value>Ваш відділ вимагає PIN-код безпеки для небезпечних дій чат-бота/SMS, тому цей параметр завжди ввімкнено.</value>
+    <value>Ваш відділ вимагає PIN-код безпеки для небезпечних дій асистента/SMS, тому цей параметр завжди ввімкнено.</value>
   </data>
   <data name="SecurityPinHelp" xml:space="preserve">
-    <value>Ваш 4-значний PIN-код безпеки підтверджує небезпечні або загальновідомчі дії, виконані через SMS або чат-бот. Уникайте повторюваних цифр (0000) і послідовностей (1234, 4321). Залиште порожнім, щоб зберегти поточний PIN.</value>
+    <value>Ваш 4-значний PIN-код безпеки підтверджує небезпечні або загальновідомчі дії, виконані через SMS або асистент. Уникайте повторюваних цифр (0000) і послідовностей (1234, 4321). Залиште порожнім, щоб зберегти поточний PIN.</value>
   </data>
   <data name="SecurityPinLabel" xml:space="preserve">
     <value>PIN-код безпеки</value>

--- a/Web/Resgrid.Web.Services/Controllers/v4/ChatController.cs
+++ b/Web/Resgrid.Web.Services/Controllers/v4/ChatController.cs
@@ -51,6 +51,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 		private readonly IAuthorizationService _authorizationService;
 		private readonly ICacheProvider _cacheProvider;
 		private readonly IEventAggregator _eventAggregator;
+		private readonly IQueueService _queueService;
 
 		public ChatController(
 			IChatChannelService chatChannelService,
@@ -64,7 +65,8 @@ namespace Resgrid.Web.Services.Controllers.v4
 			IFeatureToggleService featureToggleService,
 			IAuthorizationService authorizationService,
 			ICacheProvider cacheProvider,
-			IEventAggregator eventAggregator)
+			IEventAggregator eventAggregator,
+			IQueueService queueService)
 		{
 			_chatChannelService = chatChannelService;
 			_chatPermissionService = chatPermissionService;
@@ -78,6 +80,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 			_authorizationService = authorizationService;
 			_cacheProvider = cacheProvider;
 			_eventAggregator = eventAggregator;
+			_queueService = queueService;
 		}
 
 		#endregion Members and Constructors
@@ -816,6 +819,32 @@ namespace Resgrid.Web.Services.Controllers.v4
 
 			if (message == null)
 				return BadRequest();
+
+			// The assistant channel is also reachable from the regular chat page, so sends that arrive
+			// through this generic endpoint must still feed the chatbot pipeline (the dedicated
+			// ChatbotController.SendChatMessage does the same for the assistant panel).
+			var channel = await _chatChannelService.GetChannelByIdAsync(channelId);
+			if (channel != null && channel.ChannelType == (int)ChatChannelType.Chatbot && !String.IsNullOrWhiteSpace(message.Body))
+			{
+				await _queueService.EnqueueChatbotMessageAsync(new Resgrid.Model.Queue.ChatbotMessageQueueItem
+				{
+					DepartmentId = DepartmentId,
+					From = UserId,
+					Body = message.Body,
+					MessageId = message.ChatMessageId,
+					Platform = (int)Resgrid.Chatbot.Models.ChatbotPlatform.WebChat
+				});
+
+				// Typing indicator to the user's devices while the worker runs the pipeline.
+				_eventAggregator.SendMessage<ChatEventRaised>(new ChatEventRaised
+				{
+					DepartmentId = DepartmentId,
+					ChatChannelId = channel.ChatChannelId,
+					Kind = ChatEventKinds.ChatbotTyping,
+					TargetUserId = UserId,
+					PayloadJson = Newtonsoft.Json.JsonConvert.SerializeObject(new { channel.ChatChannelId, IsTyping = true })
+				});
+			}
 
 			var result = new ChatMessageSentResult();
 			result.Data = (await ConvertMessagesAsync(new List<ChatMessage> { message })).FirstOrDefault();

--- a/Web/Resgrid.Web.Services/Controllers/v4/ChatController.cs
+++ b/Web/Resgrid.Web.Services/Controllers/v4/ChatController.cs
@@ -826,7 +826,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 			var channel = await _chatChannelService.GetChannelByIdAsync(channelId);
 			if (channel != null && channel.ChannelType == (int)ChatChannelType.Chatbot && !String.IsNullOrWhiteSpace(message.Body))
 			{
-				await _queueService.EnqueueChatbotMessageAsync(new Resgrid.Model.Queue.ChatbotMessageQueueItem
+				var queued = await _queueService.EnqueueChatbotMessageAsync(new Resgrid.Model.Queue.ChatbotMessageQueueItem
 				{
 					DepartmentId = DepartmentId,
 					From = UserId,
@@ -834,6 +834,19 @@ namespace Resgrid.Web.Services.Controllers.v4
 					MessageId = message.ChatMessageId,
 					Platform = (int)Resgrid.Chatbot.Models.ChatbotPlatform.WebChat
 				});
+
+				// The message persisted but the assistant will never see it; surface the failure the
+				// same way ChatbotController.SendChatMessage does instead of pretending it was sent.
+				if (!queued)
+				{
+					var failedResult = new ChatMessageSentResult();
+					failedResult.Data = (await ConvertMessagesAsync(new List<ChatMessage> { message })).FirstOrDefault();
+					failedResult.PageSize = 1;
+					failedResult.Status = ResponseHelper.Failure;
+
+					ResponseHelper.PopulateV4ResponseData(failedResult);
+					return StatusCode(StatusCodes.Status500InternalServerError, failedResult);
+				}
 
 				// Typing indicator to the user's devices while the worker runs the pipeline.
 				_eventAggregator.SendMessage<ChatEventRaised>(new ChatEventRaised

--- a/Web/Resgrid.Web.Services/Controllers/v4/ChatbotController.cs
+++ b/Web/Resgrid.Web.Services/Controllers/v4/ChatbotController.cs
@@ -470,7 +470,13 @@ namespace Resgrid.Web.Services.Controllers.v4
 				return false;
 
 			var settings = await _chatChannelService.GetDepartmentSettingsAsync(DepartmentId);
-			return settings == null || settings.ChatbotEnabled;
+			if (settings != null && !settings.ChatbotEnabled)
+				return false;
+
+			// Honor the admin toggle from Department Settings > Assistant. Matching the ingress
+			// pipeline's semantics, a missing config row means enabled.
+			var config = await _departmentConfigService.GetConfigAsync(DepartmentId);
+			return config == null || config.IsEnabled;
 		}
 
 		#endregion Web Chat conversation

--- a/Web/Resgrid.Web/Areas/User/Apps/src/components/chat/chatApi.ts
+++ b/Web/Resgrid.Web/Areas/User/Apps/src/components/chat/chatApi.ts
@@ -282,15 +282,17 @@ export async function flagMessage(messageId: string, reason: number, note: strin
 export async function getChatbotChannel(): Promise<ChatbotChannelInfo | null> {
   try {
     const raw = await getJson<Record<string, unknown>>('api/v4/Chatbot/GetChatChannel');
-    const channelId = (raw.ChatChannelId ?? raw.chatChannelId) as string | undefined;
+    // The v4 envelope nests the payload under Data; tolerate a flat payload too.
+    const data = ((raw.Data ?? raw.data) ?? raw) as Record<string, unknown>;
+    const channelId = (data.ChatChannelId ?? data.chatChannelId) as string | undefined;
     if (!channelId) {
       return null;
     }
     return {
       ChatChannelId: channelId,
-      Name: (raw.Name ?? raw.name ?? 'Assistant') as string,
-      LastMessageSeq: Number(raw.LastMessageSeq ?? raw.lastMessageSeq ?? 0),
-      LastMessageOn: (raw.LastMessageOn ?? raw.lastMessageOn ?? null) as string | null,
+      Name: (data.Name ?? data.name ?? 'Assistant') as string,
+      LastMessageSeq: Number(data.LastMessageSeq ?? data.lastMessageSeq ?? 0),
+      LastMessageOn: (data.LastMessageOn ?? data.lastMessageOn ?? null) as string | null,
     };
   } catch (error) {
     if (isApiStatus(error, 404)) {


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## PR Description

This pull request addresses several fixes and improvements for the chatbot feature (now referred to as "Assistant"):

### 1. Rebranding "Chatbot" to "Assistant"
Updates all user-facing text strings across the chatbot handlers, ingress services, and localization files (English, Arabic, German, Spanish, French, Italian, Polish, Swedish, Ukrainian) to replace the term "Chatbot" with "Assistant." This includes error messages, help text, system messages, department settings labels, and profile security PIN descriptions.

### 2. Fix: Assistant channel messages from regular chat now trigger the chatbot pipeline
When a user sends a message to the assistant (Chatbot-type) channel through the generic chat `SendMessage` endpoint (e.g., from the regular chat page), the message is now also enqueued to the chatbot processing pipeline. Previously, only the dedicated `ChatbotController` endpoint fed the pipeline, meaning messages sent from the standard chat UI to the assistant channel were not processed. A typing indicator is also sent to the user's devices while the pipeline runs.

### 3. Fix: Assistant chat now respects the department-level Assistant enable/disable toggle
The `ChatbotChatEnabledAsync` check in `ChatbotController` now additionally evaluates the `DepartmentConfig.IsEnabled` setting (from Department Settings > Assistant). Previously, it only checked the chat-specific `ChatbotEnabled` setting, allowing the assistant to remain accessible even when an administrator had disabled it at the department level.

### 4. Fix: Proper handling of v4 API envelope in chat API client
The `getChatbotChannel` function in the frontend chat API now correctly unwraps the response payload nested under the `Data` property of the v4 API envelope, while maintaining backward compatibility with flat payloads. This fixes issues where the assistant channel could not be properly resolved from the API response.
<!-- kody-pr-summary:end -->