### PR TITLE
Develop

### DIFF
--- a/Core/Resgrid.Model/Repositories/IChatRepositories.cs
+++ b/Core/Resgrid.Model/Repositories/IChatRepositories.cs
@@ -88,6 +88,9 @@ namespace Resgrid.Model.Repositories
 		/// <summary>Active (not removed) explicit memberships for a user across the department.</summary>
 		Task<IEnumerable<ChatChannelMember>> GetActiveByUserIdAsync(int departmentId, string userId);
 
+		/// <summary>Active (not removed) member rows for a set of channels in one query.</summary>
+		Task<IEnumerable<ChatChannelMember>> GetActiveByChannelIdsAsync(IEnumerable<string> chatChannelIds);
+
 		/// <summary>
 		/// Monotonic read/delivered pointer update: only advances when the supplied seq is higher than the
 		/// stored one (single UPDATE ... WHERE seq &lt; @seq).

--- a/Core/Resgrid.Model/Repositories/IChatRepositories.cs
+++ b/Core/Resgrid.Model/Repositories/IChatRepositories.cs
@@ -91,6 +91,9 @@ namespace Resgrid.Model.Repositories
 		/// <summary>Active (not removed) member rows for a set of channels in one query.</summary>
 		Task<IEnumerable<ChatChannelMember>> GetActiveByChannelIdsAsync(IEnumerable<string> chatChannelIds);
 
+		/// <summary>Active (not removed) unit-participant memberships for a unit across the department.</summary>
+		Task<IEnumerable<ChatChannelMember>> GetActiveByUnitIdAsync(int departmentId, int unitId);
+
 		/// <summary>
 		/// Monotonic read/delivered pointer update: only advances when the supplied seq is higher than the
 		/// stored one (single UPDATE ... WHERE seq &lt; @seq).

--- a/Core/Resgrid.Model/Services/IChatServices.cs
+++ b/Core/Resgrid.Model/Services/IChatServices.cs
@@ -59,6 +59,9 @@ namespace Resgrid.Model.Services
 		/// <summary>Active member rows for a set of channels in one query — used to label DM channels with the counterpart's name.</summary>
 		Task<List<ChatChannelMember>> GetActiveMembersForChannelsAsync(List<string> chatChannelIds);
 
+		/// <summary>A unit's active (not-removed) memberships across the department — read pointers/preferences for unit-participant channels.</summary>
+		Task<List<ChatChannelMember>> GetActiveMembershipsForUnitAsync(int departmentId, int unitId);
+
 		/// <summary>A user's member row for a single channel (null if none); does not lazily create one.</summary>
 		Task<ChatChannelMember> GetUserMembershipAsync(string chatChannelId, string userId);
 

--- a/Core/Resgrid.Model/Services/IChatServices.cs
+++ b/Core/Resgrid.Model/Services/IChatServices.cs
@@ -56,6 +56,9 @@ namespace Resgrid.Model.Services
 		/// <summary>A user's active (not-removed) explicit memberships across the department — used for unread/preference lookups.</summary>
 		Task<List<ChatChannelMember>> GetActiveMembershipsForUserAsync(int departmentId, string userId);
 
+		/// <summary>Active member rows for a set of channels in one query — used to label DM channels with the counterpart's name.</summary>
+		Task<List<ChatChannelMember>> GetActiveMembersForChannelsAsync(List<string> chatChannelIds);
+
 		/// <summary>A user's member row for a single channel (null if none); does not lazily create one.</summary>
 		Task<ChatChannelMember> GetUserMembershipAsync(string chatChannelId, string userId);
 
@@ -274,6 +277,21 @@ namespace Resgrid.Model.Services
 
 		/// <summary>Bulk presence lookup; returns the subset of userIds currently online.</summary>
 		Task<List<string>> GetOnlineUsersAsync(int departmentId, List<string> userIds);
+
+		/// <summary>
+		/// Records the channel the user currently has open (null/empty clears it). When the user is acting
+		/// as a unit, the unit's active channel is recorded too so rig-device pushes can be suppressed.
+		/// </summary>
+		Task SetActiveChannelAsync(int departmentId, string userId, string channelId, int? unitId = null);
+
+		/// <summary>Clears the user's (and their acting unit's) active-channel marker.</summary>
+		Task ClearActiveChannelAsync(int departmentId, string userId);
+
+		/// <summary>Bulk lookup: the subset of userIds actively viewing the given channel right now.</summary>
+		Task<List<string>> GetUsersActiveInChannelAsync(int departmentId, List<string> userIds, string channelId);
+
+		/// <summary>True when the unit's device currently has the given channel open.</summary>
+		Task<bool> IsUnitActiveInChannelAsync(int departmentId, int unitId, string channelId);
 	}
 
 	/// <summary>

--- a/Core/Resgrid.Services/ChatChannelService.cs
+++ b/Core/Resgrid.Services/ChatChannelService.cs
@@ -254,7 +254,12 @@ namespace Resgrid.Services
 				saved = await _chatChannelRepository.GetByDmKeyAsync(departmentId, dmKey);
 
 			if (saved != null && string.Equals(saved.ChatChannelId, channel.ChatChannelId, StringComparison.OrdinalIgnoreCase))
+			{
+				// Roll the channel-list cache version so both participants see the new DM on their
+				// next GetChannels instead of waiting out the 45s per-user list cache.
+				await _chatPermissionService.InvalidateChannelCacheAsync(saved.ChatChannelId);
 				PublishChannelEvent(saved, ChatEventKinds.ChannelProvisioned);
+			}
 
 			return saved;
 		}
@@ -291,6 +296,7 @@ namespace Resgrid.Services
 				await AddMemberRowAsync(channel, ChatParticipantType.User, memberId, null, null, creatorUserId, cancellationToken);
 			}
 
+			await _chatPermissionService.InvalidateChannelCacheAsync(channel.ChatChannelId);
 			PublishChannelEvent(channel, ChatEventKinds.ChannelProvisioned);
 
 			return channel;
@@ -327,6 +333,7 @@ namespace Resgrid.Services
 				}
 			}
 
+			await _chatPermissionService.InvalidateChannelCacheAsync(channel.ChatChannelId);
 			PublishChannelEvent(channel, ChatEventKinds.ChannelProvisioned);
 
 			return channel;
@@ -381,6 +388,15 @@ namespace Resgrid.Services
 		public async Task<List<ChatChannelMember>> GetActiveMembershipsForUserAsync(int departmentId, string userId)
 		{
 			var members = await _chatChannelMemberRepository.GetActiveByUserIdAsync(departmentId, userId);
+			return members?.ToList() ?? new List<ChatChannelMember>();
+		}
+
+		public async Task<List<ChatChannelMember>> GetActiveMembersForChannelsAsync(List<string> chatChannelIds)
+		{
+			if (chatChannelIds == null || chatChannelIds.Count == 0)
+				return new List<ChatChannelMember>();
+
+			var members = await _chatChannelMemberRepository.GetActiveByChannelIdsAsync(chatChannelIds);
 			return members?.ToList() ?? new List<ChatChannelMember>();
 		}
 

--- a/Core/Resgrid.Services/ChatChannelService.cs
+++ b/Core/Resgrid.Services/ChatChannelService.cs
@@ -158,7 +158,9 @@ namespace Resgrid.Services
 
 				// Channels where the active unit is the participant (Dispatch/IC ↔ unit DMs, units
 				// invited to groups) — the unit's operator must see them without a personal member row.
-				if (activeUnitId.HasValue)
+				// The caller-supplied unit only counts when the user actually crews it; otherwise any
+				// department member could list another unit's private channels.
+				if (activeUnitId.HasValue && await _chatPermissionService.CanSendAsUnitAsync(userId, activeUnitId.Value, departmentId))
 				{
 					var unitMemberships = await _chatChannelMemberRepository.GetActiveByUnitIdAsync(departmentId, activeUnitId.Value);
 					var unitChannelIds = unitMemberships?

--- a/Core/Resgrid.Services/ChatChannelService.cs
+++ b/Core/Resgrid.Services/ChatChannelService.cs
@@ -156,6 +156,25 @@ namespace Resgrid.Services
 							results[channel.ChatChannelId] = channel;
 				}
 
+				// Channels where the active unit is the participant (Dispatch/IC ↔ unit DMs, units
+				// invited to groups) — the unit's operator must see them without a personal member row.
+				if (activeUnitId.HasValue)
+				{
+					var unitMemberships = await _chatChannelMemberRepository.GetActiveByUnitIdAsync(departmentId, activeUnitId.Value);
+					var unitChannelIds = unitMemberships?
+						.Select(m => m.ChatChannelId)
+						.Distinct()
+						.Where(id => !results.ContainsKey(id))
+						.ToList();
+					if (unitChannelIds != null && unitChannelIds.Count > 0)
+					{
+						var channels = await _chatChannelRepository.GetByIdsAsync(unitChannelIds);
+						if (channels != null)
+							foreach (var channel in channels)
+								results[channel.ChatChannelId] = channel;
+					}
+				}
+
 				// Implicit-audience channels (custom rule-based + active incident channels): evaluate access
 				// per channel; evaluations are cached by the permission service.
 				if (allChannels != null)
@@ -388,6 +407,12 @@ namespace Resgrid.Services
 		public async Task<List<ChatChannelMember>> GetActiveMembershipsForUserAsync(int departmentId, string userId)
 		{
 			var members = await _chatChannelMemberRepository.GetActiveByUserIdAsync(departmentId, userId);
+			return members?.ToList() ?? new List<ChatChannelMember>();
+		}
+
+		public async Task<List<ChatChannelMember>> GetActiveMembershipsForUnitAsync(int departmentId, int unitId)
+		{
+			var members = await _chatChannelMemberRepository.GetActiveByUnitIdAsync(departmentId, unitId);
 			return members?.ToList() ?? new List<ChatChannelMember>();
 		}
 

--- a/Core/Resgrid.Services/ChatMessageService.cs
+++ b/Core/Resgrid.Services/ChatMessageService.cs
@@ -693,8 +693,11 @@ namespace Resgrid.Services
 
 			if (asUnitId.HasValue)
 			{
+				// Multiple people can be logged in as the same unit — keep the individual visible
+				// ("Engine 6 (Alice Smith)") so dispatchers and IC know who is typing.
 				var unit = await _unitsService.GetUnitByIdAsync(asUnitId.Value);
-				return unit?.Name ?? profileName ?? "Unit";
+				var unitName = unit?.Name ?? "Unit";
+				return string.IsNullOrWhiteSpace(profileName) ? unitName : $"{unitName} ({profileName})";
 			}
 
 			if (asIncidentCommander)

--- a/Core/Resgrid.Services/ChatNotificationService.cs
+++ b/Core/Resgrid.Services/ChatNotificationService.cs
@@ -72,9 +72,11 @@ namespace Resgrid.Services
 				mentions?.Where(m => m.MentionType == (int)ChatMentionType.User && !string.IsNullOrWhiteSpace(m.TargetUserId)).Select(m => m.TargetUserId) ?? Enumerable.Empty<string>(),
 				StringComparer.OrdinalIgnoreCase);
 
-			// Presence suppression: online users already get the message over SignalR.
-			var onlineUsers = new HashSet<string>(
-				await _chatPresenceService.GetOnlineUsersAsync(channel.DepartmentId, audience),
+			// Active-channel suppression: only viewers with THIS conversation open are skipped — they see
+			// the message live over SignalR. Online-but-elsewhere users still get a push so background
+			// channels can alert them.
+			var activeUsers = new HashSet<string>(
+				await _chatPresenceService.GetUsersActiveInChannelAsync(channel.DepartmentId, audience, channel.ChatChannelId),
 				StringComparer.OrdinalIgnoreCase);
 
 			var isDm = channel.ChannelType == (int)ChatChannelType.DirectMessage;
@@ -100,7 +102,7 @@ namespace Resgrid.Services
 					if (string.Equals(userId, message.SenderUserId, StringComparison.OrdinalIgnoreCase))
 						continue;
 
-					if (onlineUsers.Contains(userId))
+					if (activeUsers.Contains(userId))
 						continue;
 
 					membersByUser.TryGetValue(userId, out var member);
@@ -117,6 +119,9 @@ namespace Resgrid.Services
 				foreach (var unitMember in memberRows.Where(m => m.ParticipantType == (int)ChatParticipantType.Unit && m.UnitId.HasValue && !m.RemovedOn.HasValue && !m.IsBanned))
 				{
 					if (message.SenderUnitId.HasValue && message.SenderUnitId.Value == unitMember.UnitId.Value)
+						continue;
+
+					if (await _chatPresenceService.IsUnitActiveInChannelAsync(channel.DepartmentId, unitMember.UnitId.Value, channel.ChatChannelId))
 						continue;
 
 					if (!ShouldNotify(unitMember, isUrgent, urgentOverridesMute, mentionedEveryone))

--- a/Core/Resgrid.Services/ChatPermissionService.cs
+++ b/Core/Resgrid.Services/ChatPermissionService.cs
@@ -246,7 +246,14 @@ namespace Resgrid.Services
 
 				case ChatChannelType.DirectMessage:
 				case ChatChannelType.AdHocGroup:
-					return await HasActiveMembershipAsync(channel.ChatChannelId, userId, activeUnitId);
+					if (await HasActiveMembershipAsync(channel.ChatChannelId, userId, null))
+						return true;
+
+					// The unit's member row only grants access when the caller actually crews the claimed
+					// unit — a caller-supplied activeUnitId alone must not open another unit's channels.
+					return activeUnitId.HasValue
+						&& await CanSendAsUnitAsync(userId, activeUnitId.Value, channel.DepartmentId)
+						&& await HasActiveMembershipAsync(channel.ChatChannelId, userId, activeUnitId);
 
 				case ChatChannelType.DepartmentDefault:
 					return await _departmentsService.IsUserInDepartmentAsync(channel.DepartmentId, userId);

--- a/Core/Resgrid.Services/ChatPresenceService.cs
+++ b/Core/Resgrid.Services/ChatPresenceService.cs
@@ -35,6 +35,18 @@ namespace Resgrid.Services
 		public async Task TouchAsync(int departmentId, string userId)
 		{
 			await _cacheProvider.SetStringAsync(GetKey(departmentId, userId), "1", GetTtl());
+
+			// Keep the active-channel marker (and its unit mirror) alive across heartbeats so an open
+			// conversation stays "active" without the client re-invoking SetActiveChannel.
+			var active = await _cacheProvider.GetStringAsync(GetActiveKey(departmentId, userId));
+			if (!string.IsNullOrWhiteSpace(active))
+			{
+				await _cacheProvider.SetStringAsync(GetActiveKey(departmentId, userId), active, GetTtl());
+
+				var unitId = ParseUnitId(active);
+				if (unitId.HasValue)
+					await _cacheProvider.SetStringAsync(GetUnitActiveKey(departmentId, unitId.Value), ParseChannelId(active), GetTtl());
+			}
 		}
 
 		public async Task<bool> IsOnlineAsync(int departmentId, string userId)
@@ -77,9 +89,114 @@ namespace Resgrid.Services
 			return online;
 		}
 
+		public async Task SetActiveChannelAsync(int departmentId, string userId, string channelId, int? unitId = null)
+		{
+			var activeKey = GetActiveKey(departmentId, userId);
+			var existingUnitId = ParseUnitId(await _cacheProvider.GetStringAsync(activeKey));
+
+			if (string.IsNullOrWhiteSpace(channelId))
+			{
+				await _cacheProvider.RemoveAsync(activeKey);
+				if (existingUnitId.HasValue)
+					await _cacheProvider.RemoveAsync(GetUnitActiveKey(departmentId, existingUnitId.Value));
+				return;
+			}
+
+			// Acting unit changed (or dropped): clear the stale unit marker so the old rig isn't suppressed.
+			if (existingUnitId.HasValue && existingUnitId != unitId)
+				await _cacheProvider.RemoveAsync(GetUnitActiveKey(departmentId, existingUnitId.Value));
+
+			var value = unitId.HasValue ? $"{channelId}|{unitId.Value}" : channelId;
+			await _cacheProvider.SetStringAsync(activeKey, value, GetTtl());
+
+			if (unitId.HasValue)
+				await _cacheProvider.SetStringAsync(GetUnitActiveKey(departmentId, unitId.Value), channelId, GetTtl());
+		}
+
+		public async Task ClearActiveChannelAsync(int departmentId, string userId)
+		{
+			await SetActiveChannelAsync(departmentId, userId, null);
+		}
+
+		public async Task<List<string>> GetUsersActiveInChannelAsync(int departmentId, List<string> userIds, string channelId)
+		{
+			var active = new List<string>();
+
+			if (userIds == null || userIds.Count == 0 || string.IsNullOrWhiteSpace(channelId))
+				return active;
+
+			using (var throttler = new SemaphoreSlim(8))
+			{
+				async Task LookupAsync(string userId)
+				{
+					await throttler.WaitAsync();
+					try
+					{
+						var value = await _cacheProvider.GetStringAsync(GetActiveKey(departmentId, userId));
+						if (string.Equals(ParseChannelId(value), channelId, StringComparison.OrdinalIgnoreCase))
+							lock (active)
+								active.Add(userId);
+					}
+					finally
+					{
+						throttler.Release();
+					}
+				}
+
+				var lookups = new List<Task>();
+				foreach (var userId in userIds)
+					lookups.Add(LookupAsync(userId));
+
+				await Task.WhenAll(lookups);
+			}
+
+			return active;
+		}
+
+		public async Task<bool> IsUnitActiveInChannelAsync(int departmentId, int unitId, string channelId)
+		{
+			if (unitId <= 0 || string.IsNullOrWhiteSpace(channelId))
+				return false;
+
+			var value = await _cacheProvider.GetStringAsync(GetUnitActiveKey(departmentId, unitId));
+			return string.Equals(value, channelId, StringComparison.OrdinalIgnoreCase);
+		}
+
+		// Active markers store "channelId" or "channelId|unitId" when the viewer is acting as a unit.
+		private static string ParseChannelId(string value)
+		{
+			if (string.IsNullOrWhiteSpace(value))
+				return null;
+
+			var separator = value.IndexOf('|');
+			return separator < 0 ? value : value.Substring(0, separator);
+		}
+
+		private static int? ParseUnitId(string value)
+		{
+			if (string.IsNullOrWhiteSpace(value))
+				return null;
+
+			var separator = value.IndexOf('|');
+			if (separator < 0 || separator >= value.Length - 1)
+				return null;
+
+			return int.TryParse(value.Substring(separator + 1), out var unitId) ? unitId : (int?)null;
+		}
+
 		private static string GetKey(int departmentId, string userId)
 		{
 			return $"chatpresence:{departmentId}:{userId?.ToLowerInvariant()}";
+		}
+
+		private static string GetActiveKey(int departmentId, string userId)
+		{
+			return $"chatactive:{departmentId}:{userId?.ToLowerInvariant()}";
+		}
+
+		private static string GetUnitActiveKey(int departmentId, int unitId)
+		{
+			return $"chatactiveunit:{departmentId}:{unitId}";
 		}
 
 		private static TimeSpan GetTtl()

--- a/Core/Resgrid.Services/ChatPresenceService.cs
+++ b/Core/Resgrid.Services/ChatPresenceService.cs
@@ -45,7 +45,7 @@ namespace Resgrid.Services
 
 				var unitId = ParseUnitId(active);
 				if (unitId.HasValue)
-					await _cacheProvider.SetStringAsync(GetUnitActiveKey(departmentId, unitId.Value), ParseChannelId(active), GetTtl());
+					await ClaimUnitMarkerAsync(departmentId, unitId.Value, ParseChannelId(active), userId, refreshOnly: true);
 			}
 		}
 
@@ -98,19 +98,19 @@ namespace Resgrid.Services
 			{
 				await _cacheProvider.RemoveAsync(activeKey);
 				if (existingUnitId.HasValue)
-					await _cacheProvider.RemoveAsync(GetUnitActiveKey(departmentId, existingUnitId.Value));
+					await RemoveUnitMarkerIfOwnedAsync(departmentId, existingUnitId.Value, userId);
 				return;
 			}
 
 			// Acting unit changed (or dropped): clear the stale unit marker so the old rig isn't suppressed.
 			if (existingUnitId.HasValue && existingUnitId != unitId)
-				await _cacheProvider.RemoveAsync(GetUnitActiveKey(departmentId, existingUnitId.Value));
+				await RemoveUnitMarkerIfOwnedAsync(departmentId, existingUnitId.Value, userId);
 
 			var value = unitId.HasValue ? $"{channelId}|{unitId.Value}" : channelId;
 			await _cacheProvider.SetStringAsync(activeKey, value, GetTtl());
 
 			if (unitId.HasValue)
-				await _cacheProvider.SetStringAsync(GetUnitActiveKey(departmentId, unitId.Value), channelId, GetTtl());
+				await ClaimUnitMarkerAsync(departmentId, unitId.Value, channelId, userId, refreshOnly: false);
 		}
 
 		public async Task ClearActiveChannelAsync(int departmentId, string userId)
@@ -158,11 +158,64 @@ namespace Resgrid.Services
 			if (unitId <= 0 || string.IsNullOrWhiteSpace(channelId))
 				return false;
 
-			var value = await _cacheProvider.GetStringAsync(GetUnitActiveKey(departmentId, unitId));
-			return string.Equals(value, channelId, StringComparison.OrdinalIgnoreCase);
+			var marker = await _cacheProvider.GetStringAsync(GetUnitActiveKey(departmentId, unitId));
+			var owner = ParseUnitMarkerOwner(marker);
+
+			if (owner == null || !string.Equals(ParseChannelId(marker), channelId, StringComparison.OrdinalIgnoreCase))
+				return false;
+
+			// The marker is only a hint naming its owner; the owner's personal marker is authoritative.
+			// An orphaned marker (owner moved on, or clobbered by a raced write) must not suppress pushes.
+			var ownerActive = await _cacheProvider.GetStringAsync(GetActiveKey(departmentId, owner));
+			return ParseUnitId(ownerActive) == unitId
+				&& string.Equals(ParseChannelId(ownerActive), channelId, StringComparison.OrdinalIgnoreCase);
+		}
+
+		// Several viewers can operate the same unit, but the unit mirror is a single shared key — so it
+		// records WHOSE activity it reflects ("channelId|ownerUserId") and is only refreshed or removed
+		// by that owner. ICacheProvider has no compare-and-set, so the owner checks are best-effort
+		// read-then-write; the short TTL and the owner cross-check in IsUnitActiveInChannelAsync bound
+		// the damage of a raced write to a few extra (never missing) pushes.
+		private async Task ClaimUnitMarkerAsync(int departmentId, int unitId, string channelId, string userId, bool refreshOnly)
+		{
+			var key = GetUnitActiveKey(departmentId, unitId);
+
+			if (refreshOnly)
+			{
+				var owner = ParseUnitMarkerOwner(await _cacheProvider.GetStringAsync(key));
+				if (owner != null && !string.Equals(owner, userId?.ToLowerInvariant(), StringComparison.OrdinalIgnoreCase))
+					return;
+			}
+
+			await _cacheProvider.SetStringAsync(key, $"{channelId}|{userId?.ToLowerInvariant()}", GetTtl());
+		}
+
+		private async Task RemoveUnitMarkerIfOwnedAsync(int departmentId, int unitId, string userId)
+		{
+			var key = GetUnitActiveKey(departmentId, unitId);
+			var owner = ParseUnitMarkerOwner(await _cacheProvider.GetStringAsync(key));
+
+			// Another viewer of the same unit claimed the marker since — their activity stands.
+			if (owner != null && !string.Equals(owner, userId?.ToLowerInvariant(), StringComparison.OrdinalIgnoreCase))
+				return;
+
+			await _cacheProvider.RemoveAsync(key);
+		}
+
+		private static string ParseUnitMarkerOwner(string value)
+		{
+			if (string.IsNullOrWhiteSpace(value))
+				return null;
+
+			var separator = value.IndexOf('|');
+			if (separator < 0 || separator >= value.Length - 1)
+				return null;
+
+			return value.Substring(separator + 1);
 		}
 
 		// Active markers store "channelId" or "channelId|unitId" when the viewer is acting as a unit.
+		// The unit mirror key stores "channelId|ownerUserId" (see ClaimUnitMarkerAsync).
 		private static string ParseChannelId(string value)
 		{
 			if (string.IsNullOrWhiteSpace(value))

--- a/Core/Resgrid.Services/DepartmentGroupsService.cs
+++ b/Core/Resgrid.Services/DepartmentGroupsService.cs
@@ -105,42 +105,8 @@ namespace Resgrid.Services
 
 		public async Task<List<DepartmentGroup>> GetAllGroupsForDepartmentAsync(int departmentId)
 		{
-			//List<DepartmentGroup> departmentGroups = new List<DepartmentGroup>();
-
-			//var groups = await GetAllGroupsForDepartmentUnlimitedAsync(departmentId);
-
-			//int limit = 0;
-			//if (Config.SystemBehaviorConfig.RedirectHomeToLogin)
-			//	limit = int.MaxValue;
-			//else
-			//	limit = (await _subscriptionsService.GetCurrentPlanForDepartmentAsync(departmentId)).GetLimitForTypeAsInt(PlanLimitTypes.Groups);
-
-			//int count = groups.Count < limit ? groups.Count : limit;
-
-			//// Only return users up to the plans group limit
-			//for (int i = 0; i < count; i++)
-			//{
-			//	departmentGroups.Add(groups[i]);
-			//}
-
-			var departmentGroups = await GetAllGroupsForDepartmentUnlimitedAsync(departmentId);
-
-			foreach (var group in departmentGroups)
-			{
-				if (group.ParentDepartmentGroupId.HasValue)
-				{
-					group.Parent = await GetGroupByIdAsync(group.ParentDepartmentGroupId.Value, false);
-				}
-
-				var childGroups = await _departmentGroupsRepository.GetAllGroupsByParentGroupIdAsync(group.DepartmentGroupId);
-
-				if (childGroups != null && childGroups.Any())
-					group.Children = childGroups.ToList();
-				else
-					group.Children = new List<DepartmentGroup>();
-			}
-
-			return departmentGroups;
+			// GetAllGroupsForDepartmentUnlimitedAsync already resolves addresses, parents and children
+			return await GetAllGroupsForDepartmentUnlimitedAsync(departmentId);
 		}
 
 		public async Task InvalidateGroupInCache(int groupId)
@@ -150,27 +116,73 @@ namespace Resgrid.Services
 
 		public async Task<List<DepartmentGroup>> GetAllGroupsForDepartmentUnlimitedAsync(int departmentId)
 		{
-			var groups = await _departmentGroupsRepository.GetAllGroupsByDepartmentIdAsync(departmentId);
+			// Repository returns null when the underlying query throws (it logs and swallows)
+			var groups = (await _departmentGroupsRepository.GetAllGroupsByDepartmentIdAsync(departmentId))?.ToList();
+
+			if (groups == null)
+				return new List<DepartmentGroup>();
+
+			foreach (var addressId in groups.Where(x => x.AddressId.HasValue && x.Address == null).Select(x => x.AddressId.Value).Distinct().ToList())
+			{
+				var address = await _addressService.GetAddressByIdAsync(addressId);
+
+				foreach (var g in groups.Where(x => x.AddressId == addressId && x.Address == null))
+					g.Address = address;
+			}
+
+			// The result set already contains every group in the department, so parent and
+			// child links resolve in memory instead of issuing per-group queries.
+			var groupsById = groups.ToDictionary(x => x.DepartmentGroupId);
+			var childrenByParentId = groups
+				.Where(x => x.ParentDepartmentGroupId.HasValue)
+				.GroupBy(x => x.ParentDepartmentGroupId.Value)
+				.ToDictionary(x => x.Key, x => x.ToList());
 
 			foreach (var g in groups)
 			{
-				if (g.AddressId.HasValue && g.Address == null)
-					g.Address = await _addressService.GetAddressByIdAsync(g.AddressId.Value);
-
 				if (g.ParentDepartmentGroupId.HasValue)
 				{
-					g.Parent = await GetGroupByIdAsync(g.ParentDepartmentGroupId.Value, false);
+					if (groupsById.TryGetValue(g.ParentDepartmentGroupId.Value, out var parent))
+						g.Parent = CopyWithoutRelations(parent);
+					else
+						g.Parent = await GetGroupByIdAsync(g.ParentDepartmentGroupId.Value, false);
 				}
 
-				var childGroups = await _departmentGroupsRepository.GetAllGroupsByParentGroupIdAsync(g.DepartmentGroupId);
-
-				if (childGroups != null && childGroups.Any())
-					g.Children = childGroups.ToList();
+				if (childrenByParentId.TryGetValue(g.DepartmentGroupId, out var children))
+					g.Children = children;
 				else
 					g.Children = new List<DepartmentGroup>();
 			}
 
-			return groups.ToList();
+			return groups;
+		}
+
+		// Parent links point at a detached copy so the group graph stays acyclic;
+		// Children reference the shared in-memory list instances.
+		private static DepartmentGroup CopyWithoutRelations(DepartmentGroup group)
+		{
+			return new DepartmentGroup
+			{
+				DepartmentGroupId = group.DepartmentGroupId,
+				DepartmentId = group.DepartmentId,
+				Type = group.Type,
+				AddressId = group.AddressId,
+				Address = group.Address,
+				ParentDepartmentGroupId = group.ParentDepartmentGroupId,
+				Members = group.Members,
+				Name = group.Name,
+				Geofence = group.Geofence,
+				GeofenceColor = group.GeofenceColor,
+				DispatchEmail = group.DispatchEmail,
+				MessageEmail = group.MessageEmail,
+				Latitude = group.Latitude,
+				Longitude = group.Longitude,
+				What3Words = group.What3Words,
+				DispatchToPrinter = group.DispatchToPrinter,
+				PrinterData = group.PrinterData,
+				DispatchToFax = group.DispatchToFax,
+				FaxNumber = group.FaxNumber
+			};
 		}
 
 		public async Task<List<DepartmentGroup>> GetAllGroupsForDepartmentUnlimitedThinAsync(int departmentId)

--- a/Repositories/Resgrid.Repositories.DataRepository/ChatRepositories.cs
+++ b/Repositories/Resgrid.Repositories.DataRepository/ChatRepositories.cs
@@ -869,6 +869,38 @@ namespace Resgrid.Repositories.DataRepository
 			}
 		}
 
+		public async Task<IEnumerable<ChatChannelMember>> GetActiveByChannelIdsAsync(IEnumerable<string> chatChannelIds)
+		{
+			try
+			{
+				var ids = chatChannelIds?.ToList() ?? new List<string>();
+				if (ids.Count == 0)
+					return new List<ChatChannelMember>();
+
+				var notation = _sqlConfiguration.ParameterNotation;
+				var sql = DataConfig.DatabaseType == DatabaseTypes.Postgres
+					? $"SELECT * FROM {_sqlConfiguration.SchemaName}.chatchannelmembers WHERE chatchannelid IN {notation}Ids AND removedon IS NULL"
+					: $"SELECT * FROM {_sqlConfiguration.SchemaName}.[ChatChannelMembers] WHERE [ChatChannelId] IN {notation}Ids AND [RemovedOn] IS NULL";
+
+				var select = new Func<DbConnection, Task<IEnumerable<ChatChannelMember>>>(connection =>
+					connection.QueryAsync<ChatChannelMember>(sql, new { Ids = ids }, _unitOfWork.Transaction));
+
+				if (_unitOfWork?.Connection == null)
+				{
+					using var connection = _connectionProvider.Create();
+					await connection.OpenAsync();
+					return await select(connection);
+				}
+
+				return await select(_unitOfWork.CreateOrGetConnection());
+			}
+			catch (Exception ex)
+			{
+				Logging.LogException(ex);
+				throw;
+			}
+		}
+
 		public async Task<bool> AdvanceReadPointerAsync(string chatChannelMemberId, long seq, DateTime readOn)
 		{
 			try

--- a/Repositories/Resgrid.Repositories.DataRepository/ChatRepositories.cs
+++ b/Repositories/Resgrid.Repositories.DataRepository/ChatRepositories.cs
@@ -869,6 +869,37 @@ namespace Resgrid.Repositories.DataRepository
 			}
 		}
 
+		public async Task<IEnumerable<ChatChannelMember>> GetActiveByUnitIdAsync(int departmentId, int unitId)
+		{
+			try
+			{
+				var parameters = new DynamicParametersExtension();
+				parameters.Add("DepartmentId", departmentId);
+				parameters.Add("UnitId", unitId);
+				var notation = _sqlConfiguration.ParameterNotation;
+				var sql = DataConfig.DatabaseType == DatabaseTypes.Postgres
+					? $"SELECT * FROM {_sqlConfiguration.SchemaName}.chatchannelmembers WHERE departmentid = {notation}DepartmentId AND unitid = {notation}UnitId AND participanttype = 1 AND removedon IS NULL"
+					: $"SELECT * FROM {_sqlConfiguration.SchemaName}.[ChatChannelMembers] WHERE [DepartmentId] = {notation}DepartmentId AND [UnitId] = {notation}UnitId AND [ParticipantType] = 1 AND [RemovedOn] IS NULL";
+
+				var select = new Func<DbConnection, Task<IEnumerable<ChatChannelMember>>>(connection =>
+					connection.QueryAsync<ChatChannelMember>(sql, parameters, _unitOfWork.Transaction));
+
+				if (_unitOfWork?.Connection == null)
+				{
+					using var connection = _connectionProvider.Create();
+					await connection.OpenAsync();
+					return await select(connection);
+				}
+
+				return await select(_unitOfWork.CreateOrGetConnection());
+			}
+			catch (Exception ex)
+			{
+				Logging.LogException(ex);
+				throw;
+			}
+		}
+
 		public async Task<IEnumerable<ChatChannelMember>> GetActiveByChannelIdsAsync(IEnumerable<string> chatChannelIds)
 		{
 			try

--- a/Repositories/Resgrid.Repositories.DataRepository/Servers/PostgreSql/PostgreSqlConfiguration.cs
+++ b/Repositories/Resgrid.Repositories.DataRepository/Servers/PostgreSql/PostgreSqlConfiguration.cs
@@ -1326,7 +1326,7 @@ namespace Resgrid.Repositories.DataRepository.Servers.SqlServer
 					LEFT JOIN (SELECT dgm1.*
 						FROM %SCHEMA%.%GROUPMEMBERSSTABLE% dgm1
 						INNER JOIN %SCHEMA%.%DEPARTMENTMEMBERSSTABLE% dm ON dgm1.UserId = dm.UserId
-						WHERE dm.IsDeleted = false) AS dgm ON dgm.DepartmentGroupId = dg.DepartmentGroupId
+						WHERE dm.IsDeleted = false AND dm.DepartmentId = %DID%) AS dgm ON dgm.DepartmentGroupId = dg.DepartmentGroupId
 					WHERE dg.DepartmentId = %DID%";
 			SelectAllGroupsByParentIdQuery = @"
 					SELECT %SCHEMA%.%GROUPSTABLE%.*, %SCHEMA%.%GROUPMEMBERSSTABLE%.*

--- a/Repositories/Resgrid.Repositories.DataRepository/Servers/SqlServer/SqlServerConfiguration.cs
+++ b/Repositories/Resgrid.Repositories.DataRepository/Servers/SqlServer/SqlServerConfiguration.cs
@@ -1279,7 +1279,7 @@ namespace Resgrid.Repositories.DataRepository.Servers.SqlServer
 					LEFT JOIN (SELECT dgm1.*
 						FROM %SCHEMA%.%GROUPMEMBERSSTABLE% dgm1
 						INNER JOIN %SCHEMA%.%DEPARTMENTMEMBERSSTABLE% dm ON dgm1.[UserId] = dm.[UserId]
-						WHERE dm.[IsDeleted] = 0) AS dgm ON dgm.[DepartmentGroupId] = dg.[DepartmentGroupId]
+						WHERE dm.[IsDeleted] = 0 AND dm.[DepartmentId] = %DID%) AS dgm ON dgm.[DepartmentGroupId] = dg.[DepartmentGroupId]
 					WHERE dg.[DepartmentId] = %DID%";
 			SelectAllGroupsByParentIdQuery = @"
 					SELECT %SCHEMA%.%GROUPSTABLE%.*, %SCHEMA%.%GROUPMEMBERSSTABLE%.*

--- a/Tests/Resgrid.Tests/Services/ChatChannelServiceTests.cs
+++ b/Tests/Resgrid.Tests/Services/ChatChannelServiceTests.cs
@@ -630,6 +630,7 @@ namespace Resgrid.Tests.Services
 			{
 				SetupDepartmentChannel();
 				_chatPermissionServiceMock.Setup(x => x.IsDepartmentAdminAsync(1, "user-a")).ReturnsAsync(false);
+				_chatPermissionServiceMock.Setup(x => x.CanSendAsUnitAsync("user-a", 7, 1)).ReturnsAsync(true);
 
 				var unitDm = new ChatChannel { ChatChannelId = "dm-unit-7", DepartmentId = 1, ChannelType = (int)ChatChannelType.DirectMessage, DmKey = "u:dispatcher|unit:7" };
 				_chatChannelMemberRepositoryMock.Setup(x => x.GetActiveByUnitIdAsync(1, 7)).ReturnsAsync(new List<ChatChannelMember>
@@ -641,6 +642,19 @@ namespace Resgrid.Tests.Services
 				var result = await _chatChannelService.GetChannelsForUserAsync(1, "user-a", 7);
 
 				result.Should().Contain(c => c.ChatChannelId == "dm-unit-7");
+			}
+
+			[Test]
+			public async Task active_unit_the_user_does_not_crew_should_not_expose_unit_channels()
+			{
+				SetupDepartmentChannel();
+				_chatPermissionServiceMock.Setup(x => x.IsDepartmentAdminAsync(1, "user-a")).ReturnsAsync(false);
+				_chatPermissionServiceMock.Setup(x => x.CanSendAsUnitAsync("user-a", 7, 1)).ReturnsAsync(false);
+
+				var result = await _chatChannelService.GetChannelsForUserAsync(1, "user-a", 7);
+
+				result.Should().NotContain(c => c.ChatChannelId == "dm-unit-7");
+				_chatChannelMemberRepositoryMock.Verify(x => x.GetActiveByUnitIdAsync(It.IsAny<int>(), It.IsAny<int>()), Times.Never);
 			}
 
 			[Test]

--- a/Tests/Resgrid.Tests/Services/ChatChannelServiceTests.cs
+++ b/Tests/Resgrid.Tests/Services/ChatChannelServiceTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -622,6 +623,35 @@ namespace Resgrid.Tests.Services
 
 				result.Should().ContainSingle(c => c.ChannelType == (int)ChatChannelType.GroupDefault).Which.GroupId.Should().Be(9);
 				_departmentGroupsServiceMock.Verify(x => x.GetAllGroupsForDepartmentAsync(It.IsAny<int>()), Times.Never);
+			}
+
+			[Test]
+			public async Task active_unit_should_see_channels_where_the_unit_is_the_member()
+			{
+				SetupDepartmentChannel();
+				_chatPermissionServiceMock.Setup(x => x.IsDepartmentAdminAsync(1, "user-a")).ReturnsAsync(false);
+
+				var unitDm = new ChatChannel { ChatChannelId = "dm-unit-7", DepartmentId = 1, ChannelType = (int)ChatChannelType.DirectMessage, DmKey = "u:dispatcher|unit:7" };
+				_chatChannelMemberRepositoryMock.Setup(x => x.GetActiveByUnitIdAsync(1, 7)).ReturnsAsync(new List<ChatChannelMember>
+				{
+					new ChatChannelMember { ChatChannelMemberId = "m1", ChatChannelId = "dm-unit-7", DepartmentId = 1, ParticipantType = (int)ChatParticipantType.Unit, UnitId = 7 }
+				});
+				_chatChannelRepositoryMock.Setup(x => x.GetByIdsAsync(It.Is<IEnumerable<string>>(ids => ids.Contains("dm-unit-7")))).ReturnsAsync(new List<ChatChannel> { unitDm });
+
+				var result = await _chatChannelService.GetChannelsForUserAsync(1, "user-a", 7);
+
+				result.Should().Contain(c => c.ChatChannelId == "dm-unit-7");
+			}
+
+			[Test]
+			public async Task without_an_active_unit_no_unit_membership_lookup_happens()
+			{
+				SetupDepartmentChannel();
+				_chatPermissionServiceMock.Setup(x => x.IsDepartmentAdminAsync(1, "user-a")).ReturnsAsync(false);
+
+				await _chatChannelService.GetChannelsForUserAsync(1, "user-a", null);
+
+				_chatChannelMemberRepositoryMock.Verify(x => x.GetActiveByUnitIdAsync(It.IsAny<int>(), It.IsAny<int>()), Times.Never);
 			}
 		}
 

--- a/Tests/Resgrid.Tests/Services/ChatPermissionServiceTests.cs
+++ b/Tests/Resgrid.Tests/Services/ChatPermissionServiceTests.cs
@@ -182,6 +182,57 @@ namespace Resgrid.Tests.Services
 			}
 
 			[Test]
+			public async Task dm_unit_member_should_have_access_when_the_user_crews_the_unit()
+			{
+				var channel = CreateChannel(ChatChannelType.DirectMessage);
+				_chatChannelMemberRepositoryMock.Setup(x => x.GetUserMemberAsync(channel.ChatChannelId, TestData.Users.TestUser1Id)).ReturnsAsync((ChatChannelMember)null);
+				_chatChannelMemberRepositoryMock.Setup(x => x.GetUnitMemberAsync(channel.ChatChannelId, 7)).ReturnsAsync(new ChatChannelMember
+				{
+					ChatChannelMemberId = Guid.NewGuid().ToString(),
+					ChatChannelId = channel.ChatChannelId,
+					DepartmentId = channel.DepartmentId,
+					ParticipantType = (int)ChatParticipantType.Unit,
+					UnitId = 7,
+					JoinedOn = DateTime.UtcNow
+				});
+				_unitsServiceMock.Setup(x => x.GetUnitByIdAsync(7)).ReturnsAsync(new Unit { UnitId = 7, DepartmentId = 1, Name = "Engine 6" });
+				_unitsServiceMock.Setup(x => x.GetActiveRolesForUnitAsync(7)).ReturnsAsync(new List<UnitActiveRole>
+				{
+					new UnitActiveRole { UnitId = 7, UserId = TestData.Users.TestUser1Id }
+				});
+
+				var result = await _chatPermissionService.CanAccessChannelAsync(channel, TestData.Users.TestUser1Id, 7);
+
+				result.Should().BeTrue();
+			}
+
+			[Test]
+			public async Task dm_unit_member_should_not_grant_access_when_the_user_does_not_crew_the_unit()
+			{
+				var channel = CreateChannel(ChatChannelType.DirectMessage);
+				_chatChannelMemberRepositoryMock.Setup(x => x.GetUserMemberAsync(channel.ChatChannelId, TestData.Users.TestUser1Id)).ReturnsAsync((ChatChannelMember)null);
+				_chatChannelMemberRepositoryMock.Setup(x => x.GetUnitMemberAsync(channel.ChatChannelId, 7)).ReturnsAsync(new ChatChannelMember
+				{
+					ChatChannelMemberId = Guid.NewGuid().ToString(),
+					ChatChannelId = channel.ChatChannelId,
+					DepartmentId = channel.DepartmentId,
+					ParticipantType = (int)ChatParticipantType.Unit,
+					UnitId = 7,
+					JoinedOn = DateTime.UtcNow
+				});
+				// User claims unit 7 as their active unit, but crews nothing.
+				_unitsServiceMock.Setup(x => x.GetUnitByIdAsync(7)).ReturnsAsync(new Unit { UnitId = 7, DepartmentId = 1, Name = "Engine 6" });
+				_unitsServiceMock.Setup(x => x.GetActiveRolesForUnitAsync(7)).ReturnsAsync(new List<UnitActiveRole>
+				{
+					new UnitActiveRole { UnitId = 7, UserId = TestData.Users.TestUser2Id }
+				});
+
+				var result = await _chatPermissionService.CanAccessChannelAsync(channel, TestData.Users.TestUser1Id, 7);
+
+				result.Should().BeFalse();
+			}
+
+			[Test]
 			public async Task department_default_department_member_should_have_access()
 			{
 				var channel = CreateChannel(ChatChannelType.DepartmentDefault);

--- a/Tests/Resgrid.Tests/Services/ChatPresenceServiceTests.cs
+++ b/Tests/Resgrid.Tests/Services/ChatPresenceServiceTests.cs
@@ -140,6 +140,47 @@ namespace Resgrid.Tests.Services
 				active.Should().ContainSingle();
 				_cacheProviderMock.Verify(x => x.SetStringAsync("chatactive:1:user-a", It.IsAny<string>(), It.IsAny<TimeSpan>()), Times.AtLeast(2));
 			}
+
+			[Test]
+			public async Task another_viewers_clear_does_not_remove_the_current_owners_unit_marker()
+			{
+				await _chatPresenceService.SetActiveChannelAsync(1, "user-a", "chan-1", 7);
+				await _chatPresenceService.SetActiveChannelAsync(1, "user-b", "chan-1", 7);
+
+				// user-a leaves; user-b now owns the marker and is still viewing.
+				await _chatPresenceService.ClearActiveChannelAsync(1, "user-a");
+
+				(await _chatPresenceService.IsUnitActiveInChannelAsync(1, 7, "chan-1")).Should().BeTrue();
+			}
+
+			[Test]
+			public async Task heartbeat_does_not_reclaim_a_unit_marker_owned_by_another_viewer()
+			{
+				await _chatPresenceService.SetActiveChannelAsync(1, "user-a", "chan-1", 7);
+				await _chatPresenceService.SetActiveChannelAsync(1, "user-b", "chan-2", 7);
+
+				// user-a's heartbeat must not flip the marker back to chan-1 over user-b's claim.
+				await _chatPresenceService.TouchAsync(1, "user-a");
+
+				(await _chatPresenceService.IsUnitActiveInChannelAsync(1, 7, "chan-2")).Should().BeTrue();
+				(await _chatPresenceService.IsUnitActiveInChannelAsync(1, 7, "chan-1")).Should().BeFalse();
+			}
+
+			[Test]
+			public async Task orphaned_unit_marker_whose_owner_moved_on_does_not_suppress()
+			{
+				_cache["chatactiveunit:1:7"] = "chan-1|user-a";
+
+				(await _chatPresenceService.IsUnitActiveInChannelAsync(1, 7, "chan-1")).Should().BeFalse();
+			}
+
+			[Test]
+			public async Task legacy_unowned_unit_marker_does_not_suppress()
+			{
+				_cache["chatactiveunit:1:7"] = "chan-1";
+
+				(await _chatPresenceService.IsUnitActiveInChannelAsync(1, 7, "chan-1")).Should().BeFalse();
+			}
 		}
 	}
 }

--- a/Tests/Resgrid.Tests/Services/ChatPresenceServiceTests.cs
+++ b/Tests/Resgrid.Tests/Services/ChatPresenceServiceTests.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using Resgrid.Model.Providers;
+using Resgrid.Model.Services;
+using Resgrid.Services;
+
+namespace Resgrid.Tests.Services
+{
+	namespace ChatPresenceServiceTests
+	{
+		public class with_the_chat_presence_service : TestBase
+		{
+			protected IChatPresenceService _chatPresenceService;
+			protected Mock<ICacheProvider> _cacheProviderMock;
+			protected Dictionary<string, string> _cache;
+
+			protected with_the_chat_presence_service()
+			{
+				BuildService();
+			}
+
+			protected override void Before_all_tests()
+			{
+				BuildService();
+			}
+
+			// Dictionary-backed cache fake: TTLs are ignored (expiry is not under test), everything else
+			// behaves like the real store so set/get/remove interplay is exercised end to end.
+			private void BuildService()
+			{
+				_cache = new Dictionary<string, string>(StringComparer.Ordinal);
+				_cacheProviderMock = new Mock<ICacheProvider>();
+
+				_cacheProviderMock.Setup(x => x.SetStringAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan>()))
+					.ReturnsAsync((string key, string value, TimeSpan ttl) =>
+					{
+						_cache[key] = value;
+						return true;
+					});
+				_cacheProviderMock.Setup(x => x.GetStringAsync(It.IsAny<string>()))
+					.ReturnsAsync((string key) => _cache.TryGetValue(key, out var value) ? value : null);
+				_cacheProviderMock.Setup(x => x.RemoveAsync(It.IsAny<string>()))
+					.ReturnsAsync((string key) => _cache.Remove(key));
+
+				_chatPresenceService = new ChatPresenceService(_cacheProviderMock.Object);
+			}
+		}
+
+		[TestFixture]
+		public class when_tracking_active_channels : with_the_chat_presence_service
+		{
+			[Test]
+			public async Task marks_the_user_active_in_the_channel()
+			{
+				await _chatPresenceService.SetActiveChannelAsync(1, "user-a", "chan-1");
+
+				var active = await _chatPresenceService.GetUsersActiveInChannelAsync(1, new List<string> { "user-a", "user-b" }, "chan-1");
+
+				active.Should().ContainSingle().Which.Should().Be("user-a");
+			}
+
+			[Test]
+			public async Task a_user_active_in_another_channel_is_not_returned()
+			{
+				await _chatPresenceService.SetActiveChannelAsync(1, "user-a", "chan-2");
+
+				var active = await _chatPresenceService.GetUsersActiveInChannelAsync(1, new List<string> { "user-a" }, "chan-1");
+
+				active.Should().BeEmpty();
+			}
+
+			[Test]
+			public async Task clearing_removes_the_marker()
+			{
+				await _chatPresenceService.SetActiveChannelAsync(1, "user-a", "chan-1");
+				await _chatPresenceService.ClearActiveChannelAsync(1, "user-a");
+
+				var active = await _chatPresenceService.GetUsersActiveInChannelAsync(1, new List<string> { "user-a" }, "chan-1");
+
+				active.Should().BeEmpty();
+			}
+
+			[Test]
+			public async Task setting_a_null_channel_clears_the_marker()
+			{
+				await _chatPresenceService.SetActiveChannelAsync(1, "user-a", "chan-1");
+				await _chatPresenceService.SetActiveChannelAsync(1, "user-a", null);
+
+				var active = await _chatPresenceService.GetUsersActiveInChannelAsync(1, new List<string> { "user-a" }, "chan-1");
+
+				active.Should().BeEmpty();
+			}
+		}
+
+		[TestFixture]
+		public class when_tracking_unit_active_channels : with_the_chat_presence_service
+		{
+			[Test]
+			public async Task marks_the_acting_unit_active_in_the_channel()
+			{
+				await _chatPresenceService.SetActiveChannelAsync(1, "user-a", "chan-1", 7);
+
+				(await _chatPresenceService.IsUnitActiveInChannelAsync(1, 7, "chan-1")).Should().BeTrue();
+				(await _chatPresenceService.IsUnitActiveInChannelAsync(1, 7, "chan-2")).Should().BeFalse();
+			}
+
+			[Test]
+			public async Task clearing_the_user_clears_the_unit_marker_too()
+			{
+				await _chatPresenceService.SetActiveChannelAsync(1, "user-a", "chan-1", 7);
+				await _chatPresenceService.ClearActiveChannelAsync(1, "user-a");
+
+				(await _chatPresenceService.IsUnitActiveInChannelAsync(1, 7, "chan-1")).Should().BeFalse();
+			}
+
+			[Test]
+			public async Task switching_acting_unit_clears_the_previous_units_marker()
+			{
+				await _chatPresenceService.SetActiveChannelAsync(1, "user-a", "chan-1", 7);
+				await _chatPresenceService.SetActiveChannelAsync(1, "user-a", "chan-1", 9);
+
+				(await _chatPresenceService.IsUnitActiveInChannelAsync(1, 7, "chan-1")).Should().BeFalse();
+				(await _chatPresenceService.IsUnitActiveInChannelAsync(1, 9, "chan-1")).Should().BeTrue();
+			}
+
+			[Test]
+			public async Task heartbeat_touch_keeps_the_active_markers_refreshed()
+			{
+				await _chatPresenceService.SetActiveChannelAsync(1, "user-a", "chan-1", 7);
+
+				await _chatPresenceService.TouchAsync(1, "user-a");
+
+				// Touch re-writes both markers (fresh TTL) without altering their values.
+				(await _chatPresenceService.IsUnitActiveInChannelAsync(1, 7, "chan-1")).Should().BeTrue();
+				var active = await _chatPresenceService.GetUsersActiveInChannelAsync(1, new List<string> { "user-a" }, "chan-1");
+				active.Should().ContainSingle();
+				_cacheProviderMock.Verify(x => x.SetStringAsync("chatactive:1:user-a", It.IsAny<string>(), It.IsAny<TimeSpan>()), Times.AtLeast(2));
+			}
+		}
+	}
+}

--- a/Web/Resgrid.Web.Eventing/Hubs/ChatHub.cs
+++ b/Web/Resgrid.Web.Eventing/Hubs/ChatHub.cs
@@ -278,5 +278,32 @@ namespace Resgrid.Web.Eventing.Hubs
 			if (departmentId > 0 && !string.IsNullOrWhiteSpace(userId))
 				await _chatPresenceService.TouchAsync(departmentId, userId);
 		}
+
+		/// <summary>
+		/// Marks the channel the caller is actively viewing (null/empty clears it). Push notifications for
+		/// a channel are suppressed only for viewers active in that channel — merely being online no longer
+		/// suppresses them. Clients call this on conversation open/close and on app foreground/background.
+		/// </summary>
+		public async Task SetActiveChannel(string channelId, int? asUnitId = null)
+		{
+			var departmentId = ClaimsAuthorizationHelper.GetDepartmentId();
+			var userId = ClaimsAuthorizationHelper.GetUserId();
+
+			if (departmentId <= 0 || string.IsNullOrWhiteSpace(userId))
+				return;
+
+			if (string.IsNullOrWhiteSpace(channelId))
+			{
+				await _chatPresenceService.ClearActiveChannelAsync(departmentId, userId);
+				return;
+			}
+
+			// Access-check before recording, so a forged channelId can't suppress someone else's pushes.
+			var access = await ResolveAccessibleChannelAsync(channelId, asUnitId);
+			if (access == null)
+				return;
+
+			await _chatPresenceService.SetActiveChannelAsync(departmentId, userId, channelId, asUnitId);
+		}
 	}
 }

--- a/Web/Resgrid.Web.Services/Controllers/v4/ChatController.cs
+++ b/Web/Resgrid.Web.Services/Controllers/v4/ChatController.cs
@@ -130,6 +130,8 @@ namespace Resgrid.Web.Services.Controllers.v4
 					result.Data.Add(ConvertChannelResultData(channel, member));
 				}
 
+				await ResolveDirectMessageNamesAsync(result.Data);
+
 				result.PageSize = result.Data.Count;
 				result.Status = ResponseHelper.Success;
 			}
@@ -168,6 +170,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 				var member = await _chatChannelService.GetUserMembershipAsync(channel.ChatChannelId, UserId);
 
 				result.Data = ConvertChannelResultData(channel, member);
+				await ResolveDirectMessageNamesAsync(new List<ChatChannelResultData> { result.Data });
 				result.PageSize = 1;
 				result.Status = ResponseHelper.Success;
 			}
@@ -209,6 +212,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 				var member = await _chatChannelService.GetUserMembershipAsync(channel.ChatChannelId, UserId);
 
 				result.Data = ConvertChannelResultData(channel, member);
+				await ResolveDirectMessageNamesAsync(new List<ChatChannelResultData> { result.Data });
 				result.PageSize = 1;
 				result.Status = ResponseHelper.Created;
 			}
@@ -239,11 +243,16 @@ namespace Resgrid.Web.Services.Controllers.v4
 			if (!ModelState.IsValid)
 				return BadRequest();
 
-			if (input == null || String.IsNullOrWhiteSpace(input.Name) || input.MemberUserIds == null || input.MemberUserIds.Count <= 0)
+			if (input == null || input.MemberUserIds == null || input.MemberUserIds.Count <= 0)
 				return BadRequest();
 
+			// No name supplied: name the group after its members (Slack-style), capped to the column length.
+			var name = input.Name?.Trim();
+			if (String.IsNullOrWhiteSpace(name))
+				name = await BuildGroupNameFromMembersAsync(input.MemberUserIds);
+
 			var result = new ChatChannelCreatedResult();
-			var channel = await _chatChannelService.CreateAdHocGroupChannelAsync(DepartmentId, UserId, input.Name, input.MemberUserIds, cancellationToken);
+			var channel = await _chatChannelService.CreateAdHocGroupChannelAsync(DepartmentId, UserId, name, input.MemberUserIds, cancellationToken);
 
 			if (channel != null)
 			{
@@ -1771,6 +1780,110 @@ namespace Resgrid.Web.Services.Controllers.v4
 			}
 
 			return data;
+		}
+
+		private const int MaxDerivedGroupNameLength = 100;
+
+		// "Alice Smith, Bob Jones" from the invited members (creator excluded — matches how Slack labels
+		// unnamed group DMs). Falls back to "New group" only if no profile resolves.
+		private async Task<string> BuildGroupNameFromMembersAsync(List<string> memberUserIds)
+		{
+			var ids = memberUserIds?
+				.Where(id => !String.IsNullOrWhiteSpace(id) && !String.Equals(id, UserId, StringComparison.OrdinalIgnoreCase))
+				.Distinct(StringComparer.OrdinalIgnoreCase)
+				.ToList() ?? new List<string>();
+
+			var names = new List<string>();
+			if (ids.Count > 0)
+			{
+				var profiles = await _userProfileService.GetSelectedUserProfilesAsync(ids);
+				foreach (var profile in profiles ?? new List<UserProfile>())
+				{
+					var name = profile?.FullName?.AsFirstNameLastName;
+					if (!String.IsNullOrWhiteSpace(name))
+						names.Add(name);
+				}
+			}
+
+			if (names.Count == 0)
+				return "New group";
+
+			names.Sort(StringComparer.OrdinalIgnoreCase);
+
+			var joined = String.Join(", ", names);
+			if (joined.Length <= MaxDerivedGroupNameLength)
+				return joined;
+
+			// Too long: keep whole names and count the rest ("Alice Smith, Bob Jones +3").
+			var kept = new List<string>();
+			var length = 0;
+			foreach (var name in names)
+			{
+				var addition = (kept.Count == 0 ? 0 : 2) + name.Length;
+				if (length + addition + 6 > MaxDerivedGroupNameLength)
+					break;
+
+				kept.Add(name);
+				length += addition;
+			}
+
+			if (kept.Count == 0)
+				kept.Add(names[0].Length > MaxDerivedGroupNameLength - 6 ? names[0].Substring(0, MaxDerivedGroupNameLength - 6) : names[0]);
+
+			var remaining = names.Count - kept.Count;
+			return remaining > 0 ? $"{String.Join(", ", kept)} +{remaining}" : String.Join(", ", kept);
+		}
+
+		// DM channels have no stored Name; label each with the counterpart participant so multiple
+		// DMs stay distinguishable in every client list. Unit counterparts already carry a
+		// DisplayNameOverride stamped at creation; user counterparts resolve via profile lookup.
+		private async Task ResolveDirectMessageNamesAsync(List<ChatChannelResultData> channels)
+		{
+			var dmChannels = channels?.Where(c => c != null && c.ChannelType == (int)ChatChannelType.DirectMessage && String.IsNullOrWhiteSpace(c.Name)).ToList();
+			if (dmChannels == null || dmChannels.Count == 0)
+				return;
+
+			var members = await _chatChannelService.GetActiveMembersForChannelsAsync(dmChannels.Select(c => c.ChatChannelId).ToList());
+			if (members == null || members.Count == 0)
+				return;
+
+			var counterparts = new Dictionary<string, ChatChannelMember>(StringComparer.OrdinalIgnoreCase);
+			foreach (var member in members)
+			{
+				if (member.UserId != null && String.Equals(member.UserId, UserId, StringComparison.OrdinalIgnoreCase))
+					continue;
+
+				if (!counterparts.ContainsKey(member.ChatChannelId))
+					counterparts.Add(member.ChatChannelId, member);
+			}
+
+			var userIds = counterparts.Values
+				.Where(m => String.IsNullOrWhiteSpace(m.DisplayNameOverride) && !String.IsNullOrWhiteSpace(m.UserId))
+				.Select(m => m.UserId)
+				.Distinct()
+				.ToList();
+
+			var namesByUserId = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+			if (userIds.Count > 0)
+			{
+				var profiles = await _userProfileService.GetSelectedUserProfilesAsync(userIds);
+				foreach (var profile in profiles ?? new List<UserProfile>())
+				{
+					if (profile?.UserId != null && !namesByUserId.ContainsKey(profile.UserId))
+						namesByUserId.Add(profile.UserId, profile.FullName?.AsFirstNameLastName);
+				}
+			}
+
+			foreach (var channel in dmChannels)
+			{
+				if (!counterparts.TryGetValue(channel.ChatChannelId, out var counterpart))
+					continue;
+
+				if (!String.IsNullOrWhiteSpace(counterpart.DisplayNameOverride))
+					channel.Name = counterpart.DisplayNameOverride;
+				else if (counterpart.UserId != null && namesByUserId.TryGetValue(counterpart.UserId, out var name) && !String.IsNullOrWhiteSpace(name))
+					channel.Name = name;
+			}
 		}
 
 		private static ChatChannelResultData ConvertChannelResultData(ChatChannel channel, ChatChannelMember member)

--- a/Web/Resgrid.Web.Services/Controllers/v4/ChatController.cs
+++ b/Web/Resgrid.Web.Services/Controllers/v4/ChatController.cs
@@ -122,6 +122,18 @@ namespace Resgrid.Web.Services.Controllers.v4
 				}
 			}
 
+			// Acting as a unit: the unit's member rows carry the read pointer/preferences for channels
+			// where the unit (not the person) is the participant. Personal rows still win when both exist.
+			if (activeUnitId.HasValue)
+			{
+				var unitMemberRows = await _chatChannelService.GetActiveMembershipsForUnitAsync(DepartmentId, activeUnitId.Value);
+				foreach (var member in unitMemberRows)
+				{
+					if (!membersByChannel.ContainsKey(member.ChatChannelId))
+						membersByChannel.Add(member.ChatChannelId, member);
+				}
+			}
+
 			if (channels != null && channels.Any())
 			{
 				foreach (var channel in channels)
@@ -130,7 +142,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 					result.Data.Add(ConvertChannelResultData(channel, member));
 				}
 
-				await ResolveDirectMessageNamesAsync(result.Data);
+				await ResolveDirectMessageNamesAsync(result.Data, activeUnitId);
 
 				result.PageSize = result.Data.Count;
 				result.Status = ResponseHelper.Success;
@@ -1837,7 +1849,9 @@ namespace Resgrid.Web.Services.Controllers.v4
 		// DM channels have no stored Name; label each with the counterpart participant so multiple
 		// DMs stay distinguishable in every client list. Unit counterparts already carry a
 		// DisplayNameOverride stamped at creation; user counterparts resolve via profile lookup.
-		private async Task ResolveDirectMessageNamesAsync(List<ChatChannelResultData> channels)
+		// activeUnitId identifies the viewer when they act as a unit, so the unit's own row is
+		// never chosen as the counterpart (a rig viewing its DM with dispatch must see the dispatcher).
+		private async Task ResolveDirectMessageNamesAsync(List<ChatChannelResultData> channels, int? activeUnitId = null)
 		{
 			var dmChannels = channels?.Where(c => c != null && c.ChannelType == (int)ChatChannelType.DirectMessage && String.IsNullOrWhiteSpace(c.Name)).ToList();
 			if (dmChannels == null || dmChannels.Count == 0)
@@ -1851,6 +1865,9 @@ namespace Resgrid.Web.Services.Controllers.v4
 			foreach (var member in members)
 			{
 				if (member.UserId != null && String.Equals(member.UserId, UserId, StringComparison.OrdinalIgnoreCase))
+					continue;
+
+				if (activeUnitId.HasValue && member.UnitId.HasValue && member.UnitId.Value == activeUnitId.Value)
 					continue;
 
 				if (!counterparts.ContainsKey(member.ChatChannelId))

--- a/Web/Resgrid.Web.Services/Controllers/v4/ChatController.cs
+++ b/Web/Resgrid.Web.Services/Controllers/v4/ChatController.cs
@@ -105,6 +105,11 @@ namespace Resgrid.Web.Services.Controllers.v4
 			if (!await ChatEnabledAsync())
 				return NotFound();
 
+			// The active unit is caller-supplied; only honor it when the user actually crews that unit,
+			// otherwise treat the request as personal so unit channels and member rows can't be probed.
+			if (activeUnitId.HasValue && !await _chatPermissionService.CanSendAsUnitAsync(UserId, activeUnitId.Value, DepartmentId))
+				activeUnitId = null;
+
 			var result = new GetChatChannelsResult();
 			var channels = await _chatChannelService.GetChannelsForUserAsync(DepartmentId, UserId, activeUnitId, includeArchived);
 

--- a/Web/Resgrid.Web.Services/Models/v4/Chat/ChatApiModels.cs
+++ b/Web/Resgrid.Web.Services/Models/v4/Chat/ChatApiModels.cs
@@ -1029,9 +1029,8 @@ public class CreateDirectMessageInput
 public class CreateAdHocChannelInput
 {
 	/// <summary>
-	/// Name of the channel
+	/// Name of the channel. Optional — when omitted the server names the group after its members.
 	/// </summary>
-	[Required]
 	[StringLength(100)]
 	public string Name { get; set; }
 

--- a/Web/Resgrid.Web.Services/Program.cs
+++ b/Web/Resgrid.Web.Services/Program.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Resgrid.Config;
 using Resgrid.Framework;
+using Sentry;
 using Sentry.Profiling;
 
 namespace Resgrid.Web.ServicesCore
@@ -64,6 +65,10 @@ namespace Resgrid.Web.ServicesCore
 							options.Release = Assembly.GetEntryAssembly().GetName().Version.ToString();
 							options.ProfilesSampleRate = ExternalErrorConfig.SentryProfilingSampleRate;
 							options.SetBeforeSendTransaction(SentryTransactionFilter.Filter);
+
+							// Client aborted/malformed requests (e.g. "Unexpected end of request content"
+							// when a mobile upload drops mid-body) are not actionable server errors.
+							options.AddExceptionFilterForType<Microsoft.AspNetCore.Server.Kestrel.Core.BadHttpRequestException>();
 
 							// Requires NuGet package: Sentry.Profiling
 							// Note: By default, the profiler is initialized asynchronously. This can be tuned by passing a desired initialization timeout to the constructor.

--- a/Web/Resgrid.Web.Services/Resgrid.Web.Services.xml
+++ b/Web/Resgrid.Web.Services/Resgrid.Web.Services.xml
@@ -7984,7 +7984,7 @@
         </member>
         <member name="P:Resgrid.Web.Services.Models.v4.Chat.CreateAdHocChannelInput.Name">
             <summary>
-            Name of the channel
+            Name of the channel. Optional — when omitted the server names the group after its members.
             </summary>
         </member>
         <member name="P:Resgrid.Web.Services.Models.v4.Chat.CreateAdHocChannelInput.MemberUserIds">

--- a/Web/Resgrid.Web/Areas/User/Apps/src/components/chat/ChatPageElement.tsx
+++ b/Web/Resgrid.Web/Areas/User/Apps/src/components/chat/ChatPageElement.tsx
@@ -1,9 +1,10 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import './chat.css';
 import { getCurrentUserId, isDepartmentAdmin, type ChatChannelDto, type ChatMessageDto } from './types';
 import { useChatBootstrap } from './useChatBootstrap';
 import { useChatStore, shallowArrayEqual } from './useChatStore';
-import { setActiveChannel, setHighlightMessage } from './chatStore';
+import { setActiveChannel, setHighlightMessage, upsertChannel } from './chatStore';
+import { chatHub } from './chatHub';
 import { flagChatMessage } from './chatActions';
 import { searchMessages } from './chatApi';
 import { channelDisplayName, formatRelativeDay } from './chatFormat';
@@ -40,6 +41,12 @@ export default function ChatPageElement(_props: ChatPageElementProps) {
   const currentUserId = getCurrentUserId();
   const canModerate = isDepartmentAdmin();
   const activeChannel = channels.find((channel) => channel.ChatChannelId === activeChannelId) ?? null;
+
+  // Report the on-screen conversation so the server suppresses its pushes; cleared on unmount.
+  useEffect(() => {
+    chatHub.setActiveChannel(activeChannelId);
+  }, [activeChannelId]);
+  useEffect(() => () => chatHub.setActiveChannel(null), []);
 
   // Stable identities: ChannelRow and MessageBubble are memo'd, so these callbacks must not be recreated
   // each render or those children re-render on every ChatPageElement state change (defeating their memo).
@@ -211,6 +218,9 @@ export default function ChatPageElement(_props: ChatPageElementProps) {
           onClose={() => setShowNew(false)}
           onCreated={(channel: ChatChannelDto) => {
             setShowNew(false);
+            // Seed the store immediately: the channel-list refetch races the hub event, and the
+            // conversation can only open if the channel exists in state.
+            upsertChannel(channel);
             openChannel(channel.ChatChannelId);
           }}
         />

--- a/Web/Resgrid.Web/Areas/User/Apps/src/components/chat/ChatPanelElement.tsx
+++ b/Web/Resgrid.Web/Areas/User/Apps/src/components/chat/ChatPanelElement.tsx
@@ -3,7 +3,8 @@ import './chat.css';
 import { ChatChannelType, getCurrentUserId, type ChatChannelDto, type ChatMessageDto } from './types';
 import { useChatBootstrap } from './useChatBootstrap';
 import { useChatStore, shallowArrayEqual } from './useChatStore';
-import { setActiveChannel } from './chatStore';
+import { setActiveChannel, upsertChannel } from './chatStore';
+import { chatHub } from './chatHub';
 import { flagChatMessage } from './chatActions';
 import { channelDisplayName } from './chatFormat';
 import ChannelList from './ChannelList';
@@ -48,6 +49,13 @@ export default function ChatPanelElement({ hostElement, label = 'Chat' }: ChatPa
       hostElement.style.display = chatVisible ? '' : 'none';
     }
   }, [hostElement, chatVisible]);
+
+  // Report the on-screen conversation so the server suppresses its pushes; a minimized panel
+  // counts as not viewing. Cleared on unmount (page navigation).
+  useEffect(() => {
+    chatHub.setActiveChannel(open && activeChannelId ? activeChannelId : null);
+  }, [open, activeChannelId]);
+  useEffect(() => () => chatHub.setActiveChannel(null), []);
 
   const openPanel = () => {
     setOpen(true);
@@ -161,6 +169,9 @@ export default function ChatPanelElement({ hostElement, label = 'Chat' }: ChatPa
           onClose={() => setShowNew(false)}
           onCreated={(channel: ChatChannelDto) => {
             setShowNew(false);
+            // Seed the store immediately: the channel-list refetch races the hub event, and the
+            // conversation can only open if the channel exists in state.
+            upsertChannel(channel);
             openChannel(channel.ChatChannelId);
           }}
         />

--- a/Web/Resgrid.Web/Areas/User/Apps/src/components/chat/NewConversationDialog.tsx
+++ b/Web/Resgrid.Web/Areas/User/Apps/src/components/chat/NewConversationDialog.tsx
@@ -48,8 +48,8 @@ export default function NewConversationDialog({ currentUserId, onClose, onCreate
       if (selected.length === 1) {
         channel = await createDirectMessage(selected[0]);
       } else {
-        const name = groupName.trim().length > 0 ? groupName.trim() : 'New group';
-        channel = await createAdHocChannel(name, selected);
+        // Empty name is fine — the server names the group after its members.
+        channel = await createAdHocChannel(groupName.trim(), selected);
       }
       if (channel) {
         onCreated(channel);
@@ -89,7 +89,7 @@ export default function NewConversationDialog({ currentUserId, onClose, onCreate
       {selected.length > 1 && (
         <input
           className="rgchat-input rgchat-dialog__field"
-          placeholder="Group name"
+          placeholder="Group name (optional)"
           value={groupName}
           onChange={(event) => setGroupName(event.target.value)}
         />

--- a/Web/Resgrid.Web/Areas/User/Apps/src/components/chat/chatHub.ts
+++ b/Web/Resgrid.Web/Areas/User/Apps/src/components/chat/chatHub.ts
@@ -143,6 +143,7 @@ class ChatHub {
       for (const [channelId, asUnitId] of this.joinedChannels.entries()) {
         await this.invokeJoin(channelId, asUnitId);
       }
+      this.reportActiveChannel();
       this.startHeartbeat();
     })();
 
@@ -274,6 +275,7 @@ class ChatHub {
         await this.invokeJoin(channelId, asUnitId);
         await this.deltaSync(channelId);
       }
+      this.reportActiveChannel();
       this.notifyChannelsRefresh();
     } catch (error) {
       console.error('Chat hub reconnect sync failed.', error);
@@ -364,6 +366,23 @@ class ChatHub {
   public markRead(channelId: string, seq: number, asUnitId?: number): void {
     if (this.connection && this.connection.state === HubConnectionState.Connected) {
       this.connection.invoke(CHAT_HUB_METHODS.MarkRead, channelId, seq, asUnitId ?? null).catch(() => undefined);
+    }
+  }
+
+  // Tells the server which conversation is on screen so pushes for it are suppressed while
+  // everything else still alerts. Remembered locally and re-reported after reconnects.
+  private activeChannelReported: string | null = null;
+
+  public setActiveChannel(channelId: string | null): void {
+    this.activeChannelReported = channelId;
+    this.reportActiveChannel();
+  }
+
+  private reportActiveChannel(): void {
+    if (this.connection && this.connection.state === HubConnectionState.Connected) {
+      this.connection
+        .invoke(CHAT_HUB_METHODS.SetActiveChannel, this.activeChannelReported, null)
+        .catch(() => undefined);
     }
   }
 }

--- a/Web/Resgrid.Web/Areas/User/Apps/src/components/chat/chatHub.ts
+++ b/Web/Resgrid.Web/Areas/User/Apps/src/components/chat/chatHub.ts
@@ -370,18 +370,21 @@ class ChatHub {
   }
 
   // Tells the server which conversation is on screen so pushes for it are suppressed while
-  // everything else still alerts. Remembered locally and re-reported after reconnects.
+  // everything else still alerts. Remembered locally (with the acting unit, so unit push
+  // suppression tracks the viewer too) and re-reported after reconnects.
   private activeChannelReported: string | null = null;
+  private activeChannelUnitId: number | null = null;
 
-  public setActiveChannel(channelId: string | null): void {
+  public setActiveChannel(channelId: string | null, asUnitId?: number): void {
     this.activeChannelReported = channelId;
+    this.activeChannelUnitId = channelId ? asUnitId ?? null : null;
     this.reportActiveChannel();
   }
 
   private reportActiveChannel(): void {
     if (this.connection && this.connection.state === HubConnectionState.Connected) {
       this.connection
-        .invoke(CHAT_HUB_METHODS.SetActiveChannel, this.activeChannelReported, null)
+        .invoke(CHAT_HUB_METHODS.SetActiveChannel, this.activeChannelReported, this.activeChannelUnitId)
         .catch(() => undefined);
     }
   }

--- a/Web/Resgrid.Web/Areas/User/Apps/src/components/chat/types.ts
+++ b/Web/Resgrid.Web/Areas/User/Apps/src/components/chat/types.ts
@@ -70,6 +70,7 @@ export const CHAT_HUB_METHODS = {
   LeaveChannel: 'LeaveChannel',
   Typing: 'Typing',
   MarkRead: 'MarkRead',
+  SetActiveChannel: 'SetActiveChannel',
 } as const;
 
 // Client-side lifecycle for optimistic messages (not part of the wire DTO).

--- a/Web/Resgrid.Web/Areas/User/Controllers/DepartmentController.cs
+++ b/Web/Resgrid.Web/Areas/User/Controllers/DepartmentController.cs
@@ -1450,9 +1450,11 @@ namespace Resgrid.Web.Areas.User.Controllers
 		{
 			var result = new List<RecipientJson>();
 
-			var stations = await _departmentGroupsService.GetAllGroupsForDepartmentAsync(DepartmentId);
-			var roles = await _personnelRolesService.GetRolesForDepartmentAsync(DepartmentId);
-			var profiles = await _userProfileService.GetAllProfilesForDepartmentAsync(DepartmentId);
+			// Repositories swallow DB exceptions and return null; treat as empty so a
+			// transient failure degrades to an empty grid instead of a 500.
+			var stations = await _departmentGroupsService.GetAllGroupsForDepartmentAsync(DepartmentId) ?? new List<DepartmentGroup>();
+			var roles = await _personnelRolesService.GetRolesForDepartmentAsync(DepartmentId) ?? new List<PersonnelRole>();
+			var profiles = await _userProfileService.GetAllProfilesForDepartmentAsync(DepartmentId) ?? new Dictionary<string, UserProfile>();
 
 			if (filter == 0 || filter == 1)
 			{

--- a/Web/Resgrid.Web/Areas/User/Views/Shared/_UserLayout.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Shared/_UserLayout.cshtml
@@ -40,7 +40,10 @@
                 window.Sentry.init({
                     dsn: '@Resgrid.Config.ExternalErrorConfig.ExternalErrorServiceUrlForWebsite',
                     integrations: [window.Sentry.breadcrumbsIntegration({ console: false })],
-                    tracesSampleRate: @Resgrid.Config.ExternalErrorConfig.SentryPerfSampleRate
+                    tracesSampleRate: @Resgrid.Config.ExternalErrorConfig.SentryPerfSampleRate,
+                    // Safari masks injected extension scripts as webkit-masked-url://; those
+                    // frames are browser-extension code, not ours.
+                    denyUrls: [/webkit-masked-url:\/\//i]
                 });
             }
         </script>


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Pull Request Description

This PR introduces several improvements to the chat system, department group performance, and error handling:

### Chat Enhancements
- **Active-channel push suppression**: Replaces broad "online = no push" logic with precise tracking of which channel a user is actively viewing. Push notifications are now only suppressed for users (and acting units) currently viewing that specific conversation, ensuring background channels still alert online users.
- **Unit-participant channel visibility**: Unit operators can now see and interact with channels where their unit is a participant (e.g., Dispatch↔Unit DMs, unit-invited groups) without needing a personal member row.
- **DM channel name resolution**: DM channels without stored names are dynamically labeled with the counterpart participant's display name so multiple DMs are distinguishable.
- **Auto-naming for group channels**: When creating an ad-hoc group without a name, the server auto-generates one from the invited members' names (Slack-style).
- **Unit sender attribution**: Messages sent as a unit now include the operator's name (e.g., "Engine 6 (Alice Smith)") so dispatchers know who is operating the rig.
- **Immediate channel visibility**: Cache invalidation on channel provisioning ensures both participants see new DM/group channels without waiting for the per-user list cache to expire.

### Department Groups Performance & Correctness
- Eliminated N+1 query patterns in `GetAllGroupsForDepartmentUnlimitedAsync` by resolving parent/child relationships and addresses in-memory from a single query.
- Fixed group member queries in both PostgreSQL and SQL Server to filter by `DepartmentId`, preventing cross-department data leakage when the same user belongs to multiple departments.

### Error Handling
- Filtered `BadHttpRequestException` (client-aborted requests) from Sentry to reduce noise.
- Filtered Safari extension-originated script errors (`webkit-masked-url://`) from both client and server Sentry reporting.
- Added null-safety guards in the recipients grid to gracefully degrade on transient database failures.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Chat now tracks the channel and optional acting unit you’re actively viewing.
  - Ad-hoc group names are optional and can be generated automatically from members.
  - Newly created conversations appear immediately in the chat list.
  - Unit-based channel access and membership handling has been expanded.

- **Improvements**
  - Notifications are suppressed when users or units are already active in the channel.
  - Direct-message and unit display names are more informative.

- **Bug Fixes**
  - Improved channel access validation, group filtering, and resilience when data is unavailable.
  - Reduced monitoring noise from expected client connection errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->