### PR TITLE
RG-T131 Log time issue fix

### DIFF
--- a/Core/Resgrid.Framework/DateTimeHelpers.cs
+++ b/Core/Resgrid.Framework/DateTimeHelpers.cs
@@ -96,7 +96,12 @@ namespace Resgrid.Framework
 			return resultedDay;
 		}
 
-		public static DateTime ConvertToUtc(DateTime dateTime, string timeZone)
+		/// <summary>
+		/// Converts a local (department) time into UTC. When lenient is set, local times that are
+		/// ambiguous or skipped by a DST transition are resolved instead of throwing, which matters
+		/// for user typed timestamps (i.e. a 0130 log entry on the fall back day).
+		/// </summary>
+		public static DateTime ConvertToUtc(DateTime dateTime, string timeZone, bool lenient = false)
 		{
 			//var tzdbSource = NodaTime.TimeZones.TzdbDateTimeZoneSource.Default;
 			//var tzi = TimeZoneInfo.FindSystemTimeZoneById(IanaToWindows(timeZone));
@@ -112,7 +117,9 @@ namespace Resgrid.Framework
 				var ianaTz = TZConvert.WindowsToIana(timeZone);
 
 				var localTime = LocalDateTime.FromDateTime(dateTime);
-				var zonedDateTime = localTime.InZoneStrictly(DateTimeZoneProviders.Tzdb[ianaTz]);
+				var zonedDateTime = lenient
+					? localTime.InZoneLeniently(DateTimeZoneProviders.Tzdb[ianaTz])
+					: localTime.InZoneStrictly(DateTimeZoneProviders.Tzdb[ianaTz]);
 
 				return zonedDateTime.ToDateTimeUtc();
 			}

--- a/Tests/Resgrid.Tests/Services/CommunicationTestServiceTests.cs
+++ b/Tests/Resgrid.Tests/Services/CommunicationTestServiceTests.cs
@@ -262,6 +262,35 @@ namespace Resgrid.Tests.Services
 			}
 
 			[Test]
+			public async Task should_write_a_snapshot_value_for_an_untargeted_run_rather_than_leaving_the_column_null()
+			{
+				var testId = Guid.NewGuid();
+				_communicationTestRepoMock.Setup(x => x.GetByIdAsync(testId)).ReturnsAsync(new CommunicationTest
+				{
+					CommunicationTestId = testId,
+					DepartmentId = 1,
+					TestEmail = true,
+					ResponseWindowMinutes = 60,
+					Active = true
+				});
+
+				// No targets, so the resolved audience is null -- the whole department.
+				_communicationTestTargetRepoMock.Setup(x => x.GetTargetsByTestIdAsync(testId)).ReturnsAsync(new List<CommunicationTestTarget>());
+
+				SetupRunAndResultPersistence();
+
+				var run = await _communicationTestService.StartTestRunAsync(testId, 1, TestData.Users.TestUser1Id);
+
+				// An empty/NULL column is what marks a run as predating snapshots, which sends the
+				// builder back to the test's current targeting. An untargeted run therefore has to
+				// store a real value -- the JSON literal "null" -- so its snapshot still reads as
+				// "the whole department" after the test is re-targeted. Serializing to a null string
+				// here would silently reintroduce the drift this snapshot exists to prevent.
+				run.TargetedUserIds.Should().NotBeNullOrWhiteSpace();
+				run.TargetedUserIds.Should().Be("null");
+			}
+
+			[Test]
 			public async Task should_not_rebuild_results_for_a_run_that_already_has_them()
 			{
 				var testId = Guid.NewGuid();

--- a/Web/Resgrid.Web/Areas/User/Controllers/LogsController.cs
+++ b/Web/Resgrid.Web/Areas/User/Controllers/LogsController.cs
@@ -163,6 +163,9 @@ namespace Resgrid.Web.Areas.User.Controllers
 
 				if (model.LogType == LogTypes.Run)
 				{
+					// Times come off the form in the department's local time, everything is stored in UTC.
+					model.Call.LoggedOn = ConvertLogTimeToUtc(model.Call.LoggedOn, model.Department);
+
 					if (model.CallId == 0)
 					{
 						model.Call.DepartmentId = DepartmentId;
@@ -201,10 +204,10 @@ namespace Resgrid.Web.Areas.User.Controllers
 					var endedOn = form["Log.EndedOn"];
 
 					if (!String.IsNullOrWhiteSpace(startedOn))
-						model.Log.StartedOn = DateTime.Parse(startedOn);
+						model.Log.StartedOn = ParseLogTimeToUtc(startedOn, model.Department);
 
 					if (!String.IsNullOrWhiteSpace(endedOn))
-						model.Log.EndedOn = DateTime.Parse(endedOn);
+						model.Log.EndedOn = ParseLogTimeToUtc(endedOn, model.Department);
 				}
 
 				if (model.LogType == LogTypes.Meeting)
@@ -213,10 +216,10 @@ namespace Resgrid.Web.Areas.User.Controllers
 					var endedOn = form["Log.EndedOn"];
 
 					if (!String.IsNullOrWhiteSpace(startedOn))
-						model.Log.StartedOn = DateTime.Parse(startedOn);
+						model.Log.StartedOn = ParseLogTimeToUtc(startedOn, model.Department);
 
 					if (!String.IsNullOrWhiteSpace(endedOn))
-						model.Log.EndedOn = DateTime.Parse(endedOn);
+						model.Log.EndedOn = ParseLogTimeToUtc(endedOn, model.Department);
 				}
 
 				if (model.LogType == LogTypes.Coroner)
@@ -228,7 +231,7 @@ namespace Resgrid.Web.Areas.User.Controllers
 					var coronerOthers = form["coronerOthers"];
 
 					if (!String.IsNullOrWhiteSpace(startedOn))
-						model.Log.StartedOn = DateTime.Parse(startedOn);
+						model.Log.StartedOn = ParseLogTimeToUtc(startedOn, model.Department);
 
 					if (!String.IsNullOrWhiteSpace(caseNumber))
 						model.Log.ExternalId = caseNumber;
@@ -254,19 +257,19 @@ namespace Resgrid.Web.Areas.User.Controllers
 					unit.UnitId = i;
 
 					if (!string.IsNullOrWhiteSpace(form["unit_dispatchtime_" + i]))
-						unit.Dispatched = DateTime.Parse(form["unit_dispatchtime_" + i]);
+						unit.Dispatched = ParseLogTimeToUtc(form["unit_dispatchtime_" + i], model.Department);
 
 					if (!string.IsNullOrWhiteSpace(form["unit_enroutetime_" + i]))
-						unit.Enroute = DateTime.Parse(form["unit_enroutetime_" + i]);
+						unit.Enroute = ParseLogTimeToUtc(form["unit_enroutetime_" + i], model.Department);
 
 					if (!string.IsNullOrWhiteSpace(form["unit_onscenetime_" + i]))
-						unit.OnScene = DateTime.Parse(form["unit_onscenetime_" + i]);
+						unit.OnScene = ParseLogTimeToUtc(form["unit_onscenetime_" + i], model.Department);
 
 					if (!string.IsNullOrWhiteSpace(form["unit_releasedtime_" + i]))
-						unit.Released = DateTime.Parse(form["unit_releasedtime_" + i]);
+						unit.Released = ParseLogTimeToUtc(form["unit_releasedtime_" + i], model.Department);
 
 					if (!string.IsNullOrWhiteSpace(form["unit_inquarterstime_" + i]))
-						unit.InQuarters = DateTime.Parse(form["unit_inquarterstime_" + i]);
+						unit.InQuarters = ParseLogTimeToUtc(form["unit_inquarterstime_" + i], model.Department);
 
 					model.Log.Units.Add(unit);
 
@@ -653,6 +656,24 @@ namespace Resgrid.Web.Areas.User.Controllers
 			};
 
 			return PartialView("_UnitLogBlockPartial", model);
+		}
+
+		/// <summary>
+		/// Log timestamps are typed into the form in the department's local time, but every date on
+		/// the Log (and the Call) is persisted as UTC and rendered back through TimeConverter. Without
+		/// this the entered time was stored verbatim and then shifted again on display.
+		/// </summary>
+		private static DateTime ParseLogTimeToUtc(string value, Department department)
+		{
+			return ConvertLogTimeToUtc(DateTime.Parse(value), department);
+		}
+
+		private static DateTime ConvertLogTimeToUtc(DateTime localTime, Department department)
+		{
+			if (department == null || String.IsNullOrWhiteSpace(department.TimeZone) || localTime == DateTime.MinValue)
+				return localTime;
+
+			return DateTimeHelpers.ConvertToUtc(localTime, department.TimeZone, true);
 		}
 
 		private async Task<NewLogView> PopulateLogViewModel(NewLogView model)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected log and call timestamps so entries are stored consistently in UTC based on the department’s local time zone.
  * Improved handling of ambiguous or skipped daylight-saving-time timestamps.
  * Preserved original timestamp values when time-zone information is unavailable or the value is unspecified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->