### PR TITLE
RG-T132 Push linking fix

### DIFF
--- a/Core/Resgrid.Services/CommunicationService.cs
+++ b/Core/Resgrid.Services/CommunicationService.cs
@@ -712,16 +712,16 @@ namespace Resgrid.Services
 				if (recipients.Count == 1)
 				{
 					var sendingTo = recipients.FirstOrDefault();
-					spm.Id = $"T{sendingTo.UserId}";
 
+					if (sendingTo == null)
+						return false;
+
+					spm.Id = $"T{sendingTo.UserId}";
 
 					if (!await CanSendToUser(sendingTo.UserId, departmentId))
 						return false;
 
-					if (sendingTo != null)
-					{
-						await _pushService.PushChat(spm, sendingTo.UserId, sendingTo);
-					}
+					await _pushService.PushChat(spm, sendingTo.UserId, sendingTo);
 				}
 				else
 				{

--- a/Core/Resgrid.Services/CommunicationService.cs
+++ b/Core/Resgrid.Services/CommunicationService.cs
@@ -712,7 +712,7 @@ namespace Resgrid.Services
 				if (recipients.Count == 1)
 				{
 					var sendingTo = recipients.FirstOrDefault();
-					spm.Id = $"T{sendingTo}";
+					spm.Id = $"T{sendingTo.UserId}";
 
 
 					if (!await CanSendToUser(sendingTo.UserId, departmentId))

--- a/Core/Resgrid.Services/PushService.cs
+++ b/Core/Resgrid.Services/PushService.cs
@@ -362,7 +362,7 @@ namespace Resgrid.Services
 				// Legacy Push Notifications (Azure)
 				try
 				{
-					await _notificationProvider.SendAllNotifications(call.SubTitle, call.Title, userId, string.Format("C{0}", call.CallId), soundType, true, call.ActiveCallCount, color);
+					await _notificationProvider.SendAllNotifications(call.Title, call.SubTitle, userId, string.Format("C{0}", call.CallId), soundType, true, call.ActiveCallCount, color);
 				}
 				catch (Exception ex)
 				{

--- a/Providers/Resgrid.Providers.Bus/Models/APNSPayload.cs
+++ b/Providers/Resgrid.Providers.Bus/Models/APNSPayload.cs
@@ -11,5 +11,16 @@ namespace Resgrid.Providers.Bus.Models
 		public ApnsHeader aps { get; set; }
 		public string eventCode { get; set; }
 		public string type { get; set; }
+		public ApnsCustomData body { get; set; }
+	}
+
+	/// <summary>
+	/// Serialized as the top-level `body` custom key, which is the only key
+	/// expo-notifications on iOS surfaces to the app as content.data.
+	/// </summary>
+	public class ApnsCustomData
+	{
+		public string eventCode { get; set; }
+		public string type { get; set; }
 	}
 }

--- a/Providers/Resgrid.Providers.Bus/NotificationProvider.cs
+++ b/Providers/Resgrid.Providers.Bus/NotificationProvider.cs
@@ -322,7 +322,12 @@ namespace Resgrid.Providers.Bus
 						}
 					},
 					eventCode = eventCode,
-					type = type
+					type = type,
+					body = new ApnsCustomData
+					{
+						eventCode = eventCode,
+						type = type
+					}
 				};
 
 				appleNotification = JsonConvert.SerializeObject(apnsPayload);

--- a/Providers/Resgrid.Providers.Bus/UnitNotificationProvider.cs
+++ b/Providers/Resgrid.Providers.Bus/UnitNotificationProvider.cs
@@ -351,7 +351,12 @@ namespace Resgrid.Providers.Bus
 						}
 					},
 					eventCode = eventCode,
-					type = type
+					type = type,
+					body = new ApnsCustomData
+					{
+						eventCode = eventCode,
+						type = type
+					}
 				};
 
 				appleNotification = JsonConvert.SerializeObject(apnsPayload);

--- a/Providers/Resgrid.Providers.Messaging/NovuProvider.cs
+++ b/Providers/Resgrid.Providers.Messaging/NovuProvider.cs
@@ -416,6 +416,17 @@ namespace Resgrid.Providers.Messaging
 											eventCode = eventCode,
 											customType = type
 										},
+										// expo-notifications on iOS only surfaces the top-level `body` custom key
+										// as content.data, and per the APNs spec custom keys belong beside `aps`,
+										// not inside it. The aps-nested eventCode/customType above stay for
+										// backward compatibility with already deployed apps.
+										body = new
+										{
+											eventCode = eventCode,
+											type = type
+										},
+										eventCode = eventCode,
+										type = type
 									},
 								},
 							},
@@ -431,7 +442,20 @@ namespace Resgrid.Providers.Messaging
 								["type"] = type,
 								["category"] = channelName,
 								["eventCode"] = eventCode,
-								["gcm.message_id"] = "123"
+								["gcm.message_id"] = "123",
+								// node-apn merges `payload` in as the custom data at the top level of the
+								// APNs JSON; the nested `body` key is the one expo-notifications on iOS
+								// exposes as content.data.
+								["payload"] = new Dictionary<string, object>
+								{
+									["body"] = new
+									{
+										eventCode = eventCode,
+										type = type
+									},
+									["eventCode"] = eventCode,
+									["type"] = type
+								},
 							},
 						},
 						to = new[]{ new
@@ -657,7 +681,12 @@ namespace Resgrid.Providers.Messaging
 					}
 				},
 				eventCode = eventCode,
-				type = type
+				type = type,
+				body = new ApnsCustomData
+				{
+					eventCode = eventCode,
+					type = type
+				}
 			};
 
 			var appleNotification = JsonConvert.SerializeObject(apnsPayload);

--- a/Tests/Resgrid.Tests/Services/PushServiceModernApplicationSoundTests.cs
+++ b/Tests/Resgrid.Tests/Services/PushServiceModernApplicationSoundTests.cs
@@ -1,4 +1,4 @@
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Moq;
 using NUnit.Framework;
 using Resgrid.Config;
@@ -178,8 +178,8 @@ namespace Resgrid.Tests.Services
 			await _pushService.PushCall(call, UserId, profile);
 
 			_notificationProvider.Verify(x => x.SendAllNotifications(
-				call.SubTitle,
 				call.Title,
+				call.SubTitle,
 				UserId,
 				"C99",
 				((int)expectedSound).ToString(),


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request fixes push notification linking and payload consistency across chat, call, and Apple/iOS notification flows.

### What changed

- **Fixed direct chat push linking**
  - Corrected the ID used when sending a chat notification to a single recipient so it uses the recipient’s `UserId`.
  - This ensures chat push notifications link to the intended user correctly.

- **Fixed call push notification title/subtitle ordering**
  - Updated legacy Azure push notifications for calls to send the **title** and **subtitle** in the correct order.
  - This aligns the notification content shown to users with the intended call message format.

- **Updated Apple/iOS push payloads to include custom data in a `body` field**
  - Added a top-level `body` object containing `eventCode` and `type` in APNS payloads.
  - Applied this change in the bus notification provider, unit notification provider, and Novu provider.

- **Preserved backward compatibility for existing apps**
  - Existing top-level and older payload fields remain in place while adding the new `body` structure.
  - This supports newer iOS/Expo notification handling without removing data relied on by already deployed clients.

### Functional impact

These changes improve notification deep-linking and data delivery, especially for **iOS/Expo-based apps**, so notifications carry the expected metadata needed to open the correct screen or action when tapped.
<!-- kody-pr-summary:end -->