### PR TITLE
RG-T133 Chat system hardening, audit log fixes

### DIFF
--- a/Core/Resgrid.Model/Providers/ICacheProvider.cs
+++ b/Core/Resgrid.Model/Providers/ICacheProvider.cs
@@ -6,7 +6,7 @@ namespace Resgrid.Model.Providers
 	public interface ICacheProvider
 	{
 		T Retrieve<T>(string cacheKey, Func<T> fallbackFunction, TimeSpan expiration) where T : class;
-		Task<T> RetrieveAsync<T>(string cacheKey, Func<Task<T>> fallbackFunction, TimeSpan expiration) where T : class;
+		Task<T> RetrieveAsync<T>(string cacheKey, Func<Task<T>> fallbackFunction, TimeSpan expiration);
 		void Remove(string cacheKey);
 		Task<bool> RemoveAsync(string cacheKey);
 		bool IsConnected();

--- a/Core/Resgrid.Model/Services/IChatServices.cs
+++ b/Core/Resgrid.Model/Services/IChatServices.cs
@@ -8,7 +8,7 @@ namespace Resgrid.Model.Services
 	/// <summary>
 	/// Channel lifecycle: creation, membership, preferences and the idempotent Ensure* provisioning for
 	/// default (department/group), incident (call/lane/command) and chatbot channels.
-	/// AUTHORIZATION: unless a method documents its own enforcement (AddMembersAsync, EnsureMemberStateAsync),
+	/// AUTHORIZATION: unless a method documents its own enforcement,
 	/// the CALLER must verify access via IChatPermissionService before invoking these methods — the service
 	/// executes, it does not gate reads.
 	/// </summary>
@@ -30,25 +30,25 @@ namespace Resgrid.Model.Services
 
 		/// <summary>
 		/// Finds or creates the 1:1 channel between the creator and a user or unit (DmKey dedup).
-		/// Enforces cross-tenant rules: the target user/unit must belong to the department
+		/// Enforces cross-tenant rules: the creator and target user/unit must belong to the department
 		/// (UnauthorizedAccessException otherwise). The CALLER must verify the creator may open DMs.
 		/// </summary>
 		Task<ChatChannel> GetOrCreateDirectMessageChannelAsync(int departmentId, string creatorUserId, string targetUserId, int? targetUnitId, CancellationToken cancellationToken = default(CancellationToken));
 
 		/// <summary>
-		/// Creates an ad-hoc group channel. Enforces that every memberUserId belongs to the department
+		/// Creates an ad-hoc group channel. Enforces that the creator and every memberUserId belong to the department
 		/// (UnauthorizedAccessException otherwise). The CALLER must verify the creator may create groups.
 		/// </summary>
 		Task<ChatChannel> CreateAdHocGroupChannelAsync(int departmentId, string creatorUserId, string name, List<string> memberUserIds, CancellationToken cancellationToken = default(CancellationToken));
 
-		/// <summary>Creates a permission-locked custom channel; rules are OR-evaluated (groups/roles/users). The CALLER must verify the creator may create custom channels.</summary>
+		/// <summary>Creates a permission-locked custom channel; rules are OR-evaluated (groups/roles/users). Enforces department membership and department-admin authority for the creator.</summary>
 		Task<ChatChannel> CreateCustomChannelAsync(int departmentId, string creatorUserId, string name, string topic, List<ChatChannelAccessRule> accessRules, CancellationToken cancellationToken = default(CancellationToken));
 
-		/// <summary>Name/topic update; the CALLER must verify moderator rights (CanModerateChannelAsync) first.</summary>
-		Task<ChatChannel> UpdateChannelAsync(string chatChannelId, string name, string topic, string byUserId, CancellationToken cancellationToken = default(CancellationToken));
+		/// <summary>Name/topic update; enforces the supplied department boundary and moderator rights internally.</summary>
+		Task<ChatChannel> UpdateChannelAsync(int departmentId, string chatChannelId, string name, string topic, string byUserId, CancellationToken cancellationToken = default(CancellationToken));
 
-		/// <summary>Archive/unarchive; the CALLER must verify moderator rights first.</summary>
-		Task<bool> SetChannelArchivedAsync(string chatChannelId, bool archived, string byUserId, CancellationToken cancellationToken = default(CancellationToken));
+		/// <summary>Archive/unarchive; enforces the supplied department boundary and moderator rights internally.</summary>
+		Task<bool> SetChannelArchivedAsync(int departmentId, string chatChannelId, bool archived, string byUserId, CancellationToken cancellationToken = default(CancellationToken));
 
 		/// <summary>Raw member list; the CALLER must verify the user can access the channel first.</summary>
 		Task<List<ChatChannelMember>> GetMembersAsync(string chatChannelId);
@@ -69,18 +69,16 @@ namespace Resgrid.Model.Services
 		Task<ChatChannelMember> GetUnitMembershipAsync(string chatChannelId, int unitId);
 
 		/// <summary>
-		/// Adds members. Enforcement inside: DirectMessage channels reject adds (InvalidOperationException),
-		/// CustomLocked channels require the actor to be a moderator (UnauthorizedAccessException), and every
-		/// userId must belong to the channel's department (UnauthorizedAccessException). Other channel types
-		/// rely on the CALLER to authorize the actor first.
+		/// Adds members. Enforces the supplied department boundary, supported channel types, actor membership
+		/// or moderator authority, and that every userId belongs to the channel's department.
 		/// </summary>
-		Task<List<ChatChannelMember>> AddMembersAsync(string chatChannelId, List<string> userIds, string addedByUserId, CancellationToken cancellationToken = default(CancellationToken));
+		Task<List<ChatChannelMember>> AddMembersAsync(int departmentId, string chatChannelId, List<string> userIds, string addedByUserId, CancellationToken cancellationToken = default(CancellationToken));
 
-		/// <summary>Marks the member removed (leave or kick); history row kept. The CALLER must verify the actor is the member themselves or a moderator.</summary>
-		Task<bool> RemoveMemberAsync(string chatChannelId, string userId, string removedByUserId, CancellationToken cancellationToken = default(CancellationToken));
+		/// <summary>Marks the member removed (leave or kick); enforces department scope and self-or-moderator authority internally.</summary>
+		Task<bool> RemoveMemberAsync(int departmentId, string chatChannelId, string userId, string removedByUserId, CancellationToken cancellationToken = default(CancellationToken));
 
-		/// <summary>Replaces all access rules atomically; the CALLER must verify moderator rights first.</summary>
-		Task<bool> ReplaceAccessRulesAsync(string chatChannelId, List<ChatChannelAccessRule> accessRules, string byUserId, CancellationToken cancellationToken = default(CancellationToken));
+		/// <summary>Replaces all access rules atomically; enforces department scope and moderator rights internally.</summary>
+		Task<bool> ReplaceAccessRulesAsync(int departmentId, string chatChannelId, List<ChatChannelAccessRule> accessRules, string byUserId, CancellationToken cancellationToken = default(CancellationToken));
 
 		/// <summary>
 		/// Returns the participant's member row for the channel, lazily creating one for implicit-audience
@@ -165,8 +163,8 @@ namespace Resgrid.Model.Services
 		/// <summary>Department chat settings (config defaults when no row exists); no authorization — safe for any department-scoped caller.</summary>
 		Task<ChatDepartmentSetting> GetDepartmentSettingsAsync(int departmentId);
 
-		/// <summary>Persists department chat settings; the CALLER must verify department-admin rights first.</summary>
-		Task<ChatDepartmentSetting> SaveDepartmentSettingsAsync(ChatDepartmentSetting settings, CancellationToken cancellationToken = default(CancellationToken));
+		/// <summary>Persists department chat settings after enforcing authenticated department-admin rights.</summary>
+		Task<ChatDepartmentSetting> SaveDepartmentSettingsAsync(int departmentId, string byUserId, ChatDepartmentSetting settings, CancellationToken cancellationToken = default(CancellationToken));
 	}
 
 	/// <summary>
@@ -183,6 +181,9 @@ namespace Resgrid.Model.Services
 	/// </summary>
 	public interface IChatPermissionService
 	{
+		/// <summary>True only when the user is a current, active member of the authenticated department.</summary>
+		Task<bool> IsActiveDepartmentUserAsync(int departmentId, string userId);
+
 		/// <summary>Can the user (optionally acting for a unit) read/join this channel.</summary>
 		Task<bool> CanAccessChannelAsync(ChatChannel channel, string userId, int? activeUnitId);
 
@@ -195,8 +196,14 @@ namespace Resgrid.Model.Services
 		/// <summary>True when the unit belongs to the department AND the user actively crews it (active unit role).</summary>
 		Task<bool> CanSendAsUnitAsync(string userId, int unitId, int departmentId);
 
+		/// <summary>True when the user has dispatch access in this department and may see its shared operational channels.</summary>
+		Task<bool> CanAccessDepartmentOperationalChannelsAsync(int departmentId, string userId);
+
 		/// <summary>True when the user holds an active incident-command role (or is the current IC) on the call.</summary>
 		Task<bool> CanSendAsIcAsync(string userId, int callId, int departmentId);
+
+		/// <summary>True when the active user/unit is currently assigned or dispatched to this same-department incident. Department-wide dispatch visibility is deliberately excluded.</summary>
+		Task<bool> CanAccessIncidentAsync(int departmentId, int callId, string userId, int? activeUnitId);
 
 		/// <summary>
 		/// Resolves the full user audience of a channel (for push notifications and urgent-ack provisioning).
@@ -209,6 +216,9 @@ namespace Resgrid.Model.Services
 
 		/// <summary>Drops cached permission evaluations for a channel (membership/roles changed) and bumps the channel-list cache version.</summary>
 		Task InvalidateChannelCacheAsync(string chatChannelId);
+
+		/// <summary>Current distributed authorization epoch used to isolate realtime channel groups after access changes.</summary>
+		Task<string> GetChannelAccessVersionAsync(string chatChannelId);
 	}
 
 	/// <summary>
@@ -245,42 +255,42 @@ namespace Resgrid.Model.Services
 
 	/// <summary>
 	/// Moderation: user flags, moderator actions (delete/mute/ban/lock), the immutable moderation audit
-	/// trail (mirrored to the department AuditLog) and records-request exports. Permission checks
-	/// (CanModerateChannelAsync) are the CALLER's responsibility — controllers gate, this executes.
+	/// trail (mirrored to the department AuditLog) and records-request exports. Mutations accept the
+	/// authenticated department/user separately and re-evaluate tenant and moderator authority internally.
 	/// </summary>
 	public interface IChatModerationService
 	{
-		/// <summary>Flags a message for review; dedupes an existing open flag by the same user. The CALLER must verify the user can access the channel.</summary>
-		Task<ChatMessageFlag> FlagMessageAsync(string chatMessageId, string flaggedByUserId, ChatFlagReason reason, string note, CancellationToken cancellationToken = default(CancellationToken));
+		/// <summary>Flags a message for review; enforces department scope and current channel access, then dedupes an existing open flag by the same user.</summary>
+		Task<ChatMessageFlag> FlagMessageAsync(int departmentId, string chatMessageId, string flaggedByUserId, ChatFlagReason reason, string note, CancellationToken cancellationToken = default(CancellationToken));
 
-		/// <summary>Flag queue for moderators; the CALLER must verify department-moderator rights first.</summary>
-		Task<List<ChatMessageFlag>> GetFlagsAsync(int departmentId, ChatFlagStatus status, int page, int pageSize);
+		/// <summary>Flag queue for current department administrators.</summary>
+		Task<List<ChatMessageFlag>> GetFlagsAsync(int departmentId, string byUserId, ChatFlagStatus status, int page, int pageSize);
 
-		/// <summary>Resolves a flag; departmentId must match the flag's department (cross-department ids are rejected) and only Open flags transition. The CALLER must verify moderator rights.</summary>
+		/// <summary>Resolves a flag for a current department administrator; cross-department ids are rejected and only Open flags transition.</summary>
 		Task<ChatMessageFlag> ResolveFlagAsync(string chatMessageFlagId, int departmentId, string byUserId, ChatFlagStatus resolution, string resolutionNote, CancellationToken cancellationToken = default(CancellationToken), ChatModerationContext context = null);
 
-		/// <summary>Moderator tombstone-delete; wraps IChatMessageService.DeleteMessageAsync with audit. The CALLER must verify moderator rights.</summary>
-		Task<bool> ModeratorDeleteMessageAsync(string chatMessageId, string byUserId, string reason, CancellationToken cancellationToken = default(CancellationToken), ChatModerationContext context = null);
+		/// <summary>Moderator tombstone-delete; enforces department scope and current channel moderator rights before audit.</summary>
+		Task<bool> ModeratorDeleteMessageAsync(int departmentId, string chatMessageId, string byUserId, string reason, CancellationToken cancellationToken = default(CancellationToken), ChatModerationContext context = null);
 
-		/// <summary>Mute/unmute a participant; the CALLER must verify moderator rights first.</summary>
-		Task<bool> SetUserMutedAsync(string chatChannelId, string targetUserId, DateTime? mutedUntil, string byUserId, string reason, CancellationToken cancellationToken = default(CancellationToken), ChatModerationContext context = null);
+		/// <summary>Mute/unmute a participant; enforces department scope and current channel moderator rights.</summary>
+		Task<bool> SetUserMutedAsync(int departmentId, string chatChannelId, string targetUserId, DateTime? mutedUntil, string byUserId, string reason, CancellationToken cancellationToken = default(CancellationToken), ChatModerationContext context = null);
 
-		/// <summary>Ban/unban a participant; the CALLER must verify moderator rights first.</summary>
-		Task<bool> SetUserBannedAsync(string chatChannelId, string targetUserId, bool banned, string byUserId, string reason, CancellationToken cancellationToken = default(CancellationToken), ChatModerationContext context = null);
+		/// <summary>Ban/unban a participant; enforces department scope and current channel moderator rights.</summary>
+		Task<bool> SetUserBannedAsync(int departmentId, string chatChannelId, string targetUserId, bool banned, string byUserId, string reason, CancellationToken cancellationToken = default(CancellationToken), ChatModerationContext context = null);
 
-		/// <summary>Lock/unlock a channel; the CALLER must verify moderator rights first.</summary>
-		Task<bool> SetChannelLockedAsync(string chatChannelId, bool locked, string byUserId, string reason, CancellationToken cancellationToken = default(CancellationToken), ChatModerationContext context = null);
+		/// <summary>Lock/unlock a channel; enforces department scope and current channel moderator rights.</summary>
+		Task<bool> SetChannelLockedAsync(int departmentId, string chatChannelId, bool locked, string byUserId, string reason, CancellationToken cancellationToken = default(CancellationToken), ChatModerationContext context = null);
 
-		/// <summary>Moderation audit trail; the CALLER must verify moderator rights first.</summary>
-		Task<List<ChatModerationAction>> GetModerationActionsAsync(int departmentId, string chatChannelId, int page, int pageSize);
+		/// <summary>Moderation audit trail for current department administrators.</summary>
+		Task<List<ChatModerationAction>> GetModerationActionsAsync(int departmentId, string byUserId, string chatChannelId, int page, int pageSize);
 
-		/// <summary>Queues a transcript export; the CALLER must verify moderator rights first.</summary>
+		/// <summary>Queues a transcript export after enforcing current department-admin and channel scope.</summary>
 		Task<ChatExport> RequestExportAsync(int departmentId, string byUserId, string chatChannelId, DateTime? startDate, DateTime? endDate, ChatExportFormat format, CancellationToken cancellationToken = default(CancellationToken), ChatModerationContext context = null);
 
-		/// <summary>Export list without result blobs; the CALLER must verify moderator rights first.</summary>
-		Task<List<ChatExport>> GetExportsAsync(int departmentId);
+		/// <summary>Export list without result blobs for current department administrators.</summary>
+		Task<List<ChatExport>> GetExportsAsync(int departmentId, string byUserId);
 
-		/// <summary>Full export row including result data; audits the download. The CALLER must verify moderator rights first.</summary>
+		/// <summary>Full export row including result data; enforces current department-admin rights and audits the download.</summary>
 		Task<ChatExport> GetExportForDownloadAsync(string chatExportId, int departmentId, string byUserId, CancellationToken cancellationToken = default(CancellationToken), ChatModerationContext context = null);
 	}
 
@@ -349,17 +359,17 @@ namespace Resgrid.Model.Services
 	/// <summary>
 	/// Message pipeline: validation, sequence allocation, mentions, urgent acks, edits/deletes with audit
 	/// history, reactions, pins, read pointers, paging/delta-sync, search. Publishes ChatEventRaised
-	/// envelopes for realtime fan-out. SendMessageAsync enforces posting permissions internally; every
-	/// other method requires the CALLER to authorize via IChatPermissionService first.
+	/// envelopes for realtime fan-out. Every mutation takes the authenticated department and user identity
+	/// separately from client DTOs and re-evaluates tenant scope and channel permissions internally.
 	/// </summary>
 	public interface IChatMessageService
 	{
 		/// <summary>
 		/// Sends a message as the authenticated user. Enforces CanPostAsync (access, mute/ban, lock) and
-		/// AsUnitId/AsIncidentCommander identity checks internally; <paramref name="senderUserId"/> MUST be
-		/// the authenticated user, supplied by the caller — never client input.
+		/// AsUnitId/AsIncidentCommander identity checks internally; <paramref name="departmentId"/> and
+		/// <paramref name="senderUserId"/> MUST come from the authenticated principal — never client input.
 		/// </summary>
-		Task<ChatMessage> SendMessageAsync(string senderUserId, ChatMessageSendRequest request, CancellationToken cancellationToken = default(CancellationToken));
+		Task<ChatMessage> SendMessageAsync(int departmentId, string senderUserId, ChatMessageSendRequest request, CancellationToken cancellationToken = default(CancellationToken));
 
 		/// <summary>
 		/// Internal bot send (chatbot pipeline): skips user permission checks, records no SenderUserId,
@@ -379,17 +389,17 @@ namespace Resgrid.Model.Services
 		/// <summary>Thread page; the CALLER must verify channel access first.</summary>
 		Task<List<ChatMessage>> GetThreadPageAsync(string threadRootMessageId, long? beforeSeq, int limit);
 
-		/// <summary>Sender edit (enforced inside: only the original sender); prior body preserved in ChatMessageEdits.</summary>
-		Task<ChatMessage> EditMessageAsync(string chatMessageId, string editorUserId, string newBody, CancellationToken cancellationToken = default(CancellationToken));
+		/// <summary>Sender edit; enforces department scope, channel access and original-sender identity internally.</summary>
+		Task<ChatMessage> EditMessageAsync(int departmentId, string chatMessageId, string editorUserId, string newBody, CancellationToken cancellationToken = default(CancellationToken));
 
-		/// <summary>Tombstone delete; sender self-delete or moderator (asModerator) enforced inside — asModerator must only be set after the caller verified CanModerateChannelAsync. Body preserved in ChatMessageEdits until retention purge.</summary>
-		Task<bool> DeleteMessageAsync(string chatMessageId, string byUserId, bool asModerator, string reason, CancellationToken cancellationToken = default(CancellationToken));
+		/// <summary>Tombstone delete; enforces department scope and channel access. A requested moderator delete is independently verified against current channel permissions.</summary>
+		Task<bool> DeleteMessageAsync(int departmentId, string chatMessageId, string byUserId, bool asModerator, string reason, CancellationToken cancellationToken = default(CancellationToken));
 
-		/// <summary>Adds a reaction; banned/muted participants are silently skipped. The CALLER must verify channel access first.</summary>
-		Task<bool> AddReactionAsync(string chatMessageId, string userId, int? unitId, string emoji, CancellationToken cancellationToken = default(CancellationToken));
+		/// <summary>Adds a reaction; enforces department scope, current channel access, unit authority and mute/ban state internally.</summary>
+		Task<bool> AddReactionAsync(int departmentId, string chatMessageId, string userId, int? unitId, string emoji, CancellationToken cancellationToken = default(CancellationToken));
 
-		/// <summary>Removes a reaction; the CALLER must verify channel access first.</summary>
-		Task<bool> RemoveReactionAsync(string chatMessageId, string userId, int? unitId, string emoji, CancellationToken cancellationToken = default(CancellationToken));
+		/// <summary>Removes a reaction; enforces department scope, current channel access and unit authority internally.</summary>
+		Task<bool> RemoveReactionAsync(int departmentId, string chatMessageId, string userId, int? unitId, string emoji, CancellationToken cancellationToken = default(CancellationToken));
 
 		/// <summary>Reaction rows for rendering; the CALLER must verify channel access first.</summary>
 		Task<List<ChatMessageReaction>> GetReactionsForMessagesAsync(List<string> chatMessageIds);
@@ -397,14 +407,14 @@ namespace Resgrid.Model.Services
 		/// <summary>Attachment metadata for rendering; the CALLER must verify channel access first.</summary>
 		Task<List<ChatAttachment>> GetAttachmentMetadataForMessagesAsync(List<string> chatMessageIds);
 
-		/// <summary>Pin/unpin; the CALLER must verify moderator rights first.</summary>
-		Task<bool> SetMessagePinnedAsync(string chatMessageId, string byUserId, bool pinned, CancellationToken cancellationToken = default(CancellationToken));
+		/// <summary>Pin/unpin; enforces department scope and moderator rights internally.</summary>
+		Task<bool> SetMessagePinnedAsync(int departmentId, string chatMessageId, string byUserId, bool pinned, CancellationToken cancellationToken = default(CancellationToken));
 
 		/// <summary>Pinned messages; the CALLER must verify channel access first.</summary>
 		Task<List<ChatMessage>> GetPinnedMessagesAsync(string chatChannelId);
 
-		/// <summary>Acknowledges an urgent message for the user; returns rows stamped (0 = nothing pending).</summary>
-		Task<int> AcknowledgeMessageAsync(string chatMessageId, string userId, CancellationToken cancellationToken = default(CancellationToken));
+		/// <summary>Acknowledges an urgent message; enforces department scope and current channel access before stamping the caller's row.</summary>
+		Task<int> AcknowledgeMessageAsync(int departmentId, string chatMessageId, string userId, CancellationToken cancellationToken = default(CancellationToken));
 
 		/// <summary>Ack rows for a message; the CALLER must verify channel access first.</summary>
 		Task<List<ChatMessageAck>> GetAcksForMessageAsync(string chatMessageId);

--- a/Core/Resgrid.Services/ChatChannelService.cs
+++ b/Core/Resgrid.Services/ChatChannelService.cs
@@ -22,6 +22,7 @@ namespace Resgrid.Services
 	public class ChatChannelService : IChatChannelService
 	{
 		private static readonly TimeSpan ChannelListCacheLength = TimeSpan.FromSeconds(45);
+		private const int MaxDerivedGroupNameLength = 100;
 
 		/// <summary>How long a completed incident-channel backfill suppresses the next sweep for that command.</summary>
 		private static readonly TimeSpan IncidentBackfillCacheLength = TimeSpan.FromMinutes(30);
@@ -87,6 +88,10 @@ namespace Resgrid.Services
 
 		public async Task<List<ChatChannel>> GetChannelsForUserAsync(int departmentId, string userId, int? activeUnitId, bool includeArchived = false)
 		{
+			if (departmentId <= 0 || string.IsNullOrWhiteSpace(userId) ||
+				!await IsActiveDepartmentUserAsync(departmentId, userId))
+				return new List<ChatChannel>();
+
 			async Task<List<ChatChannel>> getChannels()
 			{
 				var results = new Dictionary<string, ChatChannel>(StringComparer.OrdinalIgnoreCase);
@@ -99,11 +104,12 @@ namespace Resgrid.Services
 				// implicit-audience pass further down.
 				var allChannels = await _chatChannelRepository.GetAllByDepartmentIdAsync(departmentId, includeArchived);
 
-				// Department admins get every group's default channel; everyone else gets only the group
-				// they belong to. Existing channels come from the bulk load above — only groups with no
-				// channel yet hit the provisioning path, and a failure there is contained per group so one
-				// bad group can never blank the admin's whole channel list.
-				if (await _chatPermissionService.IsDepartmentAdminAsync(departmentId, userId))
+				// Department admins and dispatchers get every group's default channel; everyone else gets
+				// only the group they belong to. Existing channels come from the bulk load above — only
+				// groups with no channel yet hit provisioning, and one bad group cannot blank the list.
+				var canSeeAllOperationalChannels = await _chatPermissionService.IsDepartmentAdminAsync(departmentId, userId) ||
+					await _chatPermissionService.CanAccessDepartmentOperationalChannelsAsync(departmentId, userId);
+				if (canSeeAllOperationalChannels)
 				{
 					var allGroups = await _departmentGroupsService.GetAllGroupsForDepartmentAsync(departmentId);
 					if (allGroups != null && allGroups.Count > 0)
@@ -160,7 +166,13 @@ namespace Resgrid.Services
 					var channels = await _chatChannelRepository.GetByIdsAsync(membershipIds);
 					if (channels != null)
 						foreach (var channel in channels)
-							results[channel.ChatChannelId] = channel;
+						{
+							// Incident/default membership rows are only read-state. They can outlive the
+							// assignment that originally granted access, so every row must be re-evaluated.
+							if (channel.DepartmentId == departmentId &&
+								await _chatPermissionService.CanAccessChannelAsync(channel, userId, activeUnitId))
+								results[channel.ChatChannelId] = channel;
+						}
 				}
 
 				// Channels where the active unit is the participant (Dispatch/IC ↔ unit DMs, units
@@ -194,7 +206,11 @@ namespace Resgrid.Services
 						var channels = await _chatChannelRepository.GetByIdsAsync(unitChannelIds);
 						if (channels != null)
 							foreach (var channel in channels)
-								results[channel.ChatChannelId] = channel;
+							{
+								if (channel.DepartmentId == departmentId &&
+									await _chatPermissionService.CanAccessChannelAsync(channel, userId, activeUnitId))
+									results[channel.ChatChannelId] = channel;
+							}
 					}
 				}
 
@@ -221,7 +237,7 @@ namespace Resgrid.Services
 				}
 
 				return results.Values
-					.Where(c => includeArchived || !c.IsArchived)
+					.Where(c => c.DepartmentId == departmentId && (includeArchived || !c.IsArchived))
 					.OrderByDescending(c => c.LastMessageOn ?? c.CreatedOn)
 					.ToList();
 			}
@@ -239,19 +255,17 @@ namespace Resgrid.Services
 
 		public async Task<ChatChannel> GetOrCreateDirectMessageChannelAsync(int departmentId, string creatorUserId, string targetUserId, int? targetUnitId, CancellationToken cancellationToken = default(CancellationToken))
 		{
-			if (string.IsNullOrWhiteSpace(targetUserId) && !targetUnitId.HasValue)
+			var hasTargetUser = !string.IsNullOrWhiteSpace(targetUserId);
+			if (departmentId <= 0 || string.IsNullOrWhiteSpace(creatorUserId) || hasTargetUser == targetUnitId.HasValue)
 				return null;
+
+			if (!await IsActiveDepartmentUserAsync(departmentId, creatorUserId))
+				throw new UnauthorizedAccessException("The creator does not belong to this department.");
 
 			// A DM with yourself would put the same user in the member list twice and violate
 			// the unique (ChatChannelId, UserId) member index; the clients never offer it.
 			if (!targetUnitId.HasValue && string.Equals(creatorUserId, targetUserId, StringComparison.OrdinalIgnoreCase))
 				return null;
-
-			var dmKey = BuildDmKey(creatorUserId, targetUserId, targetUnitId);
-
-			var existing = await _chatChannelRepository.GetByDmKeyAsync(departmentId, dmKey);
-			if (existing != null)
-				return existing;
 
 			Unit targetUnit = null;
 			if (targetUnitId.HasValue)
@@ -260,10 +274,16 @@ namespace Resgrid.Services
 				if (targetUnit == null || targetUnit.DepartmentId != departmentId)
 					throw new UnauthorizedAccessException("The target unit does not belong to this department.");
 			}
-			else if (!await _departmentsService.IsUserInDepartmentAsync(departmentId, targetUserId))
+			else if (!await IsActiveDepartmentUserAsync(departmentId, targetUserId))
 			{
 				throw new UnauthorizedAccessException("The target user does not belong to this department.");
 			}
+
+			var dmKey = BuildDmKey(creatorUserId, targetUserId, targetUnitId);
+
+			var existing = await _chatChannelRepository.GetByDmKeyAsync(departmentId, dmKey);
+			if (existing != null)
+				return existing.DepartmentId == departmentId ? existing : null;
 
 			var channel = new ChatChannel
 			{
@@ -316,6 +336,10 @@ namespace Resgrid.Services
 
 		public async Task<ChatChannel> CreateAdHocGroupChannelAsync(int departmentId, string creatorUserId, string name, List<string> memberUserIds, CancellationToken cancellationToken = default(CancellationToken))
 		{
+			if (departmentId <= 0 || string.IsNullOrWhiteSpace(creatorUserId) ||
+				!await IsActiveDepartmentUserAsync(departmentId, creatorUserId))
+				throw new UnauthorizedAccessException("The creator does not belong to this department.");
+
 			// Validate all member memberships before any write, so an invalid member never leaves an
 			// orphaned channel or partial member rows to roll back.
 			var validatedMemberIds = memberUserIds == null
@@ -326,6 +350,15 @@ namespace Resgrid.Services
 			var membersInDepartment = await _departmentsService.GetMemberUserIdsInDepartmentAsync(departmentId, validatedMemberIds);
 			if (validatedMemberIds.Any(id => !membersInDepartment.Contains(id)))
 				throw new UnauthorizedAccessException("Every member must belong to this department.");
+
+			foreach (var memberId in validatedMemberIds)
+			{
+				if (await _departmentsService.IsUserDisabledAsync(memberId, departmentId))
+					throw new UnauthorizedAccessException("Every member must be active in this department.");
+			}
+
+			if (string.IsNullOrWhiteSpace(name))
+				name = await BuildAdHocGroupNameAsync(validatedMemberIds);
 
 			var channel = new ChatChannel
 			{
@@ -352,8 +385,56 @@ namespace Resgrid.Services
 			return channel;
 		}
 
+		private async Task<string> BuildAdHocGroupNameAsync(List<string> memberUserIds)
+		{
+			var names = new List<string>();
+			if (memberUserIds != null && memberUserIds.Count > 0)
+			{
+				var profiles = await _userProfileService.GetSelectedUserProfilesAsync(memberUserIds);
+				foreach (var profile in profiles ?? new List<UserProfile>())
+				{
+					var displayName = profile?.FullName?.AsFirstNameLastName;
+					if (!string.IsNullOrWhiteSpace(displayName))
+						names.Add(displayName);
+				}
+			}
+
+			if (names.Count == 0)
+				return "New group";
+
+			names.Sort(StringComparer.OrdinalIgnoreCase);
+			var joined = string.Join(", ", names);
+			if (joined.Length <= MaxDerivedGroupNameLength)
+				return joined;
+
+			var kept = new List<string>();
+			var length = 0;
+			foreach (var displayName in names)
+			{
+				var addition = (kept.Count == 0 ? 0 : 2) + displayName.Length;
+				if (length + addition + 6 > MaxDerivedGroupNameLength)
+					break;
+
+				kept.Add(displayName);
+				length += addition;
+			}
+
+			if (kept.Count == 0)
+				kept.Add(names[0].Length > MaxDerivedGroupNameLength - 6
+					? names[0].Substring(0, MaxDerivedGroupNameLength - 6)
+					: names[0]);
+
+			var remaining = names.Count - kept.Count;
+			return remaining > 0 ? $"{string.Join(", ", kept)} +{remaining}" : string.Join(", ", kept);
+		}
+
 		public async Task<ChatChannel> CreateCustomChannelAsync(int departmentId, string creatorUserId, string name, string topic, List<ChatChannelAccessRule> accessRules, CancellationToken cancellationToken = default(CancellationToken))
 		{
+			if (departmentId <= 0 || string.IsNullOrWhiteSpace(creatorUserId) ||
+				!await IsActiveDepartmentUserAsync(departmentId, creatorUserId) ||
+				!await _chatPermissionService.IsDepartmentAdminAsync(departmentId, creatorUserId))
+				throw new UnauthorizedAccessException("Only an administrator in this department can create a custom channel.");
+
 			var channel = new ChatChannel
 			{
 				ChatChannelId = Guid.NewGuid().ToString(),
@@ -389,10 +470,11 @@ namespace Resgrid.Services
 			return channel;
 		}
 
-		public async Task<ChatChannel> UpdateChannelAsync(string chatChannelId, string name, string topic, string byUserId, CancellationToken cancellationToken = default(CancellationToken))
+		public async Task<ChatChannel> UpdateChannelAsync(int departmentId, string chatChannelId, string name, string topic, string byUserId, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			var channel = await _chatChannelRepository.GetByIdAsync(chatChannelId);
-			if (channel == null)
+			if (channel == null || channel.DepartmentId != departmentId ||
+				!await _chatPermissionService.CanModerateChannelAsync(channel, byUserId))
 				return null;
 
 			// Targeted update: a full-row write here would rewind LastMessageSeq/LastMessageOn over the
@@ -409,10 +491,11 @@ namespace Resgrid.Services
 			return channel;
 		}
 
-		public async Task<bool> SetChannelArchivedAsync(string chatChannelId, bool archived, string byUserId, CancellationToken cancellationToken = default(CancellationToken))
+		public async Task<bool> SetChannelArchivedAsync(int departmentId, string chatChannelId, bool archived, string byUserId, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			var channel = await _chatChannelRepository.GetByIdAsync(chatChannelId);
-			if (channel == null)
+			if (channel == null || channel.DepartmentId != departmentId ||
+				!await _chatPermissionService.CanModerateChannelAsync(channel, byUserId))
 				return false;
 
 			var archivedOn = archived ? DateTime.UtcNow : (DateTime?)null;
@@ -431,8 +514,12 @@ namespace Resgrid.Services
 
 		public async Task<List<ChatChannelMember>> GetMembersAsync(string chatChannelId)
 		{
+			var channel = await _chatChannelRepository.GetByIdAsync(chatChannelId);
+			if (channel == null)
+				return new List<ChatChannelMember>();
+
 			var members = await _chatChannelMemberRepository.GetByChannelIdAsync(chatChannelId);
-			return members?.ToList() ?? new List<ChatChannelMember>();
+			return members?.Where(m => m.DepartmentId == channel.DepartmentId).ToList() ?? new List<ChatChannelMember>();
 		}
 
 		public async Task<List<ChatChannelMember>> GetActiveMembershipsForUserAsync(int departmentId, string userId)
@@ -466,18 +553,25 @@ namespace Resgrid.Services
 			return await _chatChannelMemberRepository.GetUnitMemberAsync(chatChannelId, unitId);
 		}
 
-		public async Task<List<ChatChannelMember>> AddMembersAsync(string chatChannelId, List<string> userIds, string addedByUserId, CancellationToken cancellationToken = default(CancellationToken))
+		public async Task<List<ChatChannelMember>> AddMembersAsync(int departmentId, string chatChannelId, List<string> userIds, string addedByUserId, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			var channel = await _chatChannelRepository.GetByIdAsync(chatChannelId);
-			if (channel == null)
+			if (channel == null || channel.DepartmentId != departmentId)
 				return new List<ChatChannelMember>();
 
 			if (channel.ChannelType == (int)ChatChannelType.DirectMessage)
 				throw new InvalidOperationException("Direct message channels have a fixed membership.");
 
-			if (channel.ChannelType == (int)ChatChannelType.CustomLocked &&
-				!await _chatPermissionService.CanModerateChannelAsync(channel, addedByUserId))
-				throw new UnauthorizedAccessException("Only channel moderators can add members to this channel.");
+			if (channel.ChannelType != (int)ChatChannelType.AdHocGroup && channel.ChannelType != (int)ChatChannelType.CustomLocked)
+				throw new InvalidOperationException("Members cannot be added to this channel type.");
+
+			var canModerate = await _chatPermissionService.CanModerateChannelAsync(channel, addedByUserId);
+			var actorMember = await _chatChannelMemberRepository.GetUserMemberAsync(chatChannelId, addedByUserId);
+			var isActiveMember = actorMember != null && actorMember.DepartmentId == departmentId && !actorMember.RemovedOn.HasValue &&
+				await IsActiveDepartmentUserAsync(departmentId, addedByUserId);
+
+			if ((channel.ChannelType == (int)ChatChannelType.CustomLocked && !canModerate) || (!isActiveMember && !canModerate))
+				throw new UnauthorizedAccessException("The actor cannot add members to this channel.");
 
 			var added = new List<ChatChannelMember>();
 
@@ -485,7 +579,7 @@ namespace Resgrid.Services
 			{
 				foreach (var userId in userIds.Where(u => !string.IsNullOrWhiteSpace(u)).Distinct())
 				{
-					if (!await _departmentsService.IsUserInDepartmentAsync(channel.DepartmentId, userId))
+					if (!await IsActiveDepartmentUserAsync(channel.DepartmentId, userId))
 						throw new UnauthorizedAccessException("Every member must belong to this department.");
 
 					var existing = await _chatChannelMemberRepository.GetUserMemberAsync(chatChannelId, userId);
@@ -517,26 +611,34 @@ namespace Resgrid.Services
 			return added;
 		}
 
-		public async Task<bool> RemoveMemberAsync(string chatChannelId, string userId, string removedByUserId, CancellationToken cancellationToken = default(CancellationToken))
+		public async Task<bool> RemoveMemberAsync(int departmentId, string chatChannelId, string userId, string removedByUserId, CancellationToken cancellationToken = default(CancellationToken))
 		{
+			var channel = await _chatChannelRepository.GetByIdAsync(chatChannelId);
+			if (channel == null || channel.DepartmentId != departmentId ||
+				!await IsActiveDepartmentUserAsync(departmentId, removedByUserId))
+				return false;
+
+			if (!string.Equals(userId, removedByUserId, StringComparison.OrdinalIgnoreCase) &&
+				!await _chatPermissionService.CanModerateChannelAsync(channel, removedByUserId))
+				return false;
+
 			var member = await _chatChannelMemberRepository.GetUserMemberAsync(chatChannelId, userId);
-			if (member == null || member.RemovedOn.HasValue)
+			if (member == null || member.DepartmentId != departmentId || member.RemovedOn.HasValue)
 				return false;
 
 			await _chatChannelMemberRepository.SetMemberActiveAsync(member.ChatChannelMemberId, false, cancellationToken);
 			await _chatPermissionService.InvalidateChannelCacheAsync(chatChannelId);
 
-			var channel = await _chatChannelRepository.GetByIdAsync(chatChannelId);
-			if (channel != null)
-				PublishChannelEvent(channel, ChatEventKinds.ChannelUpdated);
+			PublishChannelEvent(channel, ChatEventKinds.ChannelUpdated);
 
 			return true;
 		}
 
-		public async Task<bool> ReplaceAccessRulesAsync(string chatChannelId, List<ChatChannelAccessRule> accessRules, string byUserId, CancellationToken cancellationToken = default(CancellationToken))
+		public async Task<bool> ReplaceAccessRulesAsync(int departmentId, string chatChannelId, List<ChatChannelAccessRule> accessRules, string byUserId, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			var channel = await _chatChannelRepository.GetByIdAsync(chatChannelId);
-			if (channel == null || channel.ChannelType != (int)ChatChannelType.CustomLocked)
+			if (channel == null || channel.DepartmentId != departmentId || channel.ChannelType != (int)ChatChannelType.CustomLocked ||
+				!await _chatPermissionService.CanModerateChannelAsync(channel, byUserId))
 				return false;
 
 			// Open a shared connection/transaction so the delete and re-inserts commit atomically.
@@ -577,7 +679,8 @@ namespace Resgrid.Services
 		public async Task<ChatChannelMember> EnsureMemberStateAsync(string chatChannelId, int departmentId, string userId, int? unitId, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			var channel = await _chatChannelRepository.GetByIdAsync(chatChannelId);
-			if (channel == null)
+			if (channel == null || channel.DepartmentId != departmentId || string.IsNullOrWhiteSpace(userId) ||
+				!await _chatPermissionService.CanAccessChannelAsync(channel, userId, unitId))
 				return null;
 
 			// Invite-only channel types never self-grant membership: an existing row is reactivated,
@@ -605,6 +708,8 @@ namespace Resgrid.Services
 					throw new UnauthorizedAccessException("Membership in this channel is by invitation only.");
 
 				var unit = await _unitsService.GetUnitByIdAsync(unitId.Value);
+				if (unit == null || unit.DepartmentId != channel.DepartmentId)
+					throw new UnauthorizedAccessException("The unit does not belong to this channel's department.");
 
 				return await _chatChannelMemberRepository.InsertAsync(new ChatChannelMember
 				{
@@ -955,9 +1060,17 @@ namespace Resgrid.Services
 			// EnsureIncidentChannelsAsync, a closed command provisions nothing, and reopening a reused
 			// line here would lift the archive freeze the close put on it.
 			var command = await _incidentCommandService.GetCommandForCallAsync(departmentId, callId);
-			if (command == null || command.Status != (int)IncidentCommandStatus.Active ||
+			if (command == null || command.DepartmentId != departmentId || command.CallId != callId ||
+				command.Status != (int)IncidentCommandStatus.Active ||
 			    string.IsNullOrWhiteSpace(command.CurrentCommanderUserId))
 				return null;
+
+			if (!await _chatPermissionService.CanAccessIncidentAsync(departmentId, callId, requesterUserId, requesterUnitId))
+				throw new UnauthorizedAccessException("The requester is not assigned to this incident.");
+
+			if (requesterUnitId.HasValue &&
+				!await _chatPermissionService.CanSendAsUnitAsync(requesterUserId, requesterUnitId.Value, departmentId))
+				throw new UnauthorizedAccessException("The requester cannot act as this unit.");
 
 			Unit requesterUnit = null;
 			if (requesterUnitId.HasValue)
@@ -1115,9 +1228,15 @@ namespace Resgrid.Services
 
 		public async Task<ChatChannel> EnsureChatbotChannelAsync(int departmentId, string userId, CancellationToken cancellationToken = default(CancellationToken))
 		{
+			if (departmentId <= 0 || string.IsNullOrWhiteSpace(userId) ||
+				!await IsActiveDepartmentUserAsync(departmentId, userId))
+				return null;
+
 			var existing = await _chatChannelRepository.GetChatbotChannelAsync(departmentId, userId);
 			if (existing != null)
-				return existing;
+				return existing.DepartmentId == departmentId && string.Equals(existing.OwnerUserId, userId, StringComparison.OrdinalIgnoreCase)
+					? existing
+					: null;
 
 			var channel = await InsertProvisionedChannelAsync(new ChatChannel
 			{
@@ -1148,6 +1267,13 @@ namespace Resgrid.Services
 			}
 
 			return channel;
+		}
+
+		private async Task<bool> IsActiveDepartmentUserAsync(int departmentId, string userId)
+		{
+			return departmentId > 0 && !string.IsNullOrWhiteSpace(userId) &&
+				await _departmentsService.IsUserInDepartmentAsync(departmentId, userId) &&
+				!await _departmentsService.IsUserDisabledAsync(userId, departmentId);
 		}
 
 		public async Task<bool> SetIncidentChannelsArchivedAsync(int callId, bool archived, CancellationToken cancellationToken = default(CancellationToken))
@@ -1209,8 +1335,12 @@ namespace Resgrid.Services
 			};
 		}
 
-		public async Task<ChatDepartmentSetting> SaveDepartmentSettingsAsync(ChatDepartmentSetting settings, CancellationToken cancellationToken = default(CancellationToken))
+		public async Task<ChatDepartmentSetting> SaveDepartmentSettingsAsync(int departmentId, string byUserId, ChatDepartmentSetting settings, CancellationToken cancellationToken = default(CancellationToken))
 		{
+			if (settings == null || settings.DepartmentId != departmentId ||
+				!await _chatPermissionService.IsDepartmentAdminAsync(departmentId, byUserId))
+				return null;
+
 			var existing = await _chatDepartmentSettingRepository.GetByDepartmentIdAsync(settings.DepartmentId);
 			if (existing == null)
 			{

--- a/Core/Resgrid.Services/ChatChannelService.cs
+++ b/Core/Resgrid.Services/ChatChannelService.cs
@@ -1272,8 +1272,7 @@ namespace Resgrid.Services
 		private async Task<bool> IsActiveDepartmentUserAsync(int departmentId, string userId)
 		{
 			return departmentId > 0 && !string.IsNullOrWhiteSpace(userId) &&
-				await _departmentsService.IsUserInDepartmentAsync(departmentId, userId) &&
-				!await _departmentsService.IsUserDisabledAsync(userId, departmentId);
+				await _chatPermissionService.IsActiveDepartmentUserAsync(departmentId, userId);
 		}
 
 		public async Task<bool> SetIncidentChannelsArchivedAsync(int callId, bool archived, CancellationToken cancellationToken = default(CancellationToken))

--- a/Core/Resgrid.Services/ChatMessageService.cs
+++ b/Core/Resgrid.Services/ChatMessageService.cs
@@ -61,13 +61,13 @@ namespace Resgrid.Services
 			_eventAggregator = eventAggregator;
 		}
 
-		public async Task<ChatMessage> SendMessageAsync(string senderUserId, ChatMessageSendRequest request, CancellationToken cancellationToken = default(CancellationToken))
+		public async Task<ChatMessage> SendMessageAsync(int departmentId, string senderUserId, ChatMessageSendRequest request, CancellationToken cancellationToken = default(CancellationToken))
 		{
-			if (request == null || string.IsNullOrWhiteSpace(request.ChatChannelId) || string.IsNullOrWhiteSpace(senderUserId))
+			if (departmentId <= 0 || request == null || string.IsNullOrWhiteSpace(request.ChatChannelId) || string.IsNullOrWhiteSpace(senderUserId))
 				return null;
 
 			var channel = await _chatChannelRepository.GetByIdAsync(request.ChatChannelId);
-			if (channel == null || channel.DepartmentId != request.DepartmentId)
+			if (channel == null || channel.DepartmentId != departmentId)
 				return null;
 
 			// Idempotent resend from the mobile offline outbox.
@@ -262,31 +262,42 @@ namespace Resgrid.Services
 		}
 
 		/// <summary>
-		/// True when the channel is archived, i.e. frozen as a point-in-time record: a closed incident
-		/// command's channel and its lane channels, or a closed call's channel. Posting is already blocked
-		/// by <c>IChatPermissionService.CanPostAsync</c>; this is the matching gate for mutating what is
-		/// already there. Moderation (flagging, moderator delete) deliberately does NOT consult it.
-		/// A missing channel reads as frozen — fail closed rather than allow an unanchored edit.
+		/// Resolves a message's persisted channel inside the authenticated tenant and re-evaluates the
+		/// actor's current access. Message/channel disagreement fails closed. Moderator mode never trusts
+		/// a caller-provided role flag: current moderator authority is loaded from the permission service.
 		/// </summary>
-		private async Task<bool> IsChannelFrozenAsync(string chatChannelId)
+		private async Task<ChatChannel> GetAuthorizedMessageChannelAsync(ChatMessage message, int departmentId,
+			string userId, int? unitId, bool requireModerator = false)
 		{
-			if (string.IsNullOrWhiteSpace(chatChannelId))
-				return true;
+			if (message == null || departmentId <= 0 || message.DepartmentId != departmentId ||
+				string.IsNullOrWhiteSpace(message.ChatChannelId) || string.IsNullOrWhiteSpace(userId))
+				return null;
 
-			var channel = await _chatChannelRepository.GetByIdAsync(chatChannelId);
-			return channel == null || channel.IsArchived;
+			var channel = await _chatChannelRepository.GetByIdAsync(message.ChatChannelId);
+			if (channel == null || channel.DepartmentId != departmentId)
+				return null;
+
+			var authorized = requireModerator
+				? await _chatPermissionService.CanModerateChannelAsync(channel, userId)
+				: await _chatPermissionService.CanAccessChannelAsync(channel, userId, unitId);
+
+			return authorized ? channel : null;
 		}
 
-		public async Task<ChatMessage> EditMessageAsync(string chatMessageId, string editorUserId, string newBody, CancellationToken cancellationToken = default(CancellationToken))
+		public async Task<ChatMessage> EditMessageAsync(int departmentId, string chatMessageId, string editorUserId, string newBody, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			var message = await _chatMessageRepository.GetByIdAsync(chatMessageId);
-			if (message == null || message.DeletedOn.HasValue)
+			if (message == null || message.DeletedOn.HasValue || message.DepartmentId != departmentId)
+				return null;
+
+			var channel = await GetAuthorizedMessageChannelAsync(message, departmentId, editorUserId, null);
+			if (channel == null)
 				return null;
 
 			// An archived channel is a point-in-time record (a closed incident command/lane chat, a closed
 			// call). CanPostAsync already refuses new messages there; the history has to be just as
 			// immutable, or the record could still be rewritten after the fact.
-			if (await IsChannelFrozenAsync(message.ChatChannelId))
+			if (channel.IsArchived)
 				return null;
 
 			if (!string.Equals(message.SenderUserId, editorUserId, StringComparison.OrdinalIgnoreCase))
@@ -306,16 +317,15 @@ namespace Resgrid.Services
 			message.Body = newBody;
 			message.EditedOn = editedOn;
 
-			var channel = await _chatChannelRepository.GetByIdAsync(message.ChatChannelId);
 			PublishEvent(channel, ChatEventKinds.MessageEdited, BuildMessageDto(message));
 
 			return message;
 		}
 
-		public async Task<bool> DeleteMessageAsync(string chatMessageId, string byUserId, bool asModerator, string reason, CancellationToken cancellationToken = default(CancellationToken))
+		public async Task<bool> DeleteMessageAsync(int departmentId, string chatMessageId, string byUserId, bool asModerator, string reason, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			var message = await _chatMessageRepository.GetByIdAsync(chatMessageId);
-			if (message == null || message.DeletedOn.HasValue)
+			if (message == null || message.DeletedOn.HasValue || message.DepartmentId != departmentId)
 				return false;
 
 			var isSender = string.Equals(message.SenderUserId, byUserId, StringComparison.OrdinalIgnoreCase);
@@ -323,10 +333,13 @@ namespace Resgrid.Services
 				return false;
 
 			var isModeratorDelete = asModerator && !isSender;
+			var channel = await GetAuthorizedMessageChannelAsync(message, departmentId, byUserId, null, isModeratorDelete);
+			if (channel == null)
+				return false;
 
 			// Frozen channel: the author can no longer retract what they said, but moderation still has to
 			// work — flagged content on a closed incident must remain removable.
-			if (!isModeratorDelete && await IsChannelFrozenAsync(message.ChatChannelId))
+			if (!isModeratorDelete && channel.IsArchived)
 				return false;
 
 			await SaveEditHistoryAsync(message, isModeratorDelete ? ChatMessageEditType.ModeratorDelete : ChatMessageEditType.SenderDelete, byUserId, cancellationToken);
@@ -341,7 +354,6 @@ namespace Resgrid.Services
 			message.DeletedByUserId = byUserId;
 			message.IsModerated = isModeratorDelete;
 
-			var channel = await _chatChannelRepository.GetByIdAsync(message.ChatChannelId);
 			PublishEvent(channel, ChatEventKinds.MessageDeleted, new
 			{
 				message.ChatMessageId,
@@ -355,16 +367,18 @@ namespace Resgrid.Services
 			return true;
 		}
 
-		public async Task<bool> AddReactionAsync(string chatMessageId, string userId, int? unitId, string emoji, CancellationToken cancellationToken = default(CancellationToken))
+		public async Task<bool> AddReactionAsync(int departmentId, string chatMessageId, string userId, int? unitId, string emoji, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			if (string.IsNullOrWhiteSpace(emoji) || emoji.Length > 64)
 				return false;
 
 			var message = await _chatMessageRepository.GetByIdAsync(chatMessageId);
-			if (message == null || message.DeletedOn.HasValue)
+			if (message == null || message.DeletedOn.HasValue || message.DepartmentId != departmentId)
 				return false;
 
-			if (await IsChannelFrozenAsync(message.ChatChannelId))
+			var channel = await GetAuthorizedMessageChannelAsync(message, departmentId, userId, unitId);
+			if (channel == null || channel.IsArchived ||
+				(unitId.HasValue && !await _chatPermissionService.CanSendAsUnitAsync(userId, unitId.Value, departmentId)))
 				return false;
 
 			// Banned or currently-muted participants can't react; silently skip.
@@ -408,19 +422,20 @@ namespace Resgrid.Services
 				return true;
 			}
 
-			var channel = await _chatChannelRepository.GetByIdAsync(message.ChatChannelId);
 			PublishEvent(channel, ChatEventKinds.ReactionUpdated, new { message.ChatMessageId, message.ChatChannelId, Emoji = emoji, UserId = userId, UnitId = unitId, Added = true });
 
 			return true;
 		}
 
-		public async Task<bool> RemoveReactionAsync(string chatMessageId, string userId, int? unitId, string emoji, CancellationToken cancellationToken = default(CancellationToken))
+		public async Task<bool> RemoveReactionAsync(int departmentId, string chatMessageId, string userId, int? unitId, string emoji, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			var message = await _chatMessageRepository.GetByIdAsync(chatMessageId);
-			if (message == null)
+			if (message == null || message.DepartmentId != departmentId)
 				return false;
 
-			if (await IsChannelFrozenAsync(message.ChatChannelId))
+			var channel = await GetAuthorizedMessageChannelAsync(message, departmentId, userId, unitId);
+			if (channel == null || channel.IsArchived ||
+				(unitId.HasValue && !await _chatPermissionService.CanSendAsUnitAsync(userId, unitId.Value, departmentId)))
 				return false;
 
 			var participantType = unitId.HasValue ? (int)ChatParticipantType.Unit : (int)ChatParticipantType.User;
@@ -428,7 +443,6 @@ namespace Resgrid.Services
 
 			if (removed)
 			{
-				var channel = await _chatChannelRepository.GetByIdAsync(message.ChatChannelId);
 				PublishEvent(channel, ChatEventKinds.ReactionUpdated, new { message.ChatMessageId, message.ChatChannelId, Emoji = emoji, UserId = userId, UnitId = unitId, Added = false });
 			}
 
@@ -447,10 +461,14 @@ namespace Resgrid.Services
 			return attachments?.ToList() ?? new List<ChatAttachment>();
 		}
 
-		public async Task<bool> SetMessagePinnedAsync(string chatMessageId, string byUserId, bool pinned, CancellationToken cancellationToken = default(CancellationToken))
+		public async Task<bool> SetMessagePinnedAsync(int departmentId, string chatMessageId, string byUserId, bool pinned, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			var message = await _chatMessageRepository.GetByIdAsync(chatMessageId);
-			if (message == null || message.DeletedOn.HasValue)
+			if (message == null || message.DeletedOn.HasValue || message.DepartmentId != departmentId)
+				return false;
+
+			var channel = await GetAuthorizedMessageChannelAsync(message, departmentId, byUserId, null, requireModerator: true);
+			if (channel == null)
 				return false;
 
 			var pinnedOn = pinned ? DateTime.UtcNow : (DateTime?)null;
@@ -460,7 +478,6 @@ namespace Resgrid.Services
 			message.PinnedOn = pinnedOn;
 			message.PinnedByUserId = pinned ? byUserId : null;
 
-			var channel = await _chatChannelRepository.GetByIdAsync(message.ChatChannelId);
 			PublishEvent(channel, ChatEventKinds.ChannelUpdated, new { message.ChatChannelId, PinnedMessageId = message.ChatMessageId, Pinned = pinned });
 
 			return true;
@@ -472,19 +489,20 @@ namespace Resgrid.Services
 			return pinned?.ToList() ?? new List<ChatMessage>();
 		}
 
-		public async Task<int> AcknowledgeMessageAsync(string chatMessageId, string userId, CancellationToken cancellationToken = default(CancellationToken))
+		public async Task<int> AcknowledgeMessageAsync(int departmentId, string chatMessageId, string userId, CancellationToken cancellationToken = default(CancellationToken))
 		{
+			var message = await _chatMessageRepository.GetByIdAsync(chatMessageId);
+			if (message == null || message.DepartmentId != departmentId)
+				return 0;
+
+			var channel = await GetAuthorizedMessageChannelAsync(message, departmentId, userId, null);
+			if (channel == null)
+				return 0;
+
 			var stamped = await _chatMessageAckRepository.AcknowledgeAsync(chatMessageId, userId, DateTime.UtcNow);
 
 			if (stamped > 0)
-			{
-				var message = await _chatMessageRepository.GetByIdAsync(chatMessageId);
-				if (message != null)
-				{
-					var channel = await _chatChannelRepository.GetByIdAsync(message.ChatChannelId);
-					PublishEvent(channel, ChatEventKinds.ReceiptUpdated, new { message.ChatMessageId, message.ChatChannelId, Type = "ack", UserId = userId });
-				}
-			}
+				PublishEvent(channel, ChatEventKinds.ReceiptUpdated, new { message.ChatMessageId, message.ChatChannelId, Type = "ack", UserId = userId });
 
 			return stamped;
 		}
@@ -498,7 +516,25 @@ namespace Resgrid.Services
 		public async Task<List<ChatMessageAck>> GetPendingAcksForUserAsync(int departmentId, string userId)
 		{
 			var acks = await _chatMessageAckRepository.GetPendingByUserIdAsync(departmentId, userId);
-			return acks?.ToList() ?? new List<ChatMessageAck>();
+			var candidates = acks?.Where(a => a.DepartmentId == departmentId && !string.IsNullOrWhiteSpace(a.ChatChannelId)).ToList()
+				?? new List<ChatMessageAck>();
+			if (candidates.Count == 0)
+				return candidates;
+
+			var channels = await _chatChannelService.GetChannelsByIdsAsync(candidates.Select(a => a.ChatChannelId));
+			var channelsById = channels
+				.Where(c => c.DepartmentId == departmentId)
+				.GroupBy(c => c.ChatChannelId, StringComparer.OrdinalIgnoreCase)
+				.ToDictionary(g => g.Key, g => g.First(), StringComparer.OrdinalIgnoreCase);
+			var authorizedChannelIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+			foreach (var channel in channelsById.Values)
+			{
+				if (await _chatPermissionService.CanAccessChannelAsync(channel, userId, null))
+					authorizedChannelIds.Add(channel.ChatChannelId);
+			}
+
+			return candidates.Where(a => authorizedChannelIds.Contains(a.ChatChannelId)).ToList();
 		}
 
 		public async Task<bool> MarkReadAsync(string chatChannelId, int departmentId, string userId, int? unitId, long seq, CancellationToken cancellationToken = default(CancellationToken))
@@ -536,7 +572,8 @@ namespace Resgrid.Services
 			if (!string.IsNullOrWhiteSpace(chatChannelId))
 			{
 				var channel = await _chatChannelRepository.GetByIdAsync(chatChannelId);
-				if (channel == null || !await _chatPermissionService.CanAccessChannelAsync(channel, userId, activeUnitId))
+				if (channel == null || channel.DepartmentId != departmentId ||
+					!await _chatPermissionService.CanAccessChannelAsync(channel, userId, activeUnitId))
 					return new List<ChatMessage>();
 
 				channelIds = new List<string> { chatChannelId };

--- a/Core/Resgrid.Services/ChatMessageService.cs
+++ b/Core/Resgrid.Services/ChatMessageService.cs
@@ -273,7 +273,18 @@ namespace Resgrid.Services
 				string.IsNullOrWhiteSpace(message.ChatChannelId) || string.IsNullOrWhiteSpace(userId))
 				return null;
 
-			var channel = await _chatChannelRepository.GetByIdAsync(message.ChatChannelId);
+			ChatChannel channel;
+			try
+			{
+				channel = await _chatChannelRepository.GetByIdAsync(message.ChatChannelId);
+			}
+			catch (Exception ex)
+			{
+				Logging.LogError(ex,
+					$"Operation:{nameof(GetAuthorizedMessageChannelAsync)}; DepartmentId:{departmentId}; ChatChannelId:{message.ChatChannelId}; UserId:{userId}");
+				throw;
+			}
+
 			if (channel == null || channel.DepartmentId != departmentId)
 				return null;
 

--- a/Core/Resgrid.Services/ChatModerationService.cs
+++ b/Core/Resgrid.Services/ChatModerationService.cs
@@ -49,10 +49,15 @@ namespace Resgrid.Services
 			_eventAggregator = eventAggregator;
 		}
 
-		public async Task<ChatMessageFlag> FlagMessageAsync(string chatMessageId, string flaggedByUserId, ChatFlagReason reason, string note, CancellationToken cancellationToken = default(CancellationToken))
+		public async Task<ChatMessageFlag> FlagMessageAsync(int departmentId, string chatMessageId, string flaggedByUserId, ChatFlagReason reason, string note, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			var message = await _chatMessageRepository.GetByIdAsync(chatMessageId);
-			if (message == null)
+			if (message == null || message.DepartmentId != departmentId)
+				return null;
+
+			var channel = await _chatChannelRepository.GetByIdAsync(message.ChatChannelId);
+			if (channel == null || channel.DepartmentId != departmentId ||
+				!await _chatPermissionService.CanAccessChannelAsync(channel, flaggedByUserId, null))
 				return null;
 
 			// Dedupe: an open flag by the same user on the same message is returned, not duplicated.
@@ -78,14 +83,20 @@ namespace Resgrid.Services
 			return flag;
 		}
 
-		public async Task<List<ChatMessageFlag>> GetFlagsAsync(int departmentId, ChatFlagStatus status, int page, int pageSize)
+		public async Task<List<ChatMessageFlag>> GetFlagsAsync(int departmentId, string byUserId, ChatFlagStatus status, int page, int pageSize)
 		{
+			if (!await _chatPermissionService.IsDepartmentAdminAsync(departmentId, byUserId))
+				return new List<ChatMessageFlag>();
+
 			var flags = await _chatMessageFlagRepository.GetByStatusAsync(departmentId, (int)status, Math.Max(page, 1), pageSize <= 0 ? 25 : Math.Min(pageSize, 100));
 			return flags?.ToList() ?? new List<ChatMessageFlag>();
 		}
 
 		public async Task<ChatMessageFlag> ResolveFlagAsync(string chatMessageFlagId, int departmentId, string byUserId, ChatFlagStatus resolution, string resolutionNote, CancellationToken cancellationToken = default(CancellationToken), ChatModerationContext context = null)
 		{
+			if (!await _chatPermissionService.IsDepartmentAdminAsync(departmentId, byUserId))
+				return null;
+
 			var flag = await _chatMessageFlagRepository.GetByIdAsync(chatMessageFlagId);
 			if (flag == null || flag.DepartmentId != departmentId)
 				return null;
@@ -109,13 +120,14 @@ namespace Resgrid.Services
 			return saved;
 		}
 
-		public async Task<bool> ModeratorDeleteMessageAsync(string chatMessageId, string byUserId, string reason, CancellationToken cancellationToken = default(CancellationToken), ChatModerationContext context = null)
+		public async Task<bool> ModeratorDeleteMessageAsync(int departmentId, string chatMessageId, string byUserId, string reason, CancellationToken cancellationToken = default(CancellationToken), ChatModerationContext context = null)
 		{
 			var message = await _chatMessageRepository.GetByIdAsync(chatMessageId);
-			if (message == null)
+			if (message == null || message.DepartmentId != departmentId ||
+				await ResolveModeratedChannelAsync(departmentId, message.ChatChannelId, byUserId) == null)
 				return false;
 
-			var deleted = await _chatMessageService.DeleteMessageAsync(chatMessageId, byUserId, asModerator: true, reason, cancellationToken);
+			var deleted = await _chatMessageService.DeleteMessageAsync(departmentId, chatMessageId, byUserId, asModerator: true, reason, cancellationToken);
 			if (!deleted)
 				return false;
 
@@ -125,13 +137,13 @@ namespace Resgrid.Services
 			return true;
 		}
 
-		public async Task<bool> SetUserMutedAsync(string chatChannelId, string targetUserId, DateTime? mutedUntil, string byUserId, string reason, CancellationToken cancellationToken = default(CancellationToken), ChatModerationContext context = null)
+		public async Task<bool> SetUserMutedAsync(int departmentId, string chatChannelId, string targetUserId, DateTime? mutedUntil, string byUserId, string reason, CancellationToken cancellationToken = default(CancellationToken), ChatModerationContext context = null)
 		{
-			var channel = await _chatChannelRepository.GetByIdAsync(chatChannelId);
+			var channel = await ResolveModeratedChannelAsync(departmentId, chatChannelId, byUserId);
 			if (channel == null)
 				return false;
 
-			var member = await _chatChannelService.EnsureMemberStateAsync(chatChannelId, channel.DepartmentId, targetUserId, null, cancellationToken);
+			var member = await _chatChannelService.EnsureMemberStateAsync(chatChannelId, departmentId, targetUserId, null, cancellationToken);
 			if (member == null)
 				return false;
 
@@ -148,13 +160,13 @@ namespace Resgrid.Services
 			return true;
 		}
 
-		public async Task<bool> SetUserBannedAsync(string chatChannelId, string targetUserId, bool banned, string byUserId, string reason, CancellationToken cancellationToken = default(CancellationToken), ChatModerationContext context = null)
+		public async Task<bool> SetUserBannedAsync(int departmentId, string chatChannelId, string targetUserId, bool banned, string byUserId, string reason, CancellationToken cancellationToken = default(CancellationToken), ChatModerationContext context = null)
 		{
-			var channel = await _chatChannelRepository.GetByIdAsync(chatChannelId);
+			var channel = await ResolveModeratedChannelAsync(departmentId, chatChannelId, byUserId);
 			if (channel == null)
 				return false;
 
-			var member = await _chatChannelService.EnsureMemberStateAsync(chatChannelId, channel.DepartmentId, targetUserId, null, cancellationToken);
+			var member = await _chatChannelService.EnsureMemberStateAsync(chatChannelId, departmentId, targetUserId, null, cancellationToken);
 			if (member == null)
 				return false;
 
@@ -169,9 +181,9 @@ namespace Resgrid.Services
 			return true;
 		}
 
-		public async Task<bool> SetChannelLockedAsync(string chatChannelId, bool locked, string byUserId, string reason, CancellationToken cancellationToken = default(CancellationToken), ChatModerationContext context = null)
+		public async Task<bool> SetChannelLockedAsync(int departmentId, string chatChannelId, bool locked, string byUserId, string reason, CancellationToken cancellationToken = default(CancellationToken), ChatModerationContext context = null)
 		{
-			var channel = await _chatChannelRepository.GetByIdAsync(chatChannelId);
+			var channel = await ResolveModeratedChannelAsync(departmentId, chatChannelId, byUserId);
 			if (channel == null)
 				return false;
 
@@ -189,14 +201,34 @@ namespace Resgrid.Services
 			return true;
 		}
 
-		public async Task<List<ChatModerationAction>> GetModerationActionsAsync(int departmentId, string chatChannelId, int page, int pageSize)
+		public async Task<List<ChatModerationAction>> GetModerationActionsAsync(int departmentId, string byUserId, string chatChannelId, int page, int pageSize)
 		{
+			if (!await _chatPermissionService.IsDepartmentAdminAsync(departmentId, byUserId))
+				return new List<ChatModerationAction>();
+
+			if (!string.IsNullOrWhiteSpace(chatChannelId))
+			{
+				var channel = await _chatChannelRepository.GetByIdAsync(chatChannelId);
+				if (channel == null || channel.DepartmentId != departmentId)
+					return new List<ChatModerationAction>();
+			}
+
 			var actions = await _chatModerationActionRepository.GetByDepartmentAsync(departmentId, chatChannelId, Math.Max(page, 1), pageSize <= 0 ? 25 : Math.Min(pageSize, 100));
 			return actions?.ToList() ?? new List<ChatModerationAction>();
 		}
 
 		public async Task<ChatExport> RequestExportAsync(int departmentId, string byUserId, string chatChannelId, DateTime? startDate, DateTime? endDate, ChatExportFormat format, CancellationToken cancellationToken = default(CancellationToken), ChatModerationContext context = null)
 		{
+			if (!await _chatPermissionService.IsDepartmentAdminAsync(departmentId, byUserId))
+				return null;
+
+			if (!string.IsNullOrWhiteSpace(chatChannelId))
+			{
+				var channel = await _chatChannelRepository.GetByIdAsync(chatChannelId);
+				if (channel == null || channel.DepartmentId != departmentId)
+					return null;
+			}
+
 			var export = await _chatExportRepository.InsertAsync(new ChatExport
 			{
 				ChatExportId = Guid.NewGuid().ToString(),
@@ -218,14 +250,20 @@ namespace Resgrid.Services
 			return export;
 		}
 
-		public async Task<List<ChatExport>> GetExportsAsync(int departmentId)
+		public async Task<List<ChatExport>> GetExportsAsync(int departmentId, string byUserId)
 		{
+			if (!await _chatPermissionService.IsDepartmentAdminAsync(departmentId, byUserId))
+				return new List<ChatExport>();
+
 			var exports = await _chatExportRepository.GetMetadataByDepartmentIdAsync(departmentId);
 			return exports?.ToList() ?? new List<ChatExport>();
 		}
 
 		public async Task<ChatExport> GetExportForDownloadAsync(string chatExportId, int departmentId, string byUserId, CancellationToken cancellationToken = default(CancellationToken), ChatModerationContext context = null)
 		{
+			if (!await _chatPermissionService.IsDepartmentAdminAsync(departmentId, byUserId))
+				return null;
+
 			var export = await _chatExportRepository.GetByIdAsync(chatExportId);
 			if (export == null || export.DepartmentId != departmentId || export.Status != (int)ChatExportStatus.Complete)
 				return null;
@@ -236,6 +274,19 @@ namespace Resgrid.Services
 				AuditLogTypes.ChatExportDownloaded, cancellationToken, context);
 
 			return export;
+		}
+
+		private async Task<ChatChannel> ResolveModeratedChannelAsync(int departmentId, string chatChannelId, string byUserId)
+		{
+			if (departmentId <= 0 || string.IsNullOrWhiteSpace(chatChannelId) || string.IsNullOrWhiteSpace(byUserId))
+				return null;
+
+			var channel = await _chatChannelRepository.GetByIdAsync(chatChannelId);
+			if (channel == null || channel.DepartmentId != departmentId ||
+				!await _chatPermissionService.CanModerateChannelAsync(channel, byUserId))
+				return null;
+
+			return channel;
 		}
 
 		private async Task RecordActionAsync(int departmentId, string chatChannelId, string chatMessageId, string targetUserId, int? targetUnitId,

--- a/Core/Resgrid.Services/ChatModerationService.cs
+++ b/Core/Resgrid.Services/ChatModerationService.cs
@@ -143,7 +143,7 @@ namespace Resgrid.Services
 			if (channel == null)
 				return false;
 
-			var member = await _chatChannelService.EnsureMemberStateAsync(chatChannelId, departmentId, targetUserId, null, cancellationToken);
+			var member = await GetModerationTargetMemberAsync(channel, targetUserId, cancellationToken);
 			if (member == null)
 				return false;
 
@@ -166,7 +166,7 @@ namespace Resgrid.Services
 			if (channel == null)
 				return false;
 
-			var member = await _chatChannelService.EnsureMemberStateAsync(chatChannelId, departmentId, targetUserId, null, cancellationToken);
+			var member = await GetModerationTargetMemberAsync(channel, targetUserId, cancellationToken);
 			if (member == null)
 				return false;
 
@@ -287,6 +287,25 @@ namespace Resgrid.Services
 				return null;
 
 			return channel;
+		}
+
+		private async Task<ChatChannelMember> GetModerationTargetMemberAsync(ChatChannel channel, string targetUserId,
+			CancellationToken cancellationToken)
+		{
+			if (channel == null || string.IsNullOrWhiteSpace(targetUserId))
+				return null;
+
+			var member = await _chatChannelMemberRepository.GetUserMemberAsync(channel.ChatChannelId, targetUserId);
+			if (member != null)
+				return member.DepartmentId == channel.DepartmentId ? member : null;
+
+			if (!await _chatPermissionService.CanAccessChannelAsync(channel, targetUserId, null))
+				return null;
+
+			member = await _chatChannelService.EnsureMemberStateAsync(channel.ChatChannelId, channel.DepartmentId,
+				targetUserId, null, cancellationToken);
+
+			return member != null && member.DepartmentId == channel.DepartmentId ? member : null;
 		}
 
 		private async Task RecordActionAsync(int departmentId, string chatChannelId, string chatMessageId, string targetUserId, int? targetUnitId,

--- a/Core/Resgrid.Services/ChatPermissionService.cs
+++ b/Core/Resgrid.Services/ChatPermissionService.cs
@@ -56,19 +56,35 @@ namespace Resgrid.Services
 
 		public async Task<bool> CanAccessChannelAsync(ChatChannel channel, string userId, int? activeUnitId)
 		{
-			if (channel == null || string.IsNullOrWhiteSpace(userId))
+			if (channel == null || string.IsNullOrWhiteSpace(userId) ||
+				!await IsActiveDepartmentUserAsync(channel.DepartmentId, userId))
 				return false;
+
+			// A channel ban overrides implicit access (department, incident, dispatch, group/rule or
+			// command role). Checking only explicit-membership branches would let a banned responder
+			// re-enter the same channel through their incident/resource assignment.
+			var userMember = await _chatChannelMemberRepository.GetUserMemberAsync(channel.ChatChannelId, userId);
+			if (userMember != null && userMember.DepartmentId == channel.DepartmentId && userMember.IsBanned)
+				return false;
+
+			var channelType = (ChatChannelType)channel.ChannelType;
+			// Operational access is derived from live dispatch, incident, lane, command and unit-role state.
+			// Never return a cached allow after a resource release, lane move, command transfer or dispatch
+			// revocation; those changes are authorization boundaries, not eventual-consistency hints.
+			if (IsDispatchVisibleChannel(channelType) || channelType == ChatChannelType.IncidentCommanderLine)
+				return await EvaluateAccessAsync(channel, userId, activeUnitId);
 
 			var cacheKey = await GetPermCacheKeyAsync(channel.ChatChannelId, "access", userId, activeUnitId);
 			var cached = await _cacheProvider.GetStringAsync(cacheKey);
-			if (cached == "1")
-				return true;
+			// A cached denial is safe; a cached allow is not an authorization boundary. Membership,
+			// role and rule revocations may originate outside chat, so positive access is re-evaluated.
 			if (cached == "0")
 				return false;
 
 			var result = await EvaluateAccessAsync(channel, userId, activeUnitId);
 
-			await _cacheProvider.SetStringAsync(cacheKey, result ? "1" : "0", CacheLength);
+			if (!result)
+				await _cacheProvider.SetStringAsync(cacheKey, "0", CacheLength);
 
 			return result;
 		}
@@ -117,25 +133,19 @@ namespace Resgrid.Services
 
 		public async Task<bool> CanModerateChannelAsync(ChatChannel channel, string userId)
 		{
-			if (channel == null || string.IsNullOrWhiteSpace(userId))
+			if (channel == null || string.IsNullOrWhiteSpace(userId) ||
+				!await IsActiveDepartmentUserAsync(channel.DepartmentId, userId))
 				return false;
 
-			var cacheKey = await GetPermCacheKeyAsync(channel.ChatChannelId, "mod", userId, null);
-			var cached = await _cacheProvider.GetStringAsync(cacheKey);
-			if (cached == "1")
-				return true;
-			if (cached == "0")
-				return false;
-
-			var result = await EvaluateModerateAsync(channel, userId);
-
-			await _cacheProvider.SetStringAsync(cacheKey, result ? "1" : "0", CacheLength);
-
-			return result;
+			// Moderation is low-volume and role changes must take effect immediately (especially IC transfer).
+			return await EvaluateModerateAsync(channel, userId);
 		}
 
 		public async Task<bool> CanSendAsUnitAsync(string userId, int unitId, int departmentId)
 		{
+			if (!await IsActiveDepartmentUserAsync(departmentId, userId))
+				return false;
+
 			var unit = await _unitsService.GetUnitByIdAsync(unitId);
 			if (unit == null || unit.DepartmentId != departmentId)
 				return false;
@@ -147,8 +157,11 @@ namespace Resgrid.Services
 
 		public async Task<bool> CanSendAsIcAsync(string userId, int callId, int departmentId)
 		{
+			if (!await IsActiveDepartmentUserAsync(departmentId, userId))
+				return false;
+
 			var command = await _incidentCommandService.GetCommandForCallAsync(departmentId, callId);
-			if (command == null)
+			if (command == null || command.DepartmentId != departmentId || command.CallId != callId)
 				return false;
 
 			if (command.CurrentCommanderUserId == userId || command.EstablishedByUserId == userId)
@@ -158,11 +171,34 @@ namespace Resgrid.Services
 			return roles != null && roles.Any(r => r.UserId == userId && !r.RemovedOn.HasValue);
 		}
 
+		public async Task<bool> CanAccessIncidentAsync(int departmentId, int callId, string userId, int? activeUnitId)
+		{
+			if (callId <= 0 || !await IsActiveDepartmentUserAsync(departmentId, userId))
+				return false;
+
+			var call = await _callsService.GetCallByIdAsync(callId);
+			if (call == null || call.DepartmentId != departmentId)
+				return false;
+
+			return await IsInIncidentAudienceAsync(new ChatChannel
+			{
+				DepartmentId = departmentId,
+				CallId = callId,
+				ChannelType = (int)ChatChannelType.Incident
+			}, userId, activeUnitId);
+		}
+
+		public async Task<bool> CanAccessDepartmentOperationalChannelsAsync(int departmentId, string userId)
+		{
+			return await IsActiveDepartmentUserAsync(departmentId, userId) &&
+				await _dispatchAccessService.CanUseDispatchAsync(departmentId, userId);
+		}
+
 		public async Task<List<string>> ResolveChannelAudienceUserIdsAsync(ChatChannel channel)
 		{
 			var userIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-			if (channel == null)
+			if (channel == null || !await HasValidDepartmentScopeAsync(channel))
 				return userIds.ToList();
 
 			switch ((ChatChannelType)channel.ChannelType)
@@ -183,7 +219,7 @@ namespace Resgrid.Services
 					{
 						var groupMembers = await _departmentGroupsService.GetAllMembersForGroupAsync(channel.GroupId.Value);
 						if (groupMembers != null)
-							foreach (var m in groupMembers)
+							foreach (var m in groupMembers.Where(m => m.DepartmentId == channel.DepartmentId))
 								AddIfSet(userIds, m.UserId);
 					}
 					break;
@@ -195,9 +231,6 @@ namespace Resgrid.Services
 
 				case ChatChannelType.Incident:
 					await AddIncidentAudienceAsync(channel, userIds);
-					// The desk follows the incident's shared conversation, not just its own dispatch line.
-					foreach (var dispatcherId in await _dispatchAccessService.GetDispatchUserIdsAsync(channel.DepartmentId))
-						AddIfSet(userIds, dispatcherId);
 					break;
 
 				case ChatChannelType.IncidentLane:
@@ -214,23 +247,20 @@ namespace Resgrid.Services
 
 				case ChatChannelType.IncidentDispatch:
 					await AddIncidentAudienceAsync(channel, userIds);
-					foreach (var dispatcherId in await _dispatchAccessService.GetDispatchUserIdsAsync(channel.DepartmentId))
-						AddIfSet(userIds, dispatcherId);
 					break;
 
 				case ChatChannelType.UnitDispatch:
-					// The unit's member row resolves to its active crew; the desk side is every dispatcher.
+					// The unit's member row resolves to its active crew.
 					await AddExplicitMemberAudienceAsync(channel, userIds);
-					foreach (var dispatcherId in await _dispatchAccessService.GetDispatchUserIdsAsync(channel.DepartmentId))
-						AddIfSet(userIds, dispatcherId);
 					break;
 
 				case ChatChannelType.IncidentCommanderLine:
 					// Requester side is an explicit member row; the commander side is resolved live from the
-					// call so a command transfer moves the conversation rather than copying it. Only the
+					// call. The requester row is also filtered through current incident assignment so a
+					// release or lane removal immediately removes history and notification access. Only the
 					// CURRENT commander — deliberately not EstablishedByUserId or the wider command staff,
 					// which is what separates this from the IncidentCommand channel.
-					await AddExplicitMemberAudienceAsync(channel, userIds);
+					await AddIncidentCommanderLineRequesterAudienceAsync(channel, userIds);
 					AddIfSet(userIds, await GetCurrentCommanderUserIdAsync(channel.DepartmentId, channel.CallId.GetValueOrDefault()));
 					break;
 
@@ -239,7 +269,25 @@ namespace Resgrid.Services
 					break;
 			}
 
-			return userIds.Where(x => !string.IsNullOrWhiteSpace(x)).ToList();
+			if (IsDispatchVisibleChannel((ChatChannelType)channel.ChannelType))
+			{
+				foreach (var dispatcherId in await _dispatchAccessService.GetDispatchUserIdsAsync(channel.DepartmentId))
+					AddIfSet(userIds, dispatcherId);
+			}
+
+			// Audience resolution feeds push notifications and urgent acknowledgements. Never let a stale
+			// member/rule/assignment row send department chat content to a user outside the channel tenant.
+			var departmentUserIds = new HashSet<string>(
+				await _departmentsService.GetMemberUserIdsInDepartmentAsync(channel.DepartmentId, userIds) ?? new HashSet<string>(),
+				StringComparer.OrdinalIgnoreCase);
+			var activeUserIds = new List<string>();
+			foreach (var userId in userIds.Where(x => !string.IsNullOrWhiteSpace(x) && departmentUserIds.Contains(x)))
+			{
+				if (await _authorizationService.IsUserValidWithinLimitsAsync(userId, channel.DepartmentId))
+					activeUserIds.Add(userId);
+			}
+
+			return activeUserIds;
 		}
 
 		public async Task InvalidateChannelCacheAsync(string chatChannelId)
@@ -253,23 +301,48 @@ namespace Resgrid.Services
 			await _cacheProvider.IncrementAsync(ChannelListVersionCacheKey, VersionCacheLength);
 		}
 
+		public async Task<string> GetChannelAccessVersionAsync(string chatChannelId)
+		{
+			if (string.IsNullOrWhiteSpace(chatChannelId))
+				return null;
+
+			try
+			{
+				return await _cacheProvider.GetStringAsync(GetVersionKey(chatChannelId)) ?? "0";
+			}
+			catch (Exception ex)
+			{
+				// A missing authorization epoch must stop realtime fan-out. Falling back to the old
+				// group during a cache outage could reconnect a user whose access was just revoked.
+				Resgrid.Framework.Logging.LogException(ex);
+				return null;
+			}
+		}
+
 		private async Task<bool> EvaluateAccessAsync(ChatChannel channel, string userId, int? activeUnitId)
 		{
-			switch ((ChatChannelType)channel.ChannelType)
+			if (!await HasValidDepartmentScopeAsync(channel))
+				return false;
+
+			var channelType = (ChatChannelType)channel.ChannelType;
+			if (IsDispatchVisibleChannel(channelType) && await _dispatchAccessService.CanUseDispatchAsync(channel.DepartmentId, userId))
+				return true;
+
+			switch (channelType)
 			{
 				case ChatChannelType.Chatbot:
 					return string.Equals(channel.OwnerUserId, userId, StringComparison.OrdinalIgnoreCase);
 
 				case ChatChannelType.DirectMessage:
 				case ChatChannelType.AdHocGroup:
-					if (await HasActiveMembershipAsync(channel.ChatChannelId, userId, null))
+					if (await HasActiveMembershipAsync(channel.ChatChannelId, channel.DepartmentId, userId, null))
 						return true;
 
 					// The unit's member row only grants access when the caller actually crews the claimed
 					// unit — a caller-supplied activeUnitId alone must not open another unit's channels.
 					return activeUnitId.HasValue
 						&& await CanSendAsUnitAsync(userId, activeUnitId.Value, channel.DepartmentId)
-						&& await HasActiveMembershipAsync(channel.ChatChannelId, userId, activeUnitId);
+						&& await HasActiveMembershipAsync(channel.ChatChannelId, channel.DepartmentId, userId, activeUnitId);
 
 				case ChatChannelType.DepartmentDefault:
 					return await _departmentsService.IsUserInDepartmentAsync(channel.DepartmentId, userId);
@@ -282,66 +355,35 @@ namespace Resgrid.Services
 						return false;
 
 					var groupMembers = await _departmentGroupsService.GetAllMembersForGroupAsync(channel.GroupId.Value);
-					return groupMembers != null && groupMembers.Any(m => string.Equals(m.UserId, userId, StringComparison.OrdinalIgnoreCase));
+					return groupMembers != null && groupMembers.Any(m => m.DepartmentId == channel.DepartmentId &&
+						string.Equals(m.UserId, userId, StringComparison.OrdinalIgnoreCase));
 
 				case ChatChannelType.CustomLocked:
 					if (await IsDepartmentAdminAsync(channel.DepartmentId, userId))
 						return true;
 
-					if (await HasActiveMembershipAsync(channel.ChatChannelId, userId, null))
+					if (await HasActiveMembershipAsync(channel.ChatChannelId, channel.DepartmentId, userId, null))
 						return true;
 
 					return await MatchesAccessRulesAsync(channel, userId);
 
 				case ChatChannelType.Incident:
-					if (await IsDepartmentAdminAsync(channel.DepartmentId, userId))
-						return true;
-
-					// Authorized dispatchers see every call's shared incident conversation — that is the
-					// desk's job. The private command channel stays closed to them.
-					if (await _dispatchAccessService.CanUseDispatchAsync(channel.DepartmentId, userId))
-						return true;
-
 					return await IsInIncidentAudienceAsync(channel, userId, activeUnitId);
 
 				case ChatChannelType.IncidentLane:
-					if (await IsDepartmentAdminAsync(channel.DepartmentId, userId))
-						return true;
-
 					return await IsInLaneAudienceAsync(channel, userId, activeUnitId);
 
 				case ChatChannelType.IncidentCommand:
-					if (await IsDepartmentAdminAsync(channel.DepartmentId, userId))
-						return true;
-
-					// Command staff ONLY — deliberately not widened to dispatch. Dispatch reaches command
-					// through the incident's dispatch channel; this one stays internal to the people running
-					// the incident so command can talk candidly.
 					return await IsCommandStaffAsync(channel.DepartmentId, channel.CallId.GetValueOrDefault(), userId);
 
 				case ChatChannelType.IncidentLeads:
-					if (await IsDepartmentAdminAsync(channel.DepartmentId, userId))
-						return true;
-
 					return await IsLaneLeadOrCommanderAsync(channel.DepartmentId, channel.CallId.GetValueOrDefault(), userId);
 
 				case ChatChannelType.IncidentDispatch:
-					// Deliberately NOT widened to department admins the way the other incident channels are.
-					// The whole point of the DispatchAppLogin permission is that an admin the department has
-					// not authorized for dispatch stays out of dispatch traffic; they still get in if they
-					// are actually working the incident.
-					if (await _dispatchAccessService.CanUseDispatchAsync(channel.DepartmentId, userId))
-						return true;
-
 					return await IsInIncidentAudienceAsync(channel, userId, activeUnitId);
 
 				case ChatChannelType.UnitDispatch:
 				{
-					// Same stance as IncidentDispatch: dispatch authorization, not admin standing, opens
-					// dispatch traffic.
-					if (await _dispatchAccessService.CanUseDispatchAsync(channel.DepartmentId, userId))
-						return true;
-
 					// The unit side is proven against the channel's OWN unit, never the caller-supplied
 					// activeUnitId or a leftover user member row (lazy read-pointer rows outlive access) —
 					// crewing some other unit must not open this unit's dispatch line.
@@ -360,12 +402,14 @@ namespace Resgrid.Services
 
 					// Requester side, proven the same way DMs are — a unit's row only counts when the caller
 					// actually crews that unit.
-					if (await HasActiveMembershipAsync(channel.ChatChannelId, userId, null))
+					if (await HasActiveMembershipAsync(channel.ChatChannelId, channel.DepartmentId, userId, null) &&
+						await IsInIncidentAudienceAsync(channel, userId, null))
 						return true;
 
 					return activeUnitId.HasValue
 						&& await CanSendAsUnitAsync(userId, activeUnitId.Value, channel.DepartmentId)
-						&& await HasActiveMembershipAsync(channel.ChatChannelId, userId, activeUnitId);
+						&& await HasActiveMembershipAsync(channel.ChatChannelId, channel.DepartmentId, userId, activeUnitId)
+						&& await IsInIncidentAudienceAsync(channel, userId, activeUnitId);
 				}
 
 				default:
@@ -390,12 +434,15 @@ namespace Resgrid.Services
 
 		private async Task<bool> EvaluateModerateAsync(ChatChannel channel, string userId)
 		{
+			if (!await HasValidDepartmentScopeAsync(channel))
+				return false;
+
 			// Department admins moderate every channel type (including DMs, for flagged-content handling).
 			if (await IsDepartmentAdminAsync(channel.DepartmentId, userId))
 				return true;
 
 			var member = await _chatChannelMemberRepository.GetUserMemberAsync(channel.ChatChannelId, userId);
-			if (member != null && member.IsModerator && !member.RemovedOn.HasValue)
+			if (member != null && member.DepartmentId == channel.DepartmentId && member.IsModerator && !member.RemovedOn.HasValue)
 				return true;
 
 			switch ((ChatChannelType)channel.ChannelType)
@@ -405,7 +452,8 @@ namespace Resgrid.Services
 						return false;
 
 					var groupMembers = await _departmentGroupsService.GetAllMembersForGroupAsync(channel.GroupId.Value);
-					return groupMembers != null && groupMembers.Any(m => string.Equals(m.UserId, userId, StringComparison.OrdinalIgnoreCase) && m.IsAdmin.GetValueOrDefault());
+					return groupMembers != null && groupMembers.Any(m => m.DepartmentId == channel.DepartmentId &&
+						string.Equals(m.UserId, userId, StringComparison.OrdinalIgnoreCase) && m.IsAdmin.GetValueOrDefault());
 
 				case ChatChannelType.Incident:
 				case ChatChannelType.IncidentLane:
@@ -441,19 +489,20 @@ namespace Resgrid.Services
 				return unitId;
 
 			var members = await _chatChannelMemberRepository.GetByChannelIdAsync(channel.ChatChannelId);
-			return members?.FirstOrDefault(m => m.ParticipantType == (int)ChatParticipantType.Unit && !m.RemovedOn.HasValue && m.UnitId.HasValue)?.UnitId;
+			return members?.FirstOrDefault(m => m.DepartmentId == channel.DepartmentId &&
+				m.ParticipantType == (int)ChatParticipantType.Unit && !m.RemovedOn.HasValue && m.UnitId.HasValue)?.UnitId;
 		}
 
-		private async Task<bool> HasActiveMembershipAsync(string chatChannelId, string userId, int? activeUnitId)
+		private async Task<bool> HasActiveMembershipAsync(string chatChannelId, int departmentId, string userId, int? activeUnitId)
 		{
 			var member = await _chatChannelMemberRepository.GetUserMemberAsync(chatChannelId, userId);
-			if (member != null && !member.RemovedOn.HasValue && !member.IsBanned)
+			if (member != null && member.DepartmentId == departmentId && !member.RemovedOn.HasValue && !member.IsBanned)
 				return true;
 
 			if (activeUnitId.HasValue)
 			{
 				var unitMember = await _chatChannelMemberRepository.GetUnitMemberAsync(chatChannelId, activeUnitId.Value);
-				if (unitMember != null && !unitMember.RemovedOn.HasValue && !unitMember.IsBanned)
+				if (unitMember != null && unitMember.DepartmentId == departmentId && !unitMember.RemovedOn.HasValue && !unitMember.IsBanned)
 					return true;
 			}
 
@@ -466,7 +515,7 @@ namespace Resgrid.Services
 			if (rules == null)
 				return false;
 
-			var ruleList = rules.ToList();
+			var ruleList = rules.Where(r => r.DepartmentId == channel.DepartmentId).ToList();
 			if (ruleList.Count == 0)
 				return false;
 
@@ -483,7 +532,7 @@ namespace Resgrid.Services
 
 			foreach (var groupRule in ruleList.Where(r => r.RuleType == (int)ChatAccessRuleType.GroupMembership && r.GroupId.HasValue))
 			{
-				var memberUserIds = await GetGroupRosterUserIdsAsync(groupRule.GroupId.Value);
+				var memberUserIds = await GetGroupRosterUserIdsAsync(groupRule.GroupId.Value, channel.DepartmentId);
 				if (memberUserIds != null && memberUserIds.Any(id => string.Equals(id, userId, StringComparison.OrdinalIgnoreCase)))
 					return true;
 			}
@@ -492,20 +541,24 @@ namespace Resgrid.Services
 		}
 
 		/// <summary>Group roster lookup cached briefly: access-rule evaluation walks every group rule per user, which would otherwise N+1 the group-membership table.</summary>
-		private async Task<List<string>> GetGroupRosterUserIdsAsync(int groupId)
+		private async Task<List<string>> GetGroupRosterUserIdsAsync(int groupId, int departmentId)
 		{
 			async Task<GroupRosterCache> getRoster()
 			{
+				var group = await _departmentGroupsService.GetGroupByIdAsync(groupId, false);
+				if (group == null || group.DepartmentId != departmentId)
+					return new GroupRosterCache();
+
 				var members = await _departmentGroupsService.GetAllMembersForGroupAsync(groupId);
 				return new GroupRosterCache
 				{
-					UserIds = members?.Where(m => !string.IsNullOrWhiteSpace(m.UserId)).Select(m => m.UserId).ToList() ?? new List<string>()
+					UserIds = members?.Where(m => m.DepartmentId == departmentId && !string.IsNullOrWhiteSpace(m.UserId)).Select(m => m.UserId).ToList() ?? new List<string>()
 				};
 			}
 
 			if (SystemBehaviorConfig.CacheEnabled)
 			{
-				var cached = await _cacheProvider.RetrieveAsync($"chatperm:grouproster:{groupId}", getRoster, CacheLength);
+				var cached = await _cacheProvider.RetrieveAsync($"chatperm:grouproster:{departmentId}:{groupId}", getRoster, CacheLength);
 				return cached?.UserIds;
 			}
 
@@ -530,7 +583,7 @@ namespace Resgrid.Services
 				return true;
 
 			var call = await _callsService.GetCallByIdAsync(callId);
-			if (call != null)
+			if (call != null && call.DepartmentId == channel.DepartmentId)
 			{
 				if (call.Dispatches != null && call.Dispatches.Any(d => string.Equals(d.UserId, userId, StringComparison.OrdinalIgnoreCase)))
 					return true;
@@ -544,8 +597,13 @@ namespace Resgrid.Services
 				{
 					foreach (var groupDispatch in call.GroupDispatches)
 					{
+						var group = await _departmentGroupsService.GetGroupByIdAsync(groupDispatch.DepartmentGroupId, false);
+						if (group == null || group.DepartmentId != channel.DepartmentId)
+							continue;
+
 						var members = await _departmentGroupsService.GetAllMembersForGroupAsync(groupDispatch.DepartmentGroupId);
-						if (members != null && members.Any(m => string.Equals(m.UserId, userId, StringComparison.OrdinalIgnoreCase)))
+						if (members != null && members.Any(m => m.DepartmentId == channel.DepartmentId &&
+							string.Equals(m.UserId, userId, StringComparison.OrdinalIgnoreCase)))
 							return true;
 					}
 				}
@@ -562,7 +620,8 @@ namespace Resgrid.Services
 			var assignments = await _incidentCommandService.GetAssignmentsForCallAsync(channel.DepartmentId, callId);
 			if (assignments != null)
 			{
-				foreach (var assignment in assignments.Where(a => !a.ReleasedOn.HasValue))
+				foreach (var assignment in assignments.Where(a => !a.ReleasedOn.HasValue &&
+					a.DepartmentId == channel.DepartmentId && a.CallId == callId))
 				{
 					if (await MatchesResourceForIncidentAccessAsync(assignment, userId, activeUnitId, channel.DepartmentId))
 						return true;
@@ -611,9 +670,10 @@ namespace Resgrid.Services
 			var assignments = await _incidentCommandService.GetAssignmentsForCallAsync(channel.DepartmentId, callId);
 			if (assignments != null)
 			{
-				foreach (var assignment in assignments.Where(a => !a.ReleasedOn.HasValue && a.CommandStructureNodeId == channel.CommandStructureNodeId))
+				foreach (var assignment in assignments.Where(a => !a.ReleasedOn.HasValue && a.DepartmentId == channel.DepartmentId &&
+					a.CallId == callId && a.CommandStructureNodeId == channel.CommandStructureNodeId))
 				{
-					if (MatchesResource(assignment, userId, activeUnitId))
+					if (await MatchesResourceForIncidentAccessAsync(assignment, userId, activeUnitId, channel.DepartmentId))
 						return true;
 				}
 			}
@@ -684,29 +744,18 @@ namespace Resgrid.Services
 			return roles != null && roles.Any(r => string.Equals(r.UserId, userId, StringComparison.OrdinalIgnoreCase) && !r.RemovedOn.HasValue);
 		}
 
-		private static bool MatchesResource(ResourceAssignment assignment, string userId, int? activeUnitId)
-		{
-			if (assignment.ResourceKind == (int)ResourceAssignmentKind.RealPersonnel || assignment.ResourceKind == (int)ResourceAssignmentKind.LinkedDeptPersonnel)
-				return string.Equals(assignment.ResourceId, userId, StringComparison.OrdinalIgnoreCase);
-
-			if (activeUnitId.HasValue && (assignment.ResourceKind == (int)ResourceAssignmentKind.RealUnit || assignment.ResourceKind == (int)ResourceAssignmentKind.LinkedDeptUnit))
-				return assignment.ResourceId == activeUnitId.Value.ToString();
-
-			return false;
-		}
-
 		private async Task AddExplicitMemberAudienceAsync(ChatChannel channel, HashSet<string> userIds)
 		{
 			var members = await _chatChannelMemberRepository.GetByChannelIdAsync(channel.ChatChannelId);
 			if (members == null)
 				return;
 
-			foreach (var member in members.Where(m => !m.RemovedOn.HasValue && !m.IsBanned))
+			foreach (var member in members.Where(m => m.DepartmentId == channel.DepartmentId && !m.RemovedOn.HasValue && !m.IsBanned))
 			{
 				if (member.ParticipantType == (int)ChatParticipantType.User)
 					AddIfSet(userIds, member.UserId);
 				else if (member.ParticipantType == (int)ChatParticipantType.Unit && member.UnitId.HasValue)
-					await AddUnitCrewAsync(member.UnitId.Value, userIds);
+					await AddUnitCrewAsync(member.UnitId.Value, channel.DepartmentId, userIds);
 			}
 		}
 
@@ -716,7 +765,7 @@ namespace Resgrid.Services
 			if (rules == null)
 				return;
 
-			foreach (var rule in rules)
+			foreach (var rule in rules.Where(r => r.DepartmentId == channel.DepartmentId))
 			{
 				switch ((ChatAccessRuleType)rule.RuleType)
 				{
@@ -727,9 +776,13 @@ namespace Resgrid.Services
 					case ChatAccessRuleType.GroupMembership:
 						if (rule.GroupId.HasValue)
 						{
+							var group = await _departmentGroupsService.GetGroupByIdAsync(rule.GroupId.Value, false);
+							if (group == null || group.DepartmentId != channel.DepartmentId)
+								break;
+
 							var members = await _departmentGroupsService.GetAllMembersForGroupAsync(rule.GroupId.Value);
 							if (members != null)
-								foreach (var m in members)
+								foreach (var m in members.Where(m => m.DepartmentId == channel.DepartmentId))
 									AddIfSet(userIds, m.UserId);
 						}
 						break;
@@ -739,7 +792,7 @@ namespace Resgrid.Services
 						{
 							var roleMembers = await _personnelRolesService.GetAllMembersOfRoleAsync(rule.PersonnelRoleId.Value);
 							if (roleMembers != null)
-								foreach (var m in roleMembers)
+								foreach (var m in roleMembers.Where(m => m.DepartmentId == channel.DepartmentId))
 									AddIfSet(userIds, m.UserId);
 						}
 						break;
@@ -757,7 +810,7 @@ namespace Resgrid.Services
 			await AddCommandStaffAsync(channel.DepartmentId, callId, userIds);
 
 			var call = await _callsService.GetCallByIdAsync(callId);
-			if (call != null)
+			if (call != null && call.DepartmentId == channel.DepartmentId)
 			{
 				if (call.Dispatches != null)
 					foreach (var dispatch in call.Dispatches)
@@ -767,9 +820,13 @@ namespace Resgrid.Services
 				{
 					foreach (var groupDispatch in call.GroupDispatches)
 					{
+						var group = await _departmentGroupsService.GetGroupByIdAsync(groupDispatch.DepartmentGroupId, false);
+						if (group == null || group.DepartmentId != channel.DepartmentId)
+							continue;
+
 						var members = await _departmentGroupsService.GetAllMembersForGroupAsync(groupDispatch.DepartmentGroupId);
 						if (members != null)
-							foreach (var m in members)
+							foreach (var m in members.Where(m => m.DepartmentId == channel.DepartmentId))
 								AddIfSet(userIds, m.UserId);
 					}
 				}
@@ -780,20 +837,21 @@ namespace Resgrid.Services
 					{
 						var roleMembers = await _personnelRolesService.GetAllMembersOfRoleAsync(roleDispatch.RoleId);
 						if (roleMembers != null)
-							foreach (var m in roleMembers)
+							foreach (var m in roleMembers.Where(m => m.DepartmentId == channel.DepartmentId))
 								AddIfSet(userIds, m.UserId);
 					}
 				}
 
 				if (call.UnitDispatches != null)
 					foreach (var unitDispatch in call.UnitDispatches)
-						await AddUnitCrewAsync(unitDispatch.UnitId, userIds);
+						await AddUnitCrewAsync(unitDispatch.UnitId, channel.DepartmentId, userIds);
 			}
 
 			var assignments = await _incidentCommandService.GetAssignmentsForCallAsync(channel.DepartmentId, callId);
 			if (assignments != null)
-				foreach (var assignment in assignments.Where(a => !a.ReleasedOn.HasValue))
-					await AddResourceAsync(assignment, userIds);
+				foreach (var assignment in assignments.Where(a => !a.ReleasedOn.HasValue &&
+					a.DepartmentId == channel.DepartmentId && a.CallId == callId))
+					await AddResourceAsync(assignment, channel.DepartmentId, userIds);
 		}
 
 		private async Task AddLaneAudienceAsync(ChatChannel channel, HashSet<string> userIds)
@@ -816,8 +874,9 @@ namespace Resgrid.Services
 
 			var assignments = await _incidentCommandService.GetAssignmentsForCallAsync(channel.DepartmentId, callId);
 			if (assignments != null)
-				foreach (var assignment in assignments.Where(a => !a.ReleasedOn.HasValue && a.CommandStructureNodeId == channel.CommandStructureNodeId))
-					await AddResourceAsync(assignment, userIds);
+				foreach (var assignment in assignments.Where(a => !a.ReleasedOn.HasValue && a.DepartmentId == channel.DepartmentId &&
+					a.CallId == callId && a.CommandStructureNodeId == channel.CommandStructureNodeId))
+					await AddResourceAsync(assignment, channel.DepartmentId, userIds);
 		}
 
 		private async Task AddCommandStaffAsync(int departmentId, int callId, HashSet<string> userIds)
@@ -838,7 +897,7 @@ namespace Resgrid.Services
 					AddIfSet(userIds, role.UserId);
 		}
 
-		private async Task AddResourceAsync(ResourceAssignment assignment, HashSet<string> userIds)
+		private async Task AddResourceAsync(ResourceAssignment assignment, int departmentId, HashSet<string> userIds)
 		{
 			if (assignment.ResourceKind == (int)ResourceAssignmentKind.RealPersonnel || assignment.ResourceKind == (int)ResourceAssignmentKind.LinkedDeptPersonnel)
 			{
@@ -847,12 +906,48 @@ namespace Resgrid.Services
 			else if (assignment.ResourceKind == (int)ResourceAssignmentKind.RealUnit || assignment.ResourceKind == (int)ResourceAssignmentKind.LinkedDeptUnit)
 			{
 				if (int.TryParse(assignment.ResourceId, out var unitId))
-					await AddUnitCrewAsync(unitId, userIds);
+					await AddUnitCrewAsync(unitId, departmentId, userIds);
 			}
 		}
 
-		private async Task AddUnitCrewAsync(int unitId, HashSet<string> userIds)
+		private async Task AddIncidentCommanderLineRequesterAudienceAsync(ChatChannel channel, HashSet<string> userIds)
 		{
+			var members = await _chatChannelMemberRepository.GetByChannelIdAsync(channel.ChatChannelId);
+			if (members == null)
+				return;
+
+			foreach (var member in members.Where(m => m.DepartmentId == channel.DepartmentId && !m.RemovedOn.HasValue && !m.IsBanned))
+			{
+				if (member.ParticipantType == (int)ChatParticipantType.User && !string.IsNullOrWhiteSpace(member.UserId))
+				{
+					if (await IsInIncidentAudienceAsync(channel, member.UserId, null))
+						AddIfSet(userIds, member.UserId);
+				}
+				else if (member.ParticipantType == (int)ChatParticipantType.Unit && member.UnitId.HasValue)
+				{
+					var unit = await _unitsService.GetUnitByIdAsync(member.UnitId.Value);
+					if (unit == null || unit.DepartmentId != channel.DepartmentId)
+						continue;
+
+					var activeRoles = await _unitsService.GetActiveRolesForUnitAsync(member.UnitId.Value);
+					if (activeRoles == null)
+						continue;
+
+					foreach (var role in activeRoles.Where(r => !string.IsNullOrWhiteSpace(r.UserId)))
+					{
+						if (await IsInIncidentAudienceAsync(channel, role.UserId, member.UnitId.Value))
+							AddIfSet(userIds, role.UserId);
+					}
+				}
+			}
+		}
+
+		private async Task AddUnitCrewAsync(int unitId, int departmentId, HashSet<string> userIds)
+		{
+			var unit = await _unitsService.GetUnitByIdAsync(unitId);
+			if (unit == null || unit.DepartmentId != departmentId)
+				return;
+
 			var activeRoles = await _unitsService.GetActiveRolesForUnitAsync(unitId);
 			if (activeRoles != null)
 				foreach (var role in activeRoles)
@@ -861,7 +956,80 @@ namespace Resgrid.Services
 
 		public async Task<bool> IsDepartmentAdminAsync(int departmentId, string userId)
 		{
-			return await _authorizationService.CanUserModifyDepartmentAsync(userId, departmentId);
+			return await IsActiveDepartmentUserAsync(departmentId, userId) &&
+				await _authorizationService.CanUserModifyDepartmentAsync(userId, departmentId);
+		}
+
+		public async Task<bool> IsActiveDepartmentUserAsync(int departmentId, string userId)
+		{
+			return departmentId > 0 && !string.IsNullOrWhiteSpace(userId) &&
+				await _departmentsService.IsUserInDepartmentAsync(departmentId, userId) &&
+				await _authorizationService.IsUserValidWithinLimitsAsync(userId, departmentId);
+		}
+
+		private async Task<bool> HasValidDepartmentScopeAsync(ChatChannel channel)
+		{
+			if (channel.DepartmentId <= 0)
+				return false;
+
+			var channelType = (ChatChannelType)channel.ChannelType;
+			if (channelType == ChatChannelType.GroupDefault)
+			{
+				if (!channel.GroupId.HasValue)
+					return false;
+
+				var group = await _departmentGroupsService.GetGroupByIdAsync(channel.GroupId.Value, false);
+				return group != null && group.DepartmentId == channel.DepartmentId;
+			}
+
+			if (IsIncidentChannel(channelType))
+			{
+				if (!channel.CallId.HasValue)
+					return false;
+
+				var call = await _callsService.GetCallByIdAsync(channel.CallId.Value);
+				if (call == null || call.DepartmentId != channel.DepartmentId)
+					return false;
+
+				if (channelType == ChatChannelType.IncidentLane)
+				{
+					if (string.IsNullOrWhiteSpace(channel.CommandStructureNodeId))
+						return false;
+
+					var nodes = await _incidentCommandService.GetNodesForCallAsync(channel.DepartmentId, channel.CallId.Value);
+					return nodes != null && nodes.Any(n => n.DepartmentId == channel.DepartmentId && n.CallId == channel.CallId.Value &&
+						string.Equals(n.CommandStructureNodeId, channel.CommandStructureNodeId, StringComparison.OrdinalIgnoreCase));
+				}
+
+				return true;
+			}
+
+			if (channelType == ChatChannelType.UnitDispatch)
+			{
+				var unitId = await GetUnitDispatchChannelUnitIdAsync(channel);
+				if (!unitId.HasValue)
+					return false;
+
+				var unit = await _unitsService.GetUnitByIdAsync(unitId.Value);
+				return unit != null && unit.DepartmentId == channel.DepartmentId;
+			}
+
+			return true;
+		}
+
+		private static bool IsIncidentChannel(ChatChannelType channelType)
+		{
+			return channelType == ChatChannelType.Incident || channelType == ChatChannelType.IncidentLane ||
+				channelType == ChatChannelType.IncidentCommand || channelType == ChatChannelType.IncidentLeads ||
+				channelType == ChatChannelType.IncidentDispatch || channelType == ChatChannelType.IncidentCommanderLine;
+		}
+
+		private static bool IsDispatchVisibleChannel(ChatChannelType channelType)
+		{
+			return channelType == ChatChannelType.DepartmentDefault || channelType == ChatChannelType.GroupDefault ||
+				channelType == ChatChannelType.Incident || channelType == ChatChannelType.IncidentLane ||
+				channelType == ChatChannelType.IncidentCommand || channelType == ChatChannelType.IncidentLeads ||
+				channelType == ChatChannelType.IncidentDispatch || channelType == ChatChannelType.UnitDispatch;
 		}
 
 		private static void AddIfSet(HashSet<string> set, string userId)

--- a/Core/Resgrid.Services/ChatPermissionService.cs
+++ b/Core/Resgrid.Services/ChatPermissionService.cs
@@ -280,14 +280,18 @@ namespace Resgrid.Services
 			var departmentUserIds = new HashSet<string>(
 				await _departmentsService.GetMemberUserIdsInDepartmentAsync(channel.DepartmentId, userIds) ?? new HashSet<string>(),
 				StringComparer.OrdinalIgnoreCase);
-			var activeUserIds = new List<string>();
-			foreach (var userId in userIds.Where(x => !string.IsNullOrWhiteSpace(x) && departmentUserIds.Contains(x)))
-			{
-				if (await _authorizationService.IsUserValidWithinLimitsAsync(userId, channel.DepartmentId))
-					activeUserIds.Add(userId);
-			}
+			var activeDepartmentMembers = await _departmentsService.GetAllMembersForDepartmentUnlimitedAsync(channel.DepartmentId);
+			var activeDepartmentUserIds = new HashSet<string>(
+				activeDepartmentMembers?
+					.Where(member => member != null && !member.IsDeleted && !member.IsDisabled.GetValueOrDefault() &&
+						!string.IsNullOrWhiteSpace(member.UserId))
+					.Select(member => member.UserId) ?? Enumerable.Empty<string>(),
+				StringComparer.OrdinalIgnoreCase);
 
-			return activeUserIds;
+			return userIds
+				.Where(userId => !string.IsNullOrWhiteSpace(userId) && departmentUserIds.Contains(userId) &&
+					activeDepartmentUserIds.Contains(userId))
+				.ToList();
 		}
 
 		public async Task InvalidateChannelCacheAsync(string chatChannelId)
@@ -308,7 +312,7 @@ namespace Resgrid.Services
 
 			try
 			{
-				return await _cacheProvider.GetStringAsync(GetVersionKey(chatChannelId)) ?? "0";
+				return await _cacheProvider.GetStringAsync(GetVersionKey(chatChannelId));
 			}
 			catch (Exception ex)
 			{
@@ -434,7 +438,8 @@ namespace Resgrid.Services
 
 		private async Task<bool> EvaluateModerateAsync(ChatChannel channel, string userId)
 		{
-			if (!await HasValidDepartmentScopeAsync(channel))
+			if (channel == null || string.IsNullOrWhiteSpace(userId) ||
+				!await HasValidDepartmentScopeAsync(channel))
 				return false;
 
 			// Department admins moderate every channel type (including DMs, for flagged-content handling).
@@ -442,8 +447,11 @@ namespace Resgrid.Services
 				return true;
 
 			var member = await _chatChannelMemberRepository.GetUserMemberAsync(channel.ChatChannelId, userId);
-			if (member != null && member.DepartmentId == channel.DepartmentId && member.IsModerator && !member.RemovedOn.HasValue)
-				return true;
+			if (member != null)
+			{
+				if (member.DepartmentId == channel.DepartmentId && member.IsModerator && !member.RemovedOn.HasValue)
+					return true;
+			}
 
 			switch ((ChatChannelType)channel.ChannelType)
 			{
@@ -969,7 +977,7 @@ namespace Resgrid.Services
 
 		private async Task<bool> HasValidDepartmentScopeAsync(ChatChannel channel)
 		{
-			if (channel.DepartmentId <= 0)
+			if (channel == null || channel.DepartmentId <= 0)
 				return false;
 
 			var channelType = (ChatChannelType)channel.ChannelType;

--- a/Core/Resgrid.Services/ChatProvisioningEventService.cs
+++ b/Core/Resgrid.Services/ChatProvisioningEventService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Autofac;
 using Resgrid.Framework;
@@ -38,6 +39,12 @@ namespace Resgrid.Services
 			_eventAggregator.AddAsyncListener<IncidentClosedEvent>(OnIncidentClosedAsync);
 			_eventAggregator.AddAsyncListener<LaneLeadChangedEvent>(OnLaneLeadChangedAsync);
 			_eventAggregator.AddAsyncListener<IncidentReopenedEvent>(OnIncidentReopenedAsync);
+			// These two are published through SendMessage (the synchronous event path), so register
+			// synchronous bridges and wait for the fail-safe RunAsync handler to finish. Authorization
+			// epochs must rotate before the mutation returns; fire-and-forget would leave a payload leak
+			// window for already-joined SignalR clients.
+			_eventAggregator.AddListener<SecurityRefreshEvent>(message => OnDepartmentSecurityChangedAsync(message).GetAwaiter().GetResult());
+			_eventAggregator.AddListener<IncidentCommandUpdatedEvent>(message => OnIncidentAuthorizationChangedAsync(message).GetAwaiter().GetResult());
 		}
 
 		private Task OnCallAddedAsync(CallAddedEvent message)
@@ -161,6 +168,70 @@ namespace Resgrid.Services
 				var call = await scope.Resolve<ICallsService>().GetCallByIdAsync(message.CallId);
 				if (call != null && !call.ClosedOn.HasValue)
 					await chatChannelService.SetIncidentChannelsArchivedAsync(message.CallId, false);
+			});
+		}
+
+		private Task OnDepartmentSecurityChangedAsync(SecurityRefreshEvent message)
+		{
+			// DepartmentsService emits this once per membership/admin/visibility refresh (alongside
+			// the other visibility matrices). Handle one type only so a single change does not rotate
+			// every chat group four times.
+			if (message == null || message.DepartmentId <= 0 || message.Type != SecurityCacheTypes.WhoCanViewPersonnel)
+				return Task.CompletedTask;
+
+			return RunAsync(async scope =>
+			{
+				var channelRepository = scope.Resolve<IChatChannelRepository>();
+				var permissionService = scope.Resolve<IChatPermissionService>();
+				var channels = await channelRepository.GetAllByDepartmentIdAsync(message.DepartmentId, true);
+
+				if (channels != null)
+				{
+					foreach (var channel in channels.Where(c => c != null))
+						await permissionService.InvalidateChannelCacheAsync(channel.ChatChannelId);
+				}
+
+				_eventAggregator.SendMessage<ChatEventRaised>(new ChatEventRaised
+				{
+					DepartmentId = message.DepartmentId,
+					Kind = ChatEventKinds.ChannelUpdated,
+					PayloadJson = Newtonsoft.Json.JsonConvert.SerializeObject(new
+					{
+						DepartmentId = message.DepartmentId,
+						AuthorizationChanged = true
+					})
+				});
+			});
+		}
+
+		private Task OnIncidentAuthorizationChangedAsync(IncidentCommandUpdatedEvent message)
+		{
+			if (message == null || message.DepartmentId <= 0 || message.CallId <= 0)
+				return Task.CompletedTask;
+
+			return RunAsync(async scope =>
+			{
+				var channelRepository = scope.Resolve<IChatChannelRepository>();
+				var permissionService = scope.Resolve<IChatPermissionService>();
+				var channels = await channelRepository.GetByCallIdAsync(message.CallId);
+
+				if (channels != null)
+				{
+					foreach (var channel in channels.Where(c => c != null && c.DepartmentId == message.DepartmentId))
+						await permissionService.InvalidateChannelCacheAsync(channel.ChatChannelId);
+				}
+
+				_eventAggregator.SendMessage<ChatEventRaised>(new ChatEventRaised
+				{
+					DepartmentId = message.DepartmentId,
+					Kind = ChatEventKinds.ChannelUpdated,
+					PayloadJson = Newtonsoft.Json.JsonConvert.SerializeObject(new
+					{
+						DepartmentId = message.DepartmentId,
+						CallId = message.CallId,
+						AuthorizationChanged = true
+					})
+				});
 			});
 		}
 

--- a/Core/Resgrid.Services/ChatProvisioningEventService.cs
+++ b/Core/Resgrid.Services/ChatProvisioningEventService.cs
@@ -39,12 +39,9 @@ namespace Resgrid.Services
 			_eventAggregator.AddAsyncListener<IncidentClosedEvent>(OnIncidentClosedAsync);
 			_eventAggregator.AddAsyncListener<LaneLeadChangedEvent>(OnLaneLeadChangedAsync);
 			_eventAggregator.AddAsyncListener<IncidentReopenedEvent>(OnIncidentReopenedAsync);
-			// These two are published through SendMessage (the synchronous event path), so register
-			// synchronous bridges and wait for the fail-safe RunAsync handler to finish. Authorization
-			// epochs must rotate before the mutation returns; fire-and-forget would leave a payload leak
-			// window for already-joined SignalR clients.
+			// Security refresh is published through SendMessage (the synchronous event path), so register
+			// a synchronous bridge and wait for the fail-safe RunAsync handler to finish.
 			_eventAggregator.AddListener<SecurityRefreshEvent>(message => OnDepartmentSecurityChangedAsync(message).GetAwaiter().GetResult());
-			_eventAggregator.AddListener<IncidentCommandUpdatedEvent>(message => OnIncidentAuthorizationChangedAsync(message).GetAwaiter().GetResult());
 		}
 
 		private Task OnCallAddedAsync(CallAddedEvent message)
@@ -198,37 +195,6 @@ namespace Resgrid.Services
 					PayloadJson = Newtonsoft.Json.JsonConvert.SerializeObject(new
 					{
 						DepartmentId = message.DepartmentId,
-						AuthorizationChanged = true
-					})
-				});
-			});
-		}
-
-		private Task OnIncidentAuthorizationChangedAsync(IncidentCommandUpdatedEvent message)
-		{
-			if (message == null || message.DepartmentId <= 0 || message.CallId <= 0)
-				return Task.CompletedTask;
-
-			return RunAsync(async scope =>
-			{
-				var channelRepository = scope.Resolve<IChatChannelRepository>();
-				var permissionService = scope.Resolve<IChatPermissionService>();
-				var channels = await channelRepository.GetByCallIdAsync(message.CallId);
-
-				if (channels != null)
-				{
-					foreach (var channel in channels.Where(c => c != null && c.DepartmentId == message.DepartmentId))
-						await permissionService.InvalidateChannelCacheAsync(channel.ChatChannelId);
-				}
-
-				_eventAggregator.SendMessage<ChatEventRaised>(new ChatEventRaised
-				{
-					DepartmentId = message.DepartmentId,
-					Kind = ChatEventKinds.ChannelUpdated,
-					PayloadJson = Newtonsoft.Json.JsonConvert.SerializeObject(new
-					{
-						DepartmentId = message.DepartmentId,
-						CallId = message.CallId,
 						AuthorizationChanged = true
 					})
 				});

--- a/Core/Resgrid.Services/IncidentCommandService.cs
+++ b/Core/Resgrid.Services/IncidentCommandService.cs
@@ -1625,7 +1625,7 @@ namespace Resgrid.Services
 				var chatChannelService = ServiceLocator.Current.GetInstance<IChatChannelService>();
 				var laneChannel = (await ServiceLocator.Current.GetInstance<Resgrid.Model.Repositories.IChatChannelRepository>().GetByCommandStructureNodeIdAsync(commandStructureNodeId));
 				if (laneChannel != null && !laneChannel.IsArchived)
-					await chatChannelService.SetChannelArchivedAsync(laneChannel.ChatChannelId, true, userId, cancellationToken);
+					await chatChannelService.SetChannelArchivedAsync(laneChannel.DepartmentId, laneChannel.ChatChannelId, true, userId, cancellationToken);
 			}
 			catch (Exception ex)
 			{

--- a/Core/Resgrid.Services/ModerationService.cs
+++ b/Core/Resgrid.Services/ModerationService.cs
@@ -440,7 +440,13 @@ namespace Resgrid.Services
 					var attachmentMetadata = await _chatAttachmentRepository.GetMetadataByMessageIdsAsync(new[] { itemId });
 					var firstAttachment = attachmentMetadata?.FirstOrDefault();
 					if (firstAttachment != null)
-						attachment = await _chatAttachmentRepository.GetByIdAsync(firstAttachment.ChatAttachmentId);
+					{
+						var candidate = await _chatAttachmentRepository.GetByIdAsync(firstAttachment.ChatAttachmentId);
+						if (candidate != null && candidate.DepartmentId == departmentId &&
+							string.Equals(candidate.ChatMessageId, message.ChatMessageId, StringComparison.OrdinalIgnoreCase) &&
+							string.Equals(candidate.ChatChannelId, message.ChatChannelId, StringComparison.OrdinalIgnoreCase))
+							attachment = candidate;
+					}
 
 					return new ModerationEvidence
 					{
@@ -566,7 +572,7 @@ namespace Resgrid.Services
 			switch ((ModerationItemType)request.ItemType)
 			{
 				case ModerationItemType.ChatMessage:
-					return await _chatMessageService.DeleteMessageAsync(request.ItemId, byUserId, true,
+					return await _chatMessageService.DeleteMessageAsync(request.DepartmentId, request.ItemId, byUserId, true,
 						ModeratedChatMessage, cancellationToken);
 
 				case ModerationItemType.Message:

--- a/Core/Resgrid.Services/PermissionGateServiceBase.cs
+++ b/Core/Resgrid.Services/PermissionGateServiceBase.cs
@@ -57,8 +57,8 @@ namespace Resgrid.Services
 			try
 			{
 				var cached = await _cacheProvider.GetStringAsync(cacheKey);
-				if (cached == "1")
-					return true;
+				// Permission rows and department/group/role membership can be revoked independently of
+				// this cache. A negative verdict is safe to reuse; a positive one must be evaluated live.
 				if (cached == "0")
 					return false;
 			}
@@ -72,7 +72,8 @@ namespace Resgrid.Services
 
 			try
 			{
-				await _cacheProvider.SetStringAsync(cacheKey, allowed ? "1" : "0", CacheLength);
+				if (!allowed)
+					await _cacheProvider.SetStringAsync(cacheKey, "0", CacheLength);
 			}
 			catch (Exception ex)
 			{

--- a/Core/Resgrid.Services/PermissionsService.cs
+++ b/Core/Resgrid.Services/PermissionsService.cs
@@ -3,7 +3,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using CommonServiceLocator;
+using Resgrid.Framework;
 using Resgrid.Model;
+using Resgrid.Model.Events;
+using Resgrid.Model.Providers;
 using Resgrid.Model.Repositories;
 using Resgrid.Model.Services;
 
@@ -49,7 +53,53 @@ namespace Resgrid.Services
 			permission.UpdatedBy = userId;
 			permission.UpdatedOn = DateTime.UtcNow;
 
-			return await _permissionsRepository.SaveOrUpdateAsync(permission, cancellationToken);
+			var saved = await _permissionsRepository.SaveOrUpdateAsync(permission, cancellationToken);
+
+			if (saved != null && type == PermissionTypes.DispatchAppLogin)
+				await RotateDispatchChatAccessAsync(departmentId);
+
+			return saved;
+		}
+
+		private static async Task RotateDispatchChatAccessAsync(int departmentId)
+		{
+			if (departmentId <= 0 || !ServiceLocator.IsLocationProviderSet)
+				return;
+
+			try
+			{
+				var channelRepository = ServiceLocator.Current.GetInstance<IChatChannelRepository>();
+				var permissionService = ServiceLocator.Current.GetInstance<IChatPermissionService>();
+				var channels = await channelRepository.GetAllByDepartmentIdAsync(departmentId, true);
+
+				if (channels != null)
+				{
+					foreach (var channel in channels.Where(c => c != null && IsDispatchVisibleChannel((ChatChannelType)c.ChannelType)))
+						await permissionService.InvalidateChannelCacheAsync(channel.ChatChannelId);
+				}
+
+				ServiceLocator.Current.GetInstance<IEventAggregator>().SendMessage<ChatEventRaised>(new ChatEventRaised
+				{
+					DepartmentId = departmentId,
+					Kind = ChatEventKinds.ChannelUpdated,
+					PayloadJson = Newtonsoft.Json.JsonConvert.SerializeObject(new { DepartmentId = departmentId, AuthorizationChanged = true })
+				});
+			}
+			catch (Exception ex)
+			{
+				// The permission write is authoritative and must not be rolled back by a realtime refresh
+				// failure. REST authorization already evaluates the new row live; log and let clients
+				// reconnect if eventing/cache infrastructure is unavailable.
+				Logging.LogException(ex);
+			}
+		}
+
+		private static bool IsDispatchVisibleChannel(ChatChannelType channelType)
+		{
+			return channelType == ChatChannelType.DepartmentDefault || channelType == ChatChannelType.GroupDefault ||
+				channelType == ChatChannelType.Incident || channelType == ChatChannelType.IncidentLane ||
+				channelType == ChatChannelType.IncidentCommand || channelType == ChatChannelType.IncidentLeads ||
+				channelType == ChatChannelType.IncidentDispatch || channelType == ChatChannelType.UnitDispatch;
 		}
 
 		public bool IsUserAllowed(Permission permission, bool isUserDepartmentAdmin, bool isUserGroupAdmin,

--- a/Core/Resgrid.Services/PushService.cs
+++ b/Core/Resgrid.Services/PushService.cs
@@ -17,10 +17,12 @@ namespace Resgrid.Services
 		private readonly IUserProfileService _userProfileService;
 		private readonly INovuProvider _novuProvider;
 		private readonly IDepartmentSettingsService _departmentSettingsService;
+		private readonly IUnitsService _unitsService;
 
 		public PushService(IPushLogsService pushLogsService, INotificationProvider notificationProvider,
 			IUserProfileService userProfileService, IUnitNotificationProvider unitNotificationProvider,
-			INovuProvider novuProvider, IDepartmentSettingsService departmentSettingsService)
+			INovuProvider novuProvider, IDepartmentSettingsService departmentSettingsService,
+			IUnitsService unitsService)
 		{
 			_pushLogsService = pushLogsService;
 			_notificationProvider = notificationProvider;
@@ -28,6 +30,7 @@ namespace Resgrid.Services
 			_unitNotificationProvider = unitNotificationProvider;
 			_novuProvider = novuProvider;
 			_departmentSettingsService = departmentSettingsService;
+			_unitsService = unitsService;
 		}
 
 		public async Task<bool> Register(PushUri pushUri)
@@ -100,22 +103,67 @@ namespace Resgrid.Services
 
 		public async Task<bool> RegisterUnit(PushUri pushUri)
 		{
+			// Same reasoning as Register: a unit whose token never lands on its Novu subscriber gets no
+			// dispatch pushes at all, and every bare `false` below used to leave nothing behind to find.
 			if (pushUri == null || !pushUri.UnitId.HasValue || string.IsNullOrWhiteSpace(pushUri.DeviceId) || string.IsNullOrWhiteSpace(pushUri.PushLocation))
+			{
+				Framework.Logging.LogWarning($"PushService.RegisterUnit: incomplete registration (unitId {pushUri?.UnitId}, platform {pushUri?.PlatformType}, hasToken {!string.IsNullOrWhiteSpace(pushUri?.DeviceId)}, prefix '{pushUri?.PushLocation}'), skipped.");
 				return false;
+			}
 
 			var unitId = pushUri.UnitId.Value;
 			var code = pushUri.PushLocation;
 
+			// The user path creates its subscriber before writing credentials; the unit path never did, so a
+			// unit that had not been through some other Novu call had its credential write rejected against
+			// a subscriber that did not exist.
+			await EnsureUnitSubscriber(unitId, code, pushUri.DeviceId);
+
+			bool registered;
+
 			// 1) iOS -> APNS
 			if (pushUri.PlatformType == (int)Platforms.iOS)
-				return await _novuProvider.UpdateUnitSubscriberApns(unitId, code, pushUri.DeviceId);
-
+			{
+				registered = await _novuProvider.UpdateUnitSubscriberApns(unitId, code, pushUri.DeviceId);
+			}
 			// 2) Android -> FCM
-			if (pushUri.PlatformType == (int)Platforms.Android)
-				return await _novuProvider.UpdateUnitSubscriberFcm(unitId, code, pushUri.DeviceId);
-
+			else if (pushUri.PlatformType == (int)Platforms.Android)
+			{
+				registered = await _novuProvider.UpdateUnitSubscriberFcm(unitId, code, pushUri.DeviceId);
+			}
 			// 3) TODO: Web Push (other platforms)
-			return false;
+			else
+			{
+				Framework.Logging.LogWarning($"PushService.RegisterUnit: unsupported platform {pushUri.PlatformType} for unit {unitId} (prefix '{code}'), no push channel registered.");
+				return false;
+			}
+
+			if (!registered)
+				Framework.Logging.LogError($"PushService.RegisterUnit: Novu rejected the credential write for unit {unitId} (platform {pushUri.PlatformType}, prefix '{code}'); subscriber will have no configured push channel.");
+
+			return registered;
+		}
+
+		private async Task EnsureUnitSubscriber(int unitId, string code, string deviceId)
+		{
+			try
+			{
+				// The unit's own record is the authority on its name and department; the PushUri carries a
+				// DepartmentId that is unmapped and set by whoever built the message.
+				var unit = await _unitsService.GetUnitByIdAsync(unitId);
+
+				if (unit == null)
+				{
+					Framework.Logging.LogWarning($"PushService.RegisterUnit: unit {unitId} (prefix '{code}') was not found, its Novu subscriber could not be created.");
+					return;
+				}
+
+				await _novuProvider.CreateUnitSubscriber(unitId, code, unit.DepartmentId, unit.Name, deviceId);
+			}
+			catch (Exception ex)
+			{
+				Resgrid.Framework.Logging.LogException(ex);
+			}
 		}
 
 		public async Task<bool> UnRegisterUnit(PushUri pushUri)

--- a/Core/Resgrid.Services/PushService.cs
+++ b/Core/Resgrid.Services/PushService.cs
@@ -117,7 +117,8 @@ namespace Resgrid.Services
 			// The user path creates its subscriber before writing credentials; the unit path never did, so a
 			// unit that had not been through some other Novu call had its credential write rejected against
 			// a subscriber that did not exist.
-			await EnsureUnitSubscriber(unitId, code, pushUri.DeviceId);
+			if (!await EnsureUnitSubscriber(unitId, code, pushUri.DeviceId))
+				return false;
 
 			bool registered;
 
@@ -144,7 +145,7 @@ namespace Resgrid.Services
 			return registered;
 		}
 
-		private async Task EnsureUnitSubscriber(int unitId, string code, string deviceId)
+		private async Task<bool> EnsureUnitSubscriber(int unitId, string code, string deviceId)
 		{
 			try
 			{
@@ -155,14 +156,15 @@ namespace Resgrid.Services
 				if (unit == null)
 				{
 					Framework.Logging.LogWarning($"PushService.RegisterUnit: unit {unitId} (prefix '{code}') was not found, its Novu subscriber could not be created.");
-					return;
+					return false;
 				}
 
-				await _novuProvider.CreateUnitSubscriber(unitId, code, unit.DepartmentId, unit.Name, deviceId);
+				return await _novuProvider.CreateUnitSubscriber(unitId, code, unit.DepartmentId, unit.Name, deviceId);
 			}
 			catch (Exception ex)
 			{
 				Resgrid.Framework.Logging.LogException(ex);
+				return false;
 			}
 		}
 

--- a/Providers/Resgrid.Providers.Cache/AzureRedisCacheProvider.cs
+++ b/Providers/Resgrid.Providers.Cache/AzureRedisCacheProvider.cs
@@ -109,9 +109,9 @@ namespace Resgrid.Providers.Cache
 
 
 		public async Task<T> RetrieveAsync<T>(string cacheKey, Func<Task<T>> fallbackFunction, TimeSpan expiration)
-			where T : class
 		{
-			T data = null;
+			T data = default;
+			var hasCachedData = false;
 			IDatabase cache = null;
 
 			try
@@ -125,16 +125,20 @@ namespace Resgrid.Providers.Cache
 					try
 					{
 						if (cacheValue.HasValue)
+						{
 							data = ObjectSerialization.Deserialize<T>(cacheValue);
+							hasCachedData = data is not null;
+						}
 					}
 					catch (Exception deserializeEx)
 					{
 						Logging.LogException(deserializeEx);
 						await RemoveAsync(cacheKey);
-						data = null;
+						data = default;
+						hasCachedData = false;
 					}
 
-					if (data != null)
+					if (hasCachedData)
 						return data;
 				}
 			}
@@ -154,7 +158,7 @@ namespace Resgrid.Providers.Cache
 
 			if (Config.SystemBehaviorConfig.CacheEnabled && _connection != null && _connection.IsConnected)
 			{
-				if (data != null && cache != null)
+				if (data is not null && cache != null)
 				{
 					try
 					{

--- a/Providers/Resgrid.Providers.Claims/ChatAuthorizationPolicyExtensions.cs
+++ b/Providers/Resgrid.Providers.Claims/ChatAuthorizationPolicyExtensions.cs
@@ -1,0 +1,24 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+
+namespace Resgrid.Providers.Claims
+{
+	/// <summary>Shared identity and permission requirements for every chat transport.</summary>
+	public static class ChatAuthorizationPolicyExtensions
+	{
+		public static AuthorizationPolicyBuilder RequireChatAccessClaims(this AuthorizationPolicyBuilder policy)
+		{
+			return policy
+				.RequireAuthenticatedUser()
+				.RequireClaim(ResgridClaimTypes.Resources.Messages, ResgridClaimTypes.Actions.View)
+				.RequireAssertion(context =>
+				{
+					var userId = context.User.FindFirst(ClaimTypes.PrimarySid)?.Value;
+					var departmentIdClaim = context.User.FindFirst(ClaimTypes.PrimaryGroupSid)?.Value;
+
+					return !string.IsNullOrWhiteSpace(userId) &&
+						int.TryParse(departmentIdClaim, out var departmentId) && departmentId > 0;
+				});
+		}
+	}
+}

--- a/Providers/Resgrid.Providers.Claims/ResgridResources.cs
+++ b/Providers/Resgrid.Providers.Claims/ResgridResources.cs
@@ -57,6 +57,7 @@
 		public const string Messages_Update = "Messages_Update";
 		public const string Messages_Create = "Messages_Create";
 		public const string Messages_Delete = "Messages_Delete";
+		public const string Chat_View = "Chat_View";
 
 		public const string Profile_View = "Profile_View";
 		public const string Profile_Update = "Profile_Update";

--- a/Providers/Resgrid.Providers.Messaging/NovuProvider.cs
+++ b/Providers/Resgrid.Providers.Messaging/NovuProvider.cs
@@ -8,6 +8,7 @@ using Resgrid.Model;
 using Resgrid.Model.Providers;
 using Resgrid.Providers.Bus.Models;
 using SharpCompress.Common;
+using System.Net;
 using System.Text;
 using System.Text.RegularExpressions;
 
@@ -132,7 +133,22 @@ namespace Resgrid.Providers.Messaging
 
 					var response = await httpClient.PostAsync(requestUrl, content);
 
-					return response.IsSuccessStatusCode;
+					// A rejected create left the subscriber missing entirely, and every later credential
+					// write and trigger against it fails for a reason that looks unrelated. Only the 409 is
+					// expected: re-registering a device re-runs this, and Novu answers an already-present
+					// subscriber with a conflict, which is the steady state rather than a fault.
+					if (!response.IsSuccessStatusCode)
+					{
+						if (response.StatusCode == HttpStatusCode.Conflict)
+							return true;
+
+						var error = await response.Content.ReadAsStringAsync();
+						Logging.LogError($"Novu subscriber create failed ({(int)response.StatusCode} {response.StatusCode}) subscriber '{id}' department {departmentId}: {DescribeErrorBody(error)}");
+
+						return false;
+					}
+
+					return true;
 				}
 			}
 			catch (Exception e)

--- a/Tests/Resgrid.Tests/Framework/ObjectSerializationTests.cs
+++ b/Tests/Resgrid.Tests/Framework/ObjectSerializationTests.cs
@@ -39,5 +39,14 @@ namespace Resgrid.Tests.Framework
             testObj.Id.Should().Be(500);
             testObj.Data.Should().Be("This is just a test object. TestStringToSearchOn");
         }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void BooleanRoundTrips(bool value)
+        {
+            var serialized = ObjectSerialization.Serialize(value);
+
+            ObjectSerialization.Deserialize<bool>(serialized).Should().Be(value);
+        }
     }
 }

--- a/Tests/Resgrid.Tests/Services/ChatChannelServiceTests.cs
+++ b/Tests/Resgrid.Tests/Services/ChatChannelServiceTests.cs
@@ -81,6 +81,8 @@ namespace Resgrid.Tests.Services
 
 				// Cross-tenant validation passes by default; negative tests override this.
 				_departmentsServiceMock.Setup(x => x.IsUserInDepartmentAsync(It.IsAny<int>(), It.IsAny<string>())).ReturnsAsync(true);
+				_chatPermissionServiceMock.Setup(x => x.CanModerateChannelAsync(It.IsAny<ChatChannel>(), It.IsAny<string>())).ReturnsAsync(true);
+				_chatPermissionServiceMock.Setup(x => x.IsDepartmentAdminAsync(It.IsAny<int>(), It.IsAny<string>())).ReturnsAsync(true);
 
 				// Batch membership check (ad-hoc group creation): by default every queried id is a member.
 				_departmentsServiceMock
@@ -149,6 +151,34 @@ namespace Resgrid.Tests.Services
 		}
 
 		[TestFixture]
+		public class when_saving_department_chat_settings : with_the_chat_channel_service
+		{
+			[Test]
+			public async Task forged_settings_department_should_be_rejected_before_repository_access()
+			{
+				var settings = new ChatDepartmentSetting { DepartmentId = 2 };
+
+				var result = await _chatChannelService.SaveDepartmentSettingsAsync(1, "user-a", settings);
+
+				result.Should().BeNull();
+				_chatPermissionServiceMock.Verify(x => x.IsDepartmentAdminAsync(It.IsAny<int>(), It.IsAny<string>()), Times.Never);
+				_chatDepartmentSettingRepositoryMock.Verify(x => x.GetByDepartmentIdAsync(It.IsAny<int>()), Times.Never);
+			}
+
+			[Test]
+			public async Task non_admin_should_not_save_settings()
+			{
+				var settings = new ChatDepartmentSetting { DepartmentId = 1 };
+				_chatPermissionServiceMock.Setup(x => x.IsDepartmentAdminAsync(1, "user-a")).ReturnsAsync(false);
+
+				var result = await _chatChannelService.SaveDepartmentSettingsAsync(1, "user-a", settings);
+
+				result.Should().BeNull();
+				_chatDepartmentSettingRepositoryMock.Verify(x => x.GetByDepartmentIdAsync(It.IsAny<int>()), Times.Never);
+			}
+		}
+
+		[TestFixture]
 		public class when_ensuring_group_channels : with_the_chat_channel_service
 		{
 			[Test]
@@ -175,6 +205,17 @@ namespace Resgrid.Tests.Services
 		[TestFixture]
 		public class when_ensuring_chatbot_channels : with_the_chat_channel_service
 		{
+			[Test]
+			public async Task disabled_department_member_should_not_get_a_chatbot_channel()
+			{
+				_departmentsServiceMock.Setup(x => x.IsUserDisabledAsync("user-a", 1)).ReturnsAsync(true);
+
+				var result = await _chatChannelService.EnsureChatbotChannelAsync(1, "user-a");
+
+				result.Should().BeNull();
+				_chatChannelRepositoryMock.Verify(x => x.GetChatbotChannelAsync(It.IsAny<int>(), It.IsAny<string>()), Times.Never);
+			}
+
 			[Test]
 			public async Task missing_chatbot_channel_should_create_channel_with_owner_and_bot_members()
 			{
@@ -225,6 +266,17 @@ namespace Resgrid.Tests.Services
 		[TestFixture]
 		public class when_getting_or_creating_direct_message_channels : with_the_chat_channel_service
 		{
+			[Test]
+			public void disabled_target_user_should_be_rejected()
+			{
+				_departmentsServiceMock.Setup(x => x.IsUserDisabledAsync("user-b", 1)).ReturnsAsync(true);
+
+				Func<Task> act = async () => await _chatChannelService.GetOrCreateDirectMessageChannelAsync(1, "user-a", "user-b", null);
+
+				act.Should().ThrowAsync<UnauthorizedAccessException>();
+				_chatChannelRepositoryMock.Verify(x => x.GetByDmKeyAsync(It.IsAny<int>(), It.IsAny<string>()), Times.Never);
+			}
+
 			[Test]
 			public async Task existing_dm_key_should_return_existing_channel_without_insert()
 			{
@@ -367,12 +419,14 @@ namespace Resgrid.Tests.Services
 			[Test]
 			public async Task missing_member_row_should_be_created_then_preference_updated()
 			{
-				_chatChannelRepositoryMock.Setup(x => x.GetByIdAsync("channel-1")).ReturnsAsync(new ChatChannel
+				var channel = new ChatChannel
 				{
 					ChatChannelId = "channel-1",
 					DepartmentId = 1,
 					ChannelType = (int)ChatChannelType.DepartmentDefault
-				});
+				};
+				_chatChannelRepositoryMock.Setup(x => x.GetByIdAsync("channel-1")).ReturnsAsync(channel);
+				_chatPermissionServiceMock.Setup(x => x.CanAccessChannelAsync(channel, "user-a", null)).ReturnsAsync(true);
 				_chatChannelMemberRepositoryMock.Setup(x => x.GetUserMemberAsync("channel-1", "user-a")).ReturnsAsync((ChatChannelMember)null);
 				_chatChannelMemberRepositoryMock.Setup(x => x.SetMemberNotificationPreferenceAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
 
@@ -407,7 +461,7 @@ namespace Resgrid.Tests.Services
 			{
 				_chatChannelRepositoryMock.Setup(x => x.GetByIdAsync("dm-1")).ReturnsAsync(CreateChannel("dm-1", ChatChannelType.DirectMessage));
 
-				Func<Task> act = async () => await _chatChannelService.AddMembersAsync("dm-1", new List<string> { "user-b" }, "user-a");
+				Func<Task> act = async () => await _chatChannelService.AddMembersAsync(1, "dm-1", new List<string> { "user-b" }, "user-a");
 
 				act.Should().ThrowAsync<InvalidOperationException>();
 			}
@@ -419,7 +473,7 @@ namespace Resgrid.Tests.Services
 				_chatChannelRepositoryMock.Setup(x => x.GetByIdAsync("custom-1")).ReturnsAsync(channel);
 				_chatPermissionServiceMock.Setup(x => x.CanModerateChannelAsync(channel, "user-a")).ReturnsAsync(false);
 
-				Func<Task> act = async () => await _chatChannelService.AddMembersAsync("custom-1", new List<string> { "user-b" }, "user-a");
+				Func<Task> act = async () => await _chatChannelService.AddMembersAsync(1, "custom-1", new List<string> { "user-b" }, "user-a");
 
 				act.Should().ThrowAsync<UnauthorizedAccessException>();
 			}
@@ -432,7 +486,7 @@ namespace Resgrid.Tests.Services
 				_chatPermissionServiceMock.Setup(x => x.CanModerateChannelAsync(channel, "user-a")).ReturnsAsync(true);
 				_chatChannelMemberRepositoryMock.Setup(x => x.GetUserMemberAsync("custom-1", "user-b")).ReturnsAsync((ChatChannelMember)null);
 
-				var result = await _chatChannelService.AddMembersAsync("custom-1", new List<string> { "user-b" }, "user-a");
+				var result = await _chatChannelService.AddMembersAsync(1, "custom-1", new List<string> { "user-b" }, "user-a");
 
 				result.Should().HaveCount(1);
 				_chatChannelMemberRepositoryMock.Verify(x => x.InsertAsync(It.Is<ChatChannelMember>(m =>
@@ -447,7 +501,7 @@ namespace Resgrid.Tests.Services
 				_chatChannelRepositoryMock.Setup(x => x.GetByIdAsync("adhoc-1")).ReturnsAsync(channel);
 				_departmentsServiceMock.Setup(x => x.IsUserInDepartmentAsync(1, "outsider")).ReturnsAsync(false);
 
-				Func<Task> act = async () => await _chatChannelService.AddMembersAsync("adhoc-1", new List<string> { "outsider" }, "user-a");
+				Func<Task> act = async () => await _chatChannelService.AddMembersAsync(1, "adhoc-1", new List<string> { "outsider" }, "user-a");
 
 				act.Should().ThrowAsync<UnauthorizedAccessException>();
 			}
@@ -468,7 +522,7 @@ namespace Resgrid.Tests.Services
 				});
 				_chatChannelMemberRepositoryMock.Setup(x => x.SetMemberActiveAsync("member-1", true, It.IsAny<CancellationToken>())).ReturnsAsync(true);
 
-				var result = await _chatChannelService.AddMembersAsync("adhoc-1", new List<string> { "user-b" }, "user-a");
+				var result = await _chatChannelService.AddMembersAsync(1, "adhoc-1", new List<string> { "user-b" }, "user-a");
 
 				result.Should().HaveCount(1);
 				_chatChannelMemberRepositoryMock.Verify(x => x.SetMemberActiveAsync("member-1", true, It.IsAny<CancellationToken>()), Times.Once);
@@ -477,17 +531,78 @@ namespace Resgrid.Tests.Services
 		}
 
 		[TestFixture]
+		public class when_mutating_channels : with_the_chat_channel_service
+		{
+			[Test]
+			public async Task authenticated_department_should_override_a_forged_channel_identifier()
+			{
+				var foreignChannel = new ChatChannel
+				{
+					ChatChannelId = "department-2-channel",
+					DepartmentId = 2,
+					ChannelType = (int)ChatChannelType.AdHocGroup
+				};
+				_chatChannelRepositoryMock.Setup(x => x.GetByIdAsync(foreignChannel.ChatChannelId)).ReturnsAsync(foreignChannel);
+
+				var result = await _chatChannelService.UpdateChannelAsync(1, foreignChannel.ChatChannelId, "forged", null, "user-a");
+
+				result.Should().BeNull();
+				_chatPermissionServiceMock.Verify(x => x.CanModerateChannelAsync(It.IsAny<ChatChannel>(), It.IsAny<string>()), Times.Never);
+				_chatChannelRepositoryMock.Verify(x => x.UpdateChannelInfoAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()), Times.Never);
+			}
+		}
+
+		[TestFixture]
 		public class when_ensuring_member_state : with_the_chat_channel_service
 		{
 			[Test]
+			public async Task department_membership_alone_should_not_self_grant_an_inaccessible_channel()
+			{
+				var channel = new ChatChannel
+				{
+					ChatChannelId = "incident-1",
+					DepartmentId = 1,
+					ChannelType = (int)ChatChannelType.Incident,
+					CallId = 10
+				};
+				_chatChannelRepositoryMock.Setup(x => x.GetByIdAsync(channel.ChatChannelId)).ReturnsAsync(channel);
+				_chatPermissionServiceMock.Setup(x => x.CanAccessChannelAsync(channel, "user-a", null)).ReturnsAsync(false);
+
+				var result = await _chatChannelService.EnsureMemberStateAsync(channel.ChatChannelId, 1, "user-a", null);
+
+				result.Should().BeNull();
+				_chatChannelMemberRepositoryMock.Verify(x => x.InsertAsync(It.IsAny<ChatChannelMember>(),
+					It.IsAny<CancellationToken>(), It.IsAny<bool>()), Times.Never);
+			}
+
+			[Test]
+			public async Task channel_from_another_department_should_not_create_member_state()
+			{
+				_chatChannelRepositoryMock.Setup(x => x.GetByIdAsync("dept-2")).ReturnsAsync(new ChatChannel
+				{
+					ChatChannelId = "dept-2",
+					DepartmentId = 2,
+					ChannelType = (int)ChatChannelType.DepartmentDefault
+				});
+
+				var result = await _chatChannelService.EnsureMemberStateAsync("dept-2", 1, "user-a", null);
+
+				result.Should().BeNull();
+				_chatChannelMemberRepositoryMock.Verify(x => x.InsertAsync(It.IsAny<ChatChannelMember>(),
+					It.IsAny<CancellationToken>(), It.IsAny<bool>()), Times.Never);
+			}
+
+			[Test]
 			public void invite_only_channel_without_membership_should_throw()
 			{
-				_chatChannelRepositoryMock.Setup(x => x.GetByIdAsync("dm-1")).ReturnsAsync(new ChatChannel
+				var channel = new ChatChannel
 				{
 					ChatChannelId = "dm-1",
 					DepartmentId = 1,
 					ChannelType = (int)ChatChannelType.DirectMessage
-				});
+				};
+				_chatChannelRepositoryMock.Setup(x => x.GetByIdAsync("dm-1")).ReturnsAsync(channel);
+				_chatPermissionServiceMock.Setup(x => x.CanAccessChannelAsync(channel, "user-a", null)).ReturnsAsync(true);
 				_chatChannelMemberRepositoryMock.Setup(x => x.GetUserMemberAsync("dm-1", "user-a")).ReturnsAsync((ChatChannelMember)null);
 
 				Func<Task> act = async () => await _chatChannelService.EnsureMemberStateAsync("dm-1", 1, "user-a", null);
@@ -499,12 +614,14 @@ namespace Resgrid.Tests.Services
 			[Test]
 			public async Task invite_only_channel_with_removed_membership_should_reactivate()
 			{
-				_chatChannelRepositoryMock.Setup(x => x.GetByIdAsync("dm-1")).ReturnsAsync(new ChatChannel
+				var channel = new ChatChannel
 				{
 					ChatChannelId = "dm-1",
 					DepartmentId = 1,
 					ChannelType = (int)ChatChannelType.DirectMessage
-				});
+				};
+				_chatChannelRepositoryMock.Setup(x => x.GetByIdAsync("dm-1")).ReturnsAsync(channel);
+				_chatPermissionServiceMock.Setup(x => x.CanAccessChannelAsync(channel, "user-a", null)).ReturnsAsync(true);
 				_chatChannelMemberRepositoryMock.Setup(x => x.GetUserMemberAsync("dm-1", "user-a")).ReturnsAsync(new ChatChannelMember
 				{
 					ChatChannelMemberId = "member-1",
@@ -527,12 +644,14 @@ namespace Resgrid.Tests.Services
 			[Test]
 			public async Task implicit_channel_without_membership_should_create_row()
 			{
-				_chatChannelRepositoryMock.Setup(x => x.GetByIdAsync("dept-1")).ReturnsAsync(new ChatChannel
+				var channel = new ChatChannel
 				{
 					ChatChannelId = "dept-1",
 					DepartmentId = 1,
 					ChannelType = (int)ChatChannelType.DepartmentDefault
-				});
+				};
+				_chatChannelRepositoryMock.Setup(x => x.GetByIdAsync("dept-1")).ReturnsAsync(channel);
+				_chatPermissionServiceMock.Setup(x => x.CanAccessChannelAsync(channel, "user-a", null)).ReturnsAsync(true);
 				_chatChannelMemberRepositoryMock.Setup(x => x.GetUserMemberAsync("dept-1", "user-a")).ReturnsAsync((ChatChannelMember)null);
 
 				var result = await _chatChannelService.EnsureMemberStateAsync("dept-1", 1, "user-a", null);
@@ -541,6 +660,29 @@ namespace Resgrid.Tests.Services
 				_chatChannelMemberRepositoryMock.Verify(x => x.InsertAsync(It.Is<ChatChannelMember>(m =>
 					m.ChatChannelId == "dept-1" && m.UserId == "user-a"),
 					It.IsAny<CancellationToken>(), It.IsAny<bool>()), Times.Once);
+			}
+		}
+
+		[TestFixture]
+		public class when_listing_channel_members : with_the_chat_channel_service
+		{
+			[Test]
+			public async Task member_rows_from_another_department_should_be_filtered_out()
+			{
+				_chatChannelRepositoryMock.Setup(x => x.GetByIdAsync("channel-1")).ReturnsAsync(new ChatChannel
+				{
+					ChatChannelId = "channel-1",
+					DepartmentId = 1
+				});
+				_chatChannelMemberRepositoryMock.Setup(x => x.GetByChannelIdAsync("channel-1")).ReturnsAsync(new List<ChatChannelMember>
+				{
+					new ChatChannelMember { ChatChannelMemberId = "member-1", ChatChannelId = "channel-1", DepartmentId = 1, UserId = "user-a" },
+					new ChatChannelMember { ChatChannelMemberId = "member-2", ChatChannelId = "channel-1", DepartmentId = 2, UserId = "user-b" }
+				});
+
+				var result = await _chatChannelService.GetMembersAsync("channel-1");
+
+				result.Should().ContainSingle().Which.ChatChannelMemberId.Should().Be("member-1");
 			}
 		}
 
@@ -580,6 +722,25 @@ namespace Resgrid.Tests.Services
 				_chatChannelRepositoryMock.Verify(x => x.InsertAsync(It.Is<ChatChannel>(c => c.ChannelType == (int)ChatChannelType.GroupDefault),
 					It.IsAny<CancellationToken>(), It.IsAny<bool>()), Times.Exactly(2));
 				_departmentGroupsServiceMock.Verify(x => x.GetGroupForUserAsync(It.IsAny<string>(), It.IsAny<int>()), Times.Never);
+			}
+
+			[Test]
+			public async Task dispatcher_should_get_every_department_group_channel_provisioned()
+			{
+				SetupDepartmentChannel();
+				_chatPermissionServiceMock.Setup(x => x.IsDepartmentAdminAsync(1, "dispatcher-a")).ReturnsAsync(false);
+				_chatPermissionServiceMock.Setup(x => x.CanAccessDepartmentOperationalChannelsAsync(1, "dispatcher-a")).ReturnsAsync(true);
+				_departmentGroupsServiceMock.Setup(x => x.GetAllGroupsForDepartmentAsync(1)).ReturnsAsync(new List<DepartmentGroup>
+				{
+					new DepartmentGroup { DepartmentGroupId = 9, DepartmentId = 1, Name = "Station 1" },
+					new DepartmentGroup { DepartmentGroupId = 10, DepartmentId = 1, Name = "Station 2" }
+				});
+				_chatChannelRepositoryMock.Setup(x => x.GetByGroupIdAsync(It.IsAny<int>())).ReturnsAsync((ChatChannel)null);
+
+				var result = await _chatChannelService.GetChannelsForUserAsync(1, "dispatcher-a", null);
+
+				result.Should().Contain(c => c.ChannelType == (int)ChatChannelType.GroupDefault && c.GroupId == 9);
+				result.Should().Contain(c => c.ChannelType == (int)ChatChannelType.GroupDefault && c.GroupId == 10);
 			}
 
 			[Test]
@@ -657,10 +818,67 @@ namespace Resgrid.Tests.Services
 					new ChatChannelMember { ChatChannelMemberId = "m1", ChatChannelId = "dm-unit-7", DepartmentId = 1, ParticipantType = (int)ChatParticipantType.Unit, UnitId = 7 }
 				});
 				_chatChannelRepositoryMock.Setup(x => x.GetByIdsAsync(It.Is<IEnumerable<string>>(ids => ids.Contains("dm-unit-7")))).ReturnsAsync(new List<ChatChannel> { unitDm });
+				_chatPermissionServiceMock.Setup(x => x.CanAccessChannelAsync(unitDm, "user-a", 7)).ReturnsAsync(true);
 
 				var result = await _chatChannelService.GetChannelsForUserAsync(1, "user-a", 7);
 
 				result.Should().Contain(c => c.ChatChannelId == "dm-unit-7");
+			}
+
+			[Test]
+			public async Task stale_incident_member_row_should_not_keep_the_channel_visible_after_unassignment()
+			{
+				SetupDepartmentChannel();
+				_chatPermissionServiceMock.Setup(x => x.IsDepartmentAdminAsync(1, "user-a")).ReturnsAsync(false);
+
+				var incident = new ChatChannel
+				{
+					ChatChannelId = "incident-42",
+					DepartmentId = 1,
+					ChannelType = (int)ChatChannelType.Incident,
+					CallId = 42
+				};
+				_chatChannelMemberRepositoryMock.Setup(x => x.GetActiveByUserIdAsync(1, "user-a")).ReturnsAsync(new List<ChatChannelMember>
+				{
+					new ChatChannelMember
+					{
+						ChatChannelMemberId = "read-state-1",
+						ChatChannelId = incident.ChatChannelId,
+						DepartmentId = 1,
+						ParticipantType = (int)ChatParticipantType.User,
+						UserId = "user-a"
+					}
+				});
+				_chatChannelRepositoryMock.Setup(x => x.GetByIdsAsync(It.IsAny<IEnumerable<string>>())).ReturnsAsync(new List<ChatChannel> { incident });
+				_chatPermissionServiceMock.Setup(x => x.CanAccessChannelAsync(incident, "user-a", null)).ReturnsAsync(false);
+
+				var result = await _chatChannelService.GetChannelsForUserAsync(1, "user-a", null);
+
+				result.Should().NotContain(c => c.ChatChannelId == incident.ChatChannelId);
+			}
+
+			[Test]
+			public async Task cross_department_channel_from_a_member_row_should_not_be_listed()
+			{
+				SetupDepartmentChannel();
+				_chatPermissionServiceMock.Setup(x => x.IsDepartmentAdminAsync(1, "user-a")).ReturnsAsync(false);
+
+				var foreignChannel = new ChatChannel
+				{
+					ChatChannelId = "foreign-dm",
+					DepartmentId = 2,
+					ChannelType = (int)ChatChannelType.DirectMessage
+				};
+				_chatChannelMemberRepositoryMock.Setup(x => x.GetActiveByUserIdAsync(1, "user-a")).ReturnsAsync(new List<ChatChannelMember>
+				{
+					new ChatChannelMember { ChatChannelId = foreignChannel.ChatChannelId, DepartmentId = 1, UserId = "user-a" }
+				});
+				_chatChannelRepositoryMock.Setup(x => x.GetByIdsAsync(It.IsAny<IEnumerable<string>>())).ReturnsAsync(new List<ChatChannel> { foreignChannel });
+
+				var result = await _chatChannelService.GetChannelsForUserAsync(1, "user-a", null);
+
+				result.Should().NotContain(c => c.ChatChannelId == foreignChannel.ChatChannelId);
+				_chatPermissionServiceMock.Verify(x => x.CanAccessChannelAsync(foreignChannel, It.IsAny<string>(), It.IsAny<int?>()), Times.Never);
 			}
 
 			[Test]
@@ -819,6 +1037,17 @@ namespace Resgrid.Tests.Services
 		[TestFixture]
 		public class when_creating_ad_hoc_group_channels : with_the_chat_channel_service
 		{
+			[Test]
+			public void disabled_member_should_be_rejected_before_channel_creation()
+			{
+				_departmentsServiceMock.Setup(x => x.IsUserDisabledAsync("user-b", 1)).ReturnsAsync(true);
+
+				Func<Task> act = async () => await _chatChannelService.CreateAdHocGroupChannelAsync(1, "user-a", "Strike Team", new List<string> { "user-b" });
+
+				act.Should().ThrowAsync<UnauthorizedAccessException>();
+				_chatChannelRepositoryMock.Verify(x => x.InsertAsync(It.IsAny<ChatChannel>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()), Times.Never);
+			}
+
 			[Test]
 			public async Task creator_should_be_inserted_as_moderator()
 			{

--- a/Tests/Resgrid.Tests/Services/ChatChannelServiceTests.cs
+++ b/Tests/Resgrid.Tests/Services/ChatChannelServiceTests.cs
@@ -81,6 +81,7 @@ namespace Resgrid.Tests.Services
 
 				// Cross-tenant validation passes by default; negative tests override this.
 				_departmentsServiceMock.Setup(x => x.IsUserInDepartmentAsync(It.IsAny<int>(), It.IsAny<string>())).ReturnsAsync(true);
+				_chatPermissionServiceMock.Setup(x => x.IsActiveDepartmentUserAsync(It.IsAny<int>(), It.IsAny<string>())).ReturnsAsync(true);
 				_chatPermissionServiceMock.Setup(x => x.CanModerateChannelAsync(It.IsAny<ChatChannel>(), It.IsAny<string>())).ReturnsAsync(true);
 				_chatPermissionServiceMock.Setup(x => x.IsDepartmentAdminAsync(It.IsAny<int>(), It.IsAny<string>())).ReturnsAsync(true);
 
@@ -208,7 +209,7 @@ namespace Resgrid.Tests.Services
 			[Test]
 			public async Task disabled_department_member_should_not_get_a_chatbot_channel()
 			{
-				_departmentsServiceMock.Setup(x => x.IsUserDisabledAsync("user-a", 1)).ReturnsAsync(true);
+				_chatPermissionServiceMock.Setup(x => x.IsActiveDepartmentUserAsync(1, "user-a")).ReturnsAsync(false);
 
 				var result = await _chatChannelService.EnsureChatbotChannelAsync(1, "user-a");
 
@@ -269,7 +270,7 @@ namespace Resgrid.Tests.Services
 			[Test]
 			public void disabled_target_user_should_be_rejected()
 			{
-				_departmentsServiceMock.Setup(x => x.IsUserDisabledAsync("user-b", 1)).ReturnsAsync(true);
+				_chatPermissionServiceMock.Setup(x => x.IsActiveDepartmentUserAsync(1, "user-b")).ReturnsAsync(false);
 
 				Func<Task> act = async () => await _chatChannelService.GetOrCreateDirectMessageChannelAsync(1, "user-a", "user-b", null);
 
@@ -361,7 +362,7 @@ namespace Resgrid.Tests.Services
 			public void cross_department_target_user_should_be_rejected()
 			{
 				_chatChannelRepositoryMock.Setup(x => x.GetByDmKeyAsync(1, It.IsAny<string>())).ReturnsAsync((ChatChannel)null);
-				_departmentsServiceMock.Setup(x => x.IsUserInDepartmentAsync(1, "outsider")).ReturnsAsync(false);
+				_chatPermissionServiceMock.Setup(x => x.IsActiveDepartmentUserAsync(1, "outsider")).ReturnsAsync(false);
 
 				Func<Task> act = async () => await _chatChannelService.GetOrCreateDirectMessageChannelAsync(1, "user-a", "outsider", null);
 
@@ -499,7 +500,7 @@ namespace Resgrid.Tests.Services
 			{
 				var channel = CreateChannel("adhoc-1", ChatChannelType.AdHocGroup);
 				_chatChannelRepositoryMock.Setup(x => x.GetByIdAsync("adhoc-1")).ReturnsAsync(channel);
-				_departmentsServiceMock.Setup(x => x.IsUserInDepartmentAsync(1, "outsider")).ReturnsAsync(false);
+				_chatPermissionServiceMock.Setup(x => x.IsActiveDepartmentUserAsync(1, "outsider")).ReturnsAsync(false);
 
 				Func<Task> act = async () => await _chatChannelService.AddMembersAsync(1, "adhoc-1", new List<string> { "outsider" }, "user-a");
 

--- a/Tests/Resgrid.Tests/Services/ChatCommanderLineTests.cs
+++ b/Tests/Resgrid.Tests/Services/ChatCommanderLineTests.cs
@@ -74,6 +74,15 @@ namespace Resgrid.Tests.Services
 					.ReturnsAsync((int _, IEnumerable<string> ids) => ids == null
 						? new HashSet<string>()
 						: new HashSet<string>(ids, StringComparer.OrdinalIgnoreCase));
+				departmentsServiceMock
+					.Setup(x => x.GetAllMembersForDepartmentUnlimitedAsync(DepartmentId, It.IsAny<bool>()))
+					.ReturnsAsync(new List<DepartmentMember>
+					{
+						new DepartmentMember { DepartmentId = DepartmentId, UserId = TestData.Users.TestUser1Id },
+						new DepartmentMember { DepartmentId = DepartmentId, UserId = TestData.Users.TestUser2Id },
+						new DepartmentMember { DepartmentId = DepartmentId, UserId = TestData.Users.TestUser3Id },
+						new DepartmentMember { DepartmentId = DepartmentId, UserId = TestData.Users.TestUser4Id }
+					});
 
 				_authorizationServiceMock.Setup(x => x.CanUserModifyDepartmentAsync(It.IsAny<string>(), It.IsAny<int>())).ReturnsAsync(false);
 				_authorizationServiceMock.Setup(x => x.IsUserValidWithinLimitsAsync(It.IsAny<string>(), DepartmentId)).ReturnsAsync(true);

--- a/Tests/Resgrid.Tests/Services/ChatCommanderLineTests.cs
+++ b/Tests/Resgrid.Tests/Services/ChatCommanderLineTests.cs
@@ -40,6 +40,7 @@ namespace Resgrid.Tests.Services
 			protected Mock<ICallsService> _callsServiceMock;
 			protected Mock<IDispatchAccessService> _dispatchAccessServiceMock;
 			protected Mock<IAuthorizationService> _authorizationServiceMock;
+			protected Mock<IChatPermissionService> _channelPermissionServiceMock;
 
 			protected with_the_commander_line()
 			{
@@ -61,14 +62,25 @@ namespace Resgrid.Tests.Services
 				_callsServiceMock = new Mock<ICallsService>();
 				_dispatchAccessServiceMock = new Mock<IDispatchAccessService>();
 				_authorizationServiceMock = new Mock<IAuthorizationService>();
+				_channelPermissionServiceMock = new Mock<IChatPermissionService>();
 
 				var cacheProviderMock = new Mock<ICacheProvider>();
+				var departmentsServiceMock = new Mock<IDepartmentsService>();
 				cacheProviderMock.Setup(x => x.GetStringAsync(It.IsAny<string>())).ReturnsAsync((string)null);
 				cacheProviderMock.Setup(x => x.SetStringAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan>())).ReturnsAsync(true);
+				departmentsServiceMock.Setup(x => x.IsUserInDepartmentAsync(DepartmentId, It.IsAny<string>())).ReturnsAsync(true);
+				departmentsServiceMock
+					.Setup(x => x.GetMemberUserIdsInDepartmentAsync(DepartmentId, It.IsAny<IEnumerable<string>>()))
+					.ReturnsAsync((int _, IEnumerable<string> ids) => ids == null
+						? new HashSet<string>()
+						: new HashSet<string>(ids, StringComparer.OrdinalIgnoreCase));
 
 				_authorizationServiceMock.Setup(x => x.CanUserModifyDepartmentAsync(It.IsAny<string>(), It.IsAny<int>())).ReturnsAsync(false);
+				_authorizationServiceMock.Setup(x => x.IsUserValidWithinLimitsAsync(It.IsAny<string>(), DepartmentId)).ReturnsAsync(true);
 				_dispatchAccessServiceMock.Setup(x => x.CanUseDispatchAsync(It.IsAny<int>(), It.IsAny<string>())).ReturnsAsync(false);
 				_dispatchAccessServiceMock.Setup(x => x.GetDispatchUserIdsAsync(It.IsAny<int>())).ReturnsAsync(new List<string>());
+				_channelPermissionServiceMock.Setup(x => x.CanAccessIncidentAsync(DepartmentId, CallId, It.IsAny<string>(), It.IsAny<int?>())).ReturnsAsync(true);
+				_channelPermissionServiceMock.Setup(x => x.CanSendAsUnitAsync(It.IsAny<string>(), It.IsAny<int>(), DepartmentId)).ReturnsAsync(true);
 
 				// The atomic channel+members insert echoes the channel back, and the member rows stay
 				// inspectable through the callback argument.
@@ -87,7 +99,7 @@ namespace Resgrid.Tests.Services
 					_memberRepositoryMock.Object,
 					Mock.Of<IChatChannelAccessRuleRepository>(),
 					_authorizationServiceMock.Object,
-					Mock.Of<IDepartmentsService>(),
+					departmentsServiceMock.Object,
 					Mock.Of<IDepartmentGroupsService>(),
 					Mock.Of<IPersonnelRolesService>(),
 					_unitsServiceMock.Object,
@@ -101,8 +113,8 @@ namespace Resgrid.Tests.Services
 					_memberRepositoryMock.Object,
 					Mock.Of<IChatChannelAccessRuleRepository>(),
 					Mock.Of<IChatDepartmentSettingRepository>(),
-					Mock.Of<IChatPermissionService>(),
-					Mock.Of<IDepartmentsService>(),
+					_channelPermissionServiceMock.Object,
+					departmentsServiceMock.Object,
 					Mock.Of<IDepartmentGroupsService>(),
 					_unitsServiceMock.Object,
 					_userProfileServiceMock.Object,
@@ -162,6 +174,18 @@ namespace Resgrid.Tests.Services
 		[TestFixture]
 		public class when_provisioning_a_commander_line : with_the_commander_line
 		{
+			[Test]
+			public void requester_without_incident_assignment_should_be_rejected_before_channel_lookup()
+			{
+				GivenCommanderIs(TestData.Users.TestUser2Id);
+				_channelPermissionServiceMock.Setup(x => x.CanAccessIncidentAsync(DepartmentId, CallId, TestData.Users.TestUser1Id, null)).ReturnsAsync(false);
+
+				Func<Task> act = async () => await _chatChannelService.EnsureIncidentCommanderLineAsync(DepartmentId, CallId, TestData.Users.TestUser1Id, null);
+
+				act.Should().ThrowAsync<UnauthorizedAccessException>();
+				_channelRepositoryMock.Verify(x => x.GetByDmKeyAsync(It.IsAny<int>(), It.IsAny<string>()), Times.Never);
+			}
+
 			[Test]
 			public async Task no_established_command_should_not_provision_a_line()
 			{
@@ -341,11 +365,18 @@ namespace Resgrid.Tests.Services
 			public async Task the_requester_should_keep_access_across_a_handover()
 			{
 				GivenCommanderIs(TestData.Users.TestUser3Id);
+				_callsServiceMock.Setup(x => x.GetCallByIdAsync(CallId, It.IsAny<bool>())).ReturnsAsync(new Call
+				{
+					CallId = CallId,
+					DepartmentId = DepartmentId,
+					Dispatches = new List<CallDispatch> { new CallDispatch { CallId = CallId, UserId = TestData.Users.TestUser1Id } }
+				});
 				_memberRepositoryMock
 					.Setup(x => x.GetUserMemberAsync("commander-line-1", TestData.Users.TestUser1Id))
 					.ReturnsAsync(new ChatChannelMember
 					{
 						ChatChannelId = "commander-line-1",
+						DepartmentId = DepartmentId,
 						UserId = TestData.Users.TestUser1Id,
 						ParticipantType = (int)ChatParticipantType.User
 					});
@@ -353,6 +384,38 @@ namespace Resgrid.Tests.Services
 				var result = await _chatPermissionService.CanAccessChannelAsync(BuildCommanderLine(), TestData.Users.TestUser1Id, null);
 
 				result.Should().BeTrue();
+			}
+
+			[Test]
+			public async Task a_released_requester_should_lose_access_even_when_the_member_row_remains()
+			{
+				GivenCommanderIs(TestData.Users.TestUser2Id);
+				_memberRepositoryMock
+					.Setup(x => x.GetUserMemberAsync("commander-line-1", TestData.Users.TestUser1Id))
+					.ReturnsAsync(new ChatChannelMember
+					{
+						ChatChannelId = "commander-line-1",
+						DepartmentId = DepartmentId,
+						UserId = TestData.Users.TestUser1Id,
+						ParticipantType = (int)ChatParticipantType.User
+					});
+				_memberRepositoryMock.Setup(x => x.GetByChannelIdAsync("commander-line-1")).ReturnsAsync(new List<ChatChannelMember>
+				{
+					new ChatChannelMember
+					{
+						ChatChannelId = "commander-line-1",
+						DepartmentId = DepartmentId,
+						UserId = TestData.Users.TestUser1Id,
+						ParticipantType = (int)ChatParticipantType.User
+					}
+				});
+				_incidentCommandServiceMock.Setup(x => x.GetAssignmentsForCallAsync(DepartmentId, CallId)).ReturnsAsync(new List<ResourceAssignment>());
+
+				var result = await _chatPermissionService.CanAccessChannelAsync(BuildCommanderLine(), TestData.Users.TestUser1Id, null);
+				var audience = await _chatPermissionService.ResolveChannelAudienceUserIdsAsync(BuildCommanderLine());
+
+				result.Should().BeFalse();
+				audience.Should().NotContain(TestData.Users.TestUser1Id);
 			}
 
 			[Test]
@@ -394,11 +457,18 @@ namespace Resgrid.Tests.Services
 			public async Task the_audience_should_be_the_requester_plus_the_current_commander_only()
 			{
 				GivenCommanderIs(TestData.Users.TestUser2Id);
+				_callsServiceMock.Setup(x => x.GetCallByIdAsync(CallId, It.IsAny<bool>())).ReturnsAsync(new Call
+				{
+					CallId = CallId,
+					DepartmentId = DepartmentId,
+					Dispatches = new List<CallDispatch> { new CallDispatch { CallId = CallId, UserId = TestData.Users.TestUser1Id } }
+				});
 				_memberRepositoryMock.Setup(x => x.GetByChannelIdAsync("commander-line-1")).ReturnsAsync(new List<ChatChannelMember>
 				{
 					new ChatChannelMember
 					{
 						ChatChannelId = "commander-line-1",
+						DepartmentId = DepartmentId,
 						UserId = TestData.Users.TestUser1Id,
 						ParticipantType = (int)ChatParticipantType.User
 					}

--- a/Tests/Resgrid.Tests/Services/ChatFrozenChannelTests.cs
+++ b/Tests/Resgrid.Tests/Services/ChatFrozenChannelTests.cs
@@ -29,6 +29,7 @@ namespace Resgrid.Tests.Services
 		private Mock<IChatMessageRepository> _messageRepository;
 		private Mock<IChatMessageReactionRepository> _reactionRepository;
 		private Mock<IChatMessageEditRepository> _editRepository;
+		private Mock<IChatPermissionService> _permissionService;
 		private ChatMessage _message;
 
 		[SetUp]
@@ -47,6 +48,9 @@ namespace Resgrid.Tests.Services
 			_messageRepository = new Mock<IChatMessageRepository>();
 			_reactionRepository = new Mock<IChatMessageReactionRepository>();
 			_editRepository = new Mock<IChatMessageEditRepository>();
+			_permissionService = new Mock<IChatPermissionService>();
+			_permissionService.Setup(x => x.CanAccessChannelAsync(It.IsAny<ChatChannel>(), It.IsAny<string>(), It.IsAny<int?>())).ReturnsAsync(true);
+			_permissionService.Setup(x => x.CanModerateChannelAsync(It.IsAny<ChatChannel>(), It.IsAny<string>())).ReturnsAsync(true);
 
 			_messageRepository.Setup(x => x.GetByIdAsync(MessageId)).ReturnsAsync(_message);
 			_messageRepository
@@ -75,7 +79,7 @@ namespace Resgrid.Tests.Services
 				Mock.Of<IChatMessageAckRepository>(),
 				Mock.Of<IChatChannelMemberRepository>(),
 				Mock.Of<IChatChannelService>(),
-				Mock.Of<IChatPermissionService>(),
+				_permissionService.Object,
 				Mock.Of<IUserProfileService>(),
 				Mock.Of<IUnitsService>(),
 				Mock.Of<IEventAggregator>());
@@ -85,7 +89,7 @@ namespace Resgrid.Tests.Services
 		{
 			GivenChannelArchived(true);
 
-			var result = await BuildService().EditMessageAsync(MessageId, SenderId, "rewritten after the fact");
+			var result = await BuildService().EditMessageAsync(1, MessageId, SenderId, "rewritten after the fact");
 
 			result.Should().BeNull();
 			_message.Body.Should().Be("original body");
@@ -97,7 +101,7 @@ namespace Resgrid.Tests.Services
 		{
 			GivenChannelArchived(false);
 
-			var result = await BuildService().EditMessageAsync(MessageId, SenderId, "corrected");
+			var result = await BuildService().EditMessageAsync(1, MessageId, SenderId, "corrected");
 
 			result.Should().NotBeNull();
 			result.Body.Should().Be("corrected");
@@ -108,7 +112,7 @@ namespace Resgrid.Tests.Services
 		{
 			GivenChannelArchived(true);
 
-			var result = await BuildService().DeleteMessageAsync(MessageId, SenderId, asModerator: false, reason: null);
+			var result = await BuildService().DeleteMessageAsync(1, MessageId, SenderId, asModerator: false, reason: null);
 
 			result.Should().BeFalse();
 			_messageRepository.Verify(x => x.TombstoneAsync(MessageId, It.IsAny<DateTime>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never);
@@ -121,7 +125,7 @@ namespace Resgrid.Tests.Services
 
 			// Moderation has to keep working on a closed incident — that is the whole point of leaving
 			// flagging available on a frozen record.
-			var result = await BuildService().DeleteMessageAsync(MessageId, "moderator", asModerator: true, reason: "policy");
+			var result = await BuildService().DeleteMessageAsync(1, MessageId, "moderator", asModerator: true, reason: "policy");
 
 			result.Should().BeTrue();
 			_message.IsModerated.Should().BeTrue();
@@ -134,8 +138,8 @@ namespace Resgrid.Tests.Services
 			GivenChannelArchived(true);
 			var service = BuildService();
 
-			(await service.AddReactionAsync(MessageId, SenderId, null, "👍")).Should().BeFalse();
-			(await service.RemoveReactionAsync(MessageId, SenderId, null, "👍")).Should().BeFalse();
+			(await service.AddReactionAsync(1, MessageId, SenderId, null, "👍")).Should().BeFalse();
+			(await service.RemoveReactionAsync(1, MessageId, SenderId, null, "👍")).Should().BeFalse();
 
 			_reactionRepository.Verify(x => x.InsertAsync(It.IsAny<ChatMessageReaction>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()), Times.Never);
 			_reactionRepository.Verify(
@@ -148,7 +152,7 @@ namespace Resgrid.Tests.Services
 		{
 			_channelRepository.Setup(x => x.GetByIdAsync(ChannelId)).ReturnsAsync((ChatChannel)null);
 
-			var result = await BuildService().EditMessageAsync(MessageId, SenderId, "rewritten");
+			var result = await BuildService().EditMessageAsync(1, MessageId, SenderId, "rewritten");
 
 			result.Should().BeNull();
 		}

--- a/Tests/Resgrid.Tests/Services/ChatMessageServiceTests.cs
+++ b/Tests/Resgrid.Tests/Services/ChatMessageServiceTests.cs
@@ -34,6 +34,7 @@ namespace Resgrid.Tests.Services
 			var channelRepository = new Mock<IChatChannelRepository>();
 			var messageRepository = new Mock<IChatMessageRepository>();
 			var editRepository = new Mock<IChatMessageEditRepository>();
+			var permissionService = new Mock<IChatPermissionService>();
 			var eventAggregator = new Mock<IEventAggregator>();
 			ChatEventRaised deleteEvent = null;
 
@@ -42,6 +43,8 @@ namespace Resgrid.Tests.Services
 				.Setup(x => x.TombstoneAsync(message.ChatMessageId, It.IsAny<DateTime>(), deletingUserId, expectedModerated, It.IsAny<CancellationToken>()))
 				.ReturnsAsync(true);
 			channelRepository.Setup(x => x.GetByIdAsync(channel.ChatChannelId)).ReturnsAsync(channel);
+			permissionService.Setup(x => x.CanAccessChannelAsync(channel, deletingUserId, null)).ReturnsAsync(true);
+			permissionService.Setup(x => x.CanModerateChannelAsync(channel, deletingUserId)).ReturnsAsync(true);
 			eventAggregator
 				.Setup(x => x.SendMessage<ChatEventRaised>(It.IsAny<ChatEventRaised>()))
 				.Callback<ChatEventRaised>(raised => deleteEvent = raised);
@@ -56,12 +59,12 @@ namespace Resgrid.Tests.Services
 				Mock.Of<IChatMessageAckRepository>(),
 				Mock.Of<IChatChannelMemberRepository>(),
 				Mock.Of<IChatChannelService>(),
-				Mock.Of<IChatPermissionService>(),
+				permissionService.Object,
 				Mock.Of<IUserProfileService>(),
 				Mock.Of<IUnitsService>(),
 				eventAggregator.Object);
 
-			var result = await service.DeleteMessageAsync(message.ChatMessageId, deletingUserId, true, null);
+			var result = await service.DeleteMessageAsync(message.DepartmentId, message.ChatMessageId, deletingUserId, true, null);
 
 			result.Should().BeTrue();
 			message.IsModerated.Should().Be(expectedModerated);
@@ -93,9 +96,11 @@ namespace Resgrid.Tests.Services
 			var channelRepository = new Mock<IChatChannelRepository>();
 			var messageRepository = new Mock<IChatMessageRepository>();
 			var reactionRepository = new Mock<IChatMessageReactionRepository>();
+			var permissionService = new Mock<IChatPermissionService>();
 
 			messageRepository.Setup(x => x.GetByIdAsync(message.ChatMessageId)).ReturnsAsync(message);
 			channelRepository.Setup(x => x.GetByIdAsync(channel.ChatChannelId)).ReturnsAsync(channel);
+			permissionService.Setup(x => x.CanAccessChannelAsync(channel, "user-1", null)).ReturnsAsync(true);
 			reactionRepository
 				.Setup(x => x.GetByMessageIdsAsync(It.IsAny<System.Collections.Generic.IEnumerable<string>>()))
 				.ReturnsAsync(new[]
@@ -122,19 +127,104 @@ namespace Resgrid.Tests.Services
 				Mock.Of<IChatMessageAckRepository>(),
 				Mock.Of<IChatChannelMemberRepository>(),
 				Mock.Of<IChatChannelService>(),
-				Mock.Of<IChatPermissionService>(),
+				permissionService.Object,
 				Mock.Of<IUserProfileService>(),
 				Mock.Of<IUnitsService>(),
 				Mock.Of<IEventAggregator>());
 
 			// Case-insensitive user match: stored UserId is "USER-1", caller sends "user-1".
-			var result = await service.AddReactionAsync(message.ChatMessageId, "user-1", null, emoji);
+			var result = await service.AddReactionAsync(message.DepartmentId, message.ChatMessageId, "user-1", null, emoji);
 
 			result.Should().Be(expectedResult);
 			reactionRepository.Verify(
 				x => x.InsertAsync(It.IsAny<ChatMessageReaction>(), It.IsAny<CancellationToken>(), false),
 				expectInsert ? Times.Once() : Times.Never());
 		}
+
+		[Test]
+		public async Task SendMessageAsync_should_not_trust_the_department_in_the_client_request()
+		{
+			var channel = new ChatChannel { ChatChannelId = "channel-2", DepartmentId = 2 };
+			var channelRepository = new Mock<IChatChannelRepository>();
+			var permissionService = new Mock<IChatPermissionService>();
+			channelRepository.Setup(x => x.GetByIdAsync(channel.ChatChannelId)).ReturnsAsync(channel);
+
+			var service = new ChatMessageService(
+				channelRepository.Object, Mock.Of<IChatMessageRepository>(), Mock.Of<IChatMessageEditRepository>(),
+				Mock.Of<IChatAttachmentRepository>(), Mock.Of<IChatMessageReactionRepository>(), Mock.Of<IChatMessageMentionRepository>(),
+				Mock.Of<IChatMessageAckRepository>(), Mock.Of<IChatChannelMemberRepository>(), Mock.Of<IChatChannelService>(),
+				permissionService.Object, Mock.Of<IUserProfileService>(), Mock.Of<IUnitsService>(), Mock.Of<IEventAggregator>());
+
+			var result = await service.SendMessageAsync(1, "user-1", new ChatMessageSendRequest
+			{
+				ChatChannelId = channel.ChatChannelId,
+				DepartmentId = 2,
+				Body = "forged cross-tenant send",
+				MessageType = ChatMessageType.Text
+			});
+
+			result.Should().BeNull();
+			permissionService.Verify(x => x.CanPostAsync(It.IsAny<ChatChannel>(), It.IsAny<string>(), It.IsAny<int?>()), Times.Never);
+		}
+
+		[Test]
+		public async Task EditMessageAsync_should_reject_an_owned_message_outside_the_authenticated_department()
+		{
+			var message = new ChatMessage
+			{
+				ChatMessageId = "message-2",
+				ChatChannelId = "channel-2",
+				DepartmentId = 2,
+				SenderUserId = "user-1",
+				Body = "department two"
+			};
+			var messageRepository = new Mock<IChatMessageRepository>();
+			var permissionService = new Mock<IChatPermissionService>();
+			messageRepository.Setup(x => x.GetByIdAsync(message.ChatMessageId)).ReturnsAsync(message);
+
+			var service = new ChatMessageService(
+				Mock.Of<IChatChannelRepository>(), messageRepository.Object, Mock.Of<IChatMessageEditRepository>(),
+				Mock.Of<IChatAttachmentRepository>(), Mock.Of<IChatMessageReactionRepository>(), Mock.Of<IChatMessageMentionRepository>(),
+				Mock.Of<IChatMessageAckRepository>(), Mock.Of<IChatChannelMemberRepository>(), Mock.Of<IChatChannelService>(),
+				permissionService.Object, Mock.Of<IUserProfileService>(), Mock.Of<IUnitsService>(), Mock.Of<IEventAggregator>());
+
+			var result = await service.EditMessageAsync(1, message.ChatMessageId, message.SenderUserId, "forged edit");
+
+			result.Should().BeNull();
+			messageRepository.Verify(x => x.UpdateBodyAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()), Times.Never);
+			permissionService.Verify(x => x.CanAccessChannelAsync(It.IsAny<ChatChannel>(), It.IsAny<string>(), It.IsAny<int?>()), Times.Never);
+		}
+
+		[Test]
+		public async Task DeleteMessageAsync_should_revalidate_requested_moderator_authority()
+		{
+			var message = new ChatMessage
+			{
+				ChatMessageId = "message-1",
+				ChatChannelId = "channel-1",
+				DepartmentId = 1,
+				SenderUserId = "sender"
+			};
+			var channel = new ChatChannel { ChatChannelId = message.ChatChannelId, DepartmentId = 1 };
+			var channelRepository = new Mock<IChatChannelRepository>();
+			var messageRepository = new Mock<IChatMessageRepository>();
+			var permissionService = new Mock<IChatPermissionService>();
+			messageRepository.Setup(x => x.GetByIdAsync(message.ChatMessageId)).ReturnsAsync(message);
+			channelRepository.Setup(x => x.GetByIdAsync(channel.ChatChannelId)).ReturnsAsync(channel);
+			permissionService.Setup(x => x.CanModerateChannelAsync(channel, "not-a-moderator")).ReturnsAsync(false);
+
+			var service = new ChatMessageService(
+				channelRepository.Object, messageRepository.Object, Mock.Of<IChatMessageEditRepository>(),
+				Mock.Of<IChatAttachmentRepository>(), Mock.Of<IChatMessageReactionRepository>(), Mock.Of<IChatMessageMentionRepository>(),
+				Mock.Of<IChatMessageAckRepository>(), Mock.Of<IChatChannelMemberRepository>(), Mock.Of<IChatChannelService>(),
+				permissionService.Object, Mock.Of<IUserProfileService>(), Mock.Of<IUnitsService>(), Mock.Of<IEventAggregator>());
+
+			var result = await service.DeleteMessageAsync(1, message.ChatMessageId, "not-a-moderator", true, "forged role");
+
+			result.Should().BeFalse();
+			messageRepository.Verify(x => x.TombstoneAsync(It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never);
+		}
+
 		/// <summary>
 		/// Metadata url validation is a pure static helper on the service, so it is exercised directly
 		/// rather than through the full SendMessageAsync dependency graph.

--- a/Tests/Resgrid.Tests/Services/ChatModerationServiceTests.cs
+++ b/Tests/Resgrid.Tests/Services/ChatModerationServiceTests.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using Resgrid.Model;
+using Resgrid.Model.Providers;
+using Resgrid.Model.Repositories;
+using Resgrid.Model.Services;
+using Resgrid.Services;
+
+namespace Resgrid.Tests.Services
+{
+	[TestFixture]
+	public class ChatModerationServiceTests
+	{
+		private const string ChannelId = "channel-1";
+		private const string ModeratorUserId = "moderator";
+		private const string TargetUserId = "target";
+
+		private ChatChannel _channel;
+		private Mock<IChatChannelRepository> _channelRepository;
+		private Mock<IChatChannelMemberRepository> _memberRepository;
+		private Mock<IChatChannelService> _channelService;
+		private Mock<IChatPermissionService> _permissionService;
+		private ChatModerationService _service;
+
+		[SetUp]
+		public void SetUp()
+		{
+			_channel = new ChatChannel { ChatChannelId = ChannelId, DepartmentId = 1 };
+			_channelRepository = new Mock<IChatChannelRepository>();
+			_memberRepository = new Mock<IChatChannelMemberRepository>();
+			_channelService = new Mock<IChatChannelService>();
+			_permissionService = new Mock<IChatPermissionService>();
+			var actionRepository = new Mock<IChatModerationActionRepository>();
+			var auditService = new Mock<IAuditService>();
+
+			_channelRepository.Setup(x => x.GetByIdAsync(ChannelId)).ReturnsAsync(_channel);
+			_permissionService.Setup(x => x.CanModerateChannelAsync(_channel, ModeratorUserId)).ReturnsAsync(true);
+			_permissionService.Setup(x => x.InvalidateChannelCacheAsync(ChannelId)).Returns(Task.CompletedTask);
+			_memberRepository.Setup(x => x.SetMemberMutedAsync(It.IsAny<string>(), It.IsAny<DateTime?>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+			_memberRepository.Setup(x => x.SetMemberBannedAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+			actionRepository.Setup(x => x.InsertAsync(It.IsAny<ChatModerationAction>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()))
+				.ReturnsAsync((ChatModerationAction action, CancellationToken _, bool _) => action);
+			auditService.Setup(x => x.SaveAuditLogAsync(It.IsAny<AuditLog>(), It.IsAny<CancellationToken>()))
+				.ReturnsAsync((AuditLog auditLog, CancellationToken _) => auditLog);
+
+			_service = new ChatModerationService(
+				Mock.Of<IChatMessageFlagRepository>(),
+				actionRepository.Object,
+				Mock.Of<IChatExportRepository>(),
+				_channelRepository.Object,
+				_memberRepository.Object,
+				Mock.Of<IChatMessageRepository>(),
+				Mock.Of<IChatMessageService>(),
+				_channelService.Object,
+				_permissionService.Object,
+				auditService.Object,
+				Mock.Of<IEventAggregator>());
+		}
+
+		[Test]
+		public async Task Existing_banned_member_can_be_unbanned_without_current_channel_access()
+		{
+			var member = CreateMember();
+			member.IsBanned = true;
+			_memberRepository.Setup(x => x.GetUserMemberAsync(ChannelId, TargetUserId)).ReturnsAsync(member);
+			_permissionService.Setup(x => x.CanAccessChannelAsync(_channel, TargetUserId, null)).ReturnsAsync(false);
+
+			var result = await _service.SetUserBannedAsync(1, ChannelId, TargetUserId, false, ModeratorUserId, "appeal accepted");
+
+			result.Should().BeTrue();
+			_memberRepository.Verify(x => x.SetMemberBannedAsync(member.ChatChannelMemberId, false, null, It.IsAny<CancellationToken>()), Times.Once);
+			_permissionService.Verify(x => x.CanAccessChannelAsync(It.IsAny<ChatChannel>(), It.IsAny<string>(), It.IsAny<int?>()), Times.Never);
+			_channelService.Verify(x => x.EnsureMemberStateAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()), Times.Never);
+		}
+
+		[Test]
+		public async Task Existing_member_can_be_unmuted_without_current_channel_access()
+		{
+			var member = CreateMember();
+			member.MutedUntil = DateTime.UtcNow.AddHours(1);
+			_memberRepository.Setup(x => x.GetUserMemberAsync(ChannelId, TargetUserId)).ReturnsAsync(member);
+			_permissionService.Setup(x => x.CanAccessChannelAsync(_channel, TargetUserId, null)).ReturnsAsync(false);
+
+			var result = await _service.SetUserMutedAsync(1, ChannelId, TargetUserId, null, ModeratorUserId, "mute lifted");
+
+			result.Should().BeTrue();
+			_memberRepository.Verify(x => x.SetMemberMutedAsync(member.ChatChannelMemberId, null, It.IsAny<CancellationToken>()), Times.Once);
+			_permissionService.Verify(x => x.CanAccessChannelAsync(It.IsAny<ChatChannel>(), It.IsAny<string>(), It.IsAny<int?>()), Times.Never);
+			_channelService.Verify(x => x.EnsureMemberStateAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()), Times.Never);
+		}
+
+		[Test]
+		public async Task Missing_unauthorized_member_is_not_created_for_moderation()
+		{
+			_memberRepository.Setup(x => x.GetUserMemberAsync(ChannelId, TargetUserId)).ReturnsAsync((ChatChannelMember)null);
+			_permissionService.Setup(x => x.CanAccessChannelAsync(_channel, TargetUserId, null)).ReturnsAsync(false);
+
+			var result = await _service.SetUserBannedAsync(1, ChannelId, TargetUserId, true, ModeratorUserId, "policy violation");
+
+			result.Should().BeFalse();
+			_channelService.Verify(x => x.EnsureMemberStateAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()), Times.Never);
+			_memberRepository.Verify(x => x.SetMemberBannedAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+		}
+
+		[Test]
+		public async Task Missing_authorized_member_is_created_before_moderation_update()
+		{
+			var member = CreateMember();
+			var mutedUntil = DateTime.UtcNow.AddHours(1);
+			_memberRepository.Setup(x => x.GetUserMemberAsync(ChannelId, TargetUserId)).ReturnsAsync((ChatChannelMember)null);
+			_permissionService.Setup(x => x.CanAccessChannelAsync(_channel, TargetUserId, null)).ReturnsAsync(true);
+			_channelService.Setup(x => x.EnsureMemberStateAsync(ChannelId, 1, TargetUserId, null, It.IsAny<CancellationToken>())).ReturnsAsync(member);
+
+			var result = await _service.SetUserMutedAsync(1, ChannelId, TargetUserId, mutedUntil, ModeratorUserId, "cooldown");
+
+			result.Should().BeTrue();
+			_channelService.Verify(x => x.EnsureMemberStateAsync(ChannelId, 1, TargetUserId, null, It.IsAny<CancellationToken>()), Times.Once);
+			_memberRepository.Verify(x => x.SetMemberMutedAsync(member.ChatChannelMemberId, mutedUntil, It.IsAny<CancellationToken>()), Times.Once);
+		}
+
+		private static ChatChannelMember CreateMember()
+		{
+			return new ChatChannelMember
+			{
+				ChatChannelMemberId = "member-1",
+				ChatChannelId = ChannelId,
+				DepartmentId = 1,
+				UserId = TargetUserId
+			};
+		}
+	}
+}

--- a/Tests/Resgrid.Tests/Services/ChatPermissionServiceTests.cs
+++ b/Tests/Resgrid.Tests/Services/ChatPermissionServiceTests.cs
@@ -63,6 +63,17 @@ namespace Resgrid.Tests.Services
 
 				// Default: nobody is a department admin unless a test says otherwise.
 				_authorizationServiceMock.Setup(x => x.CanUserModifyDepartmentAsync(It.IsAny<string>(), It.IsAny<int>())).ReturnsAsync(false);
+				_authorizationServiceMock.Setup(x => x.IsUserValidWithinLimitsAsync(It.IsAny<string>(), 1)).ReturnsAsync(true);
+				_departmentsServiceMock.Setup(x => x.IsUserInDepartmentAsync(1, It.IsAny<string>())).ReturnsAsync(true);
+				_departmentsServiceMock
+					.Setup(x => x.GetMemberUserIdsInDepartmentAsync(1, It.IsAny<IEnumerable<string>>()))
+					.ReturnsAsync((int _, IEnumerable<string> ids) => ids == null
+						? new HashSet<string>()
+						: new HashSet<string>(ids, StringComparer.OrdinalIgnoreCase));
+				_departmentGroupsServiceMock.Setup(x => x.GetGroupByIdAsync(It.IsAny<int>(), It.IsAny<bool>()))
+					.ReturnsAsync((int groupId, bool _) => new DepartmentGroup { DepartmentGroupId = groupId, DepartmentId = 1 });
+				_callsServiceMock.Setup(x => x.GetCallByIdAsync(It.IsAny<int>(), It.IsAny<bool>()))
+					.ReturnsAsync((int callId, bool _) => new Call { CallId = callId, DepartmentId = 1 });
 
 				// Default: nobody is authorized for dispatch unless a test opts in.
 				_dispatchAccessServiceMock.Setup(x => x.CanUseDispatchAsync(It.IsAny<int>(), It.IsAny<string>())).ReturnsAsync(false);
@@ -110,6 +121,42 @@ namespace Resgrid.Tests.Services
 		[TestFixture]
 		public class when_evaluating_channel_access : with_the_chat_permission_service
 		{
+			[Test]
+			public async Task inactive_department_member_should_not_have_access()
+			{
+				var channel = CreateChannel(ChatChannelType.DepartmentDefault);
+				_authorizationServiceMock.Setup(x => x.IsUserValidWithinLimitsAsync(TestData.Users.TestUser1Id, 1)).ReturnsAsync(false);
+
+				var result = await _chatPermissionService.CanAccessChannelAsync(channel, TestData.Users.TestUser1Id, null);
+
+				result.Should().BeFalse();
+			}
+
+			[Test]
+			public async Task cached_access_should_not_outlive_active_department_membership()
+			{
+				var channel = CreateChannel(ChatChannelType.DepartmentDefault);
+				_authorizationServiceMock.Setup(x => x.IsUserValidWithinLimitsAsync(TestData.Users.TestUser1Id, 1)).ReturnsAsync(false);
+				_cacheProviderMock.Setup(x => x.GetStringAsync(It.Is<string>(key => key.Contains(":access:")))).ReturnsAsync("1");
+
+				var result = await _chatPermissionService.CanAccessChannelAsync(channel, TestData.Users.TestUser1Id, null);
+
+				result.Should().BeFalse();
+			}
+
+			[Test]
+			public async Task cached_allow_should_not_outlive_channel_membership()
+			{
+				var channel = CreateChannel(ChatChannelType.DirectMessage);
+				_cacheProviderMock.Setup(x => x.GetStringAsync(It.Is<string>(key => key.Contains(":access:")))).ReturnsAsync("1");
+				_chatChannelMemberRepositoryMock.Setup(x => x.GetUserMemberAsync(channel.ChatChannelId, TestData.Users.TestUser1Id))
+					.ReturnsAsync((ChatChannelMember)null);
+
+				var result = await _chatPermissionService.CanAccessChannelAsync(channel, TestData.Users.TestUser1Id, null);
+
+				result.Should().BeFalse();
+			}
+
 			[Test]
 			public async Task chatbot_owner_should_have_access()
 			{
@@ -175,6 +222,32 @@ namespace Resgrid.Tests.Services
 			{
 				var channel = CreateChannel(ChatChannelType.DirectMessage);
 				_chatChannelMemberRepositoryMock.Setup(x => x.GetUserMemberAsync(channel.ChatChannelId, TestData.Users.TestUser1Id)).ReturnsAsync((ChatChannelMember)null);
+
+				var result = await _chatPermissionService.CanAccessChannelAsync(channel, TestData.Users.TestUser1Id, null);
+
+				result.Should().BeFalse();
+			}
+
+			[Test]
+			public async Task dm_member_from_another_department_should_not_have_access()
+			{
+				var channel = CreateChannel(ChatChannelType.DirectMessage);
+				var member = CreateUserMember(channel, TestData.Users.TestUser1Id);
+				member.DepartmentId = 2;
+				_chatChannelMemberRepositoryMock.Setup(x => x.GetUserMemberAsync(channel.ChatChannelId, TestData.Users.TestUser1Id)).ReturnsAsync(member);
+
+				var result = await _chatPermissionService.CanAccessChannelAsync(channel, TestData.Users.TestUser1Id, null);
+
+				result.Should().BeFalse();
+			}
+
+			[Test]
+			public async Task user_outside_the_channel_department_should_not_have_access_even_with_a_member_row()
+			{
+				var channel = CreateChannel(ChatChannelType.DirectMessage);
+				_departmentsServiceMock.Setup(x => x.IsUserInDepartmentAsync(1, TestData.Users.TestUser1Id)).ReturnsAsync(false);
+				_chatChannelMemberRepositoryMock.Setup(x => x.GetUserMemberAsync(channel.ChatChannelId, TestData.Users.TestUser1Id))
+					.ReturnsAsync(CreateUserMember(channel, TestData.Users.TestUser1Id));
 
 				var result = await _chatPermissionService.CanAccessChannelAsync(channel, TestData.Users.TestUser1Id, null);
 
@@ -261,7 +334,7 @@ namespace Resgrid.Tests.Services
 				channel.GroupId = 9;
 				_departmentGroupsServiceMock.Setup(x => x.GetAllMembersForGroupAsync(9)).ReturnsAsync(new List<DepartmentGroupMember>
 				{
-					new DepartmentGroupMember { DepartmentGroupId = 9, UserId = TestData.Users.TestUser1Id }
+					new DepartmentGroupMember { DepartmentGroupId = 9, DepartmentId = 1, UserId = TestData.Users.TestUser1Id }
 				});
 
 				var result = await _chatPermissionService.CanAccessChannelAsync(channel, TestData.Users.TestUser1Id, null);
@@ -276,7 +349,7 @@ namespace Resgrid.Tests.Services
 				channel.GroupId = 9;
 				_departmentGroupsServiceMock.Setup(x => x.GetAllMembersForGroupAsync(9)).ReturnsAsync(new List<DepartmentGroupMember>
 				{
-					new DepartmentGroupMember { DepartmentGroupId = 9, UserId = TestData.Users.TestUser2Id }
+					new DepartmentGroupMember { DepartmentGroupId = 9, DepartmentId = 1, UserId = TestData.Users.TestUser2Id }
 				});
 
 				var result = await _chatPermissionService.CanAccessChannelAsync(channel, TestData.Users.TestUser1Id, null);
@@ -298,12 +371,56 @@ namespace Resgrid.Tests.Services
 			}
 
 			[Test]
+			public async Task group_default_dispatcher_should_have_access()
+			{
+				var channel = CreateChannel(ChatChannelType.GroupDefault);
+				channel.GroupId = 9;
+				_dispatchAccessServiceMock.Setup(x => x.CanUseDispatchAsync(1, TestData.Users.TestUser1Id)).ReturnsAsync(true);
+
+				var result = await _chatPermissionService.CanAccessChannelAsync(channel, TestData.Users.TestUser1Id, null);
+
+				result.Should().BeTrue();
+			}
+
+			[Test]
+			public async Task group_default_from_another_department_should_not_be_accessible()
+			{
+				var channel = CreateChannel(ChatChannelType.GroupDefault);
+				channel.GroupId = 9;
+				_departmentGroupsServiceMock.Setup(x => x.GetGroupByIdAsync(9, It.IsAny<bool>())).ReturnsAsync(new DepartmentGroup
+				{
+					DepartmentGroupId = 9,
+					DepartmentId = 2
+				});
+				_dispatchAccessServiceMock.Setup(x => x.CanUseDispatchAsync(1, TestData.Users.TestUser1Id)).ReturnsAsync(true);
+
+				var result = await _chatPermissionService.CanAccessChannelAsync(channel, TestData.Users.TestUser1Id, null);
+
+				result.Should().BeFalse();
+			}
+
+			[Test]
+			public async Task group_member_row_from_another_department_should_not_grant_access()
+			{
+				var channel = CreateChannel(ChatChannelType.GroupDefault);
+				channel.GroupId = 9;
+				_departmentGroupsServiceMock.Setup(x => x.GetAllMembersForGroupAsync(9)).ReturnsAsync(new List<DepartmentGroupMember>
+				{
+					new DepartmentGroupMember { DepartmentGroupId = 9, DepartmentId = 2, UserId = TestData.Users.TestUser1Id }
+				});
+
+				var result = await _chatPermissionService.CanAccessChannelAsync(channel, TestData.Users.TestUser1Id, null);
+
+				result.Should().BeFalse();
+			}
+
+			[Test]
 			public async Task custom_locked_matching_user_rule_should_have_access()
 			{
 				var channel = CreateChannel(ChatChannelType.CustomLocked);
 				_chatChannelAccessRuleRepositoryMock.Setup(x => x.GetByChannelIdAsync(channel.ChatChannelId)).ReturnsAsync(new List<ChatChannelAccessRule>
 				{
-					new ChatChannelAccessRule { RuleType = (int)ChatAccessRuleType.User, UserId = TestData.Users.TestUser1Id }
+					new ChatChannelAccessRule { DepartmentId = 1, RuleType = (int)ChatAccessRuleType.User, UserId = TestData.Users.TestUser1Id }
 				});
 
 				var result = await _chatPermissionService.CanAccessChannelAsync(channel, TestData.Users.TestUser1Id, null);
@@ -317,7 +434,7 @@ namespace Resgrid.Tests.Services
 				var channel = CreateChannel(ChatChannelType.CustomLocked);
 				_chatChannelAccessRuleRepositoryMock.Setup(x => x.GetByChannelIdAsync(channel.ChatChannelId)).ReturnsAsync(new List<ChatChannelAccessRule>
 				{
-					new ChatChannelAccessRule { RuleType = (int)ChatAccessRuleType.Role, PersonnelRoleId = 5 }
+					new ChatChannelAccessRule { DepartmentId = 1, RuleType = (int)ChatAccessRuleType.Role, PersonnelRoleId = 5 }
 				});
 				_personnelRolesServiceMock.Setup(x => x.GetRolesForUserAsync(TestData.Users.TestUser1Id, 1)).ReturnsAsync(new List<PersonnelRole>
 				{
@@ -335,11 +452,11 @@ namespace Resgrid.Tests.Services
 				var channel = CreateChannel(ChatChannelType.CustomLocked);
 				_chatChannelAccessRuleRepositoryMock.Setup(x => x.GetByChannelIdAsync(channel.ChatChannelId)).ReturnsAsync(new List<ChatChannelAccessRule>
 				{
-					new ChatChannelAccessRule { RuleType = (int)ChatAccessRuleType.GroupMembership, GroupId = 9 }
+					new ChatChannelAccessRule { DepartmentId = 1, RuleType = (int)ChatAccessRuleType.GroupMembership, GroupId = 9 }
 				});
 				_departmentGroupsServiceMock.Setup(x => x.GetAllMembersForGroupAsync(9)).ReturnsAsync(new List<DepartmentGroupMember>
 				{
-					new DepartmentGroupMember { DepartmentGroupId = 9, UserId = TestData.Users.TestUser1Id }
+					new DepartmentGroupMember { DepartmentGroupId = 9, DepartmentId = 1, UserId = TestData.Users.TestUser1Id }
 				});
 
 				var result = await _chatPermissionService.CanAccessChannelAsync(channel, TestData.Users.TestUser1Id, null);
@@ -354,9 +471,9 @@ namespace Resgrid.Tests.Services
 				_chatChannelMemberRepositoryMock.Setup(x => x.GetUserMemberAsync(channel.ChatChannelId, TestData.Users.TestUser1Id)).ReturnsAsync((ChatChannelMember)null);
 				_chatChannelAccessRuleRepositoryMock.Setup(x => x.GetByChannelIdAsync(channel.ChatChannelId)).ReturnsAsync(new List<ChatChannelAccessRule>
 				{
-					new ChatChannelAccessRule { RuleType = (int)ChatAccessRuleType.User, UserId = TestData.Users.TestUser2Id },
-					new ChatChannelAccessRule { RuleType = (int)ChatAccessRuleType.Role, PersonnelRoleId = 5 },
-					new ChatChannelAccessRule { RuleType = (int)ChatAccessRuleType.GroupMembership, GroupId = 9 }
+					new ChatChannelAccessRule { DepartmentId = 1, RuleType = (int)ChatAccessRuleType.User, UserId = TestData.Users.TestUser2Id },
+					new ChatChannelAccessRule { DepartmentId = 1, RuleType = (int)ChatAccessRuleType.Role, PersonnelRoleId = 5 },
+					new ChatChannelAccessRule { DepartmentId = 1, RuleType = (int)ChatAccessRuleType.GroupMembership, GroupId = 9 }
 				});
 				_personnelRolesServiceMock.Setup(x => x.GetRolesForUserAsync(TestData.Users.TestUser1Id, 1)).ReturnsAsync(new List<PersonnelRole>
 				{
@@ -364,7 +481,7 @@ namespace Resgrid.Tests.Services
 				});
 				_departmentGroupsServiceMock.Setup(x => x.GetAllMembersForGroupAsync(9)).ReturnsAsync(new List<DepartmentGroupMember>
 				{
-					new DepartmentGroupMember { DepartmentGroupId = 9, UserId = TestData.Users.TestUser2Id }
+					new DepartmentGroupMember { DepartmentGroupId = 9, DepartmentId = 1, UserId = TestData.Users.TestUser2Id }
 				});
 
 				var result = await _chatPermissionService.CanAccessChannelAsync(channel, TestData.Users.TestUser1Id, null);
@@ -376,6 +493,61 @@ namespace Resgrid.Tests.Services
 		[TestFixture]
 		public class when_evaluating_incident_channel_access : with_the_chat_permission_service
 		{
+			[Test]
+			public async Task department_dispatch_standing_alone_should_not_count_as_incident_assignment()
+			{
+				_dispatchAccessServiceMock.Setup(x => x.CanUseDispatchAsync(1, TestData.Users.TestUser1Id)).ReturnsAsync(true);
+				_incidentCommandServiceMock.Setup(x => x.GetAssignmentsForCallAsync(1, 42)).ReturnsAsync(new List<ResourceAssignment>());
+
+				var result = await _chatPermissionService.CanAccessIncidentAsync(1, 42, TestData.Users.TestUser1Id, null);
+
+				result.Should().BeFalse();
+			}
+
+			[Test]
+			public async Task cached_access_should_not_outlive_incident_assignment()
+			{
+				var channel = CreateChannel(ChatChannelType.Incident);
+				channel.CallId = 42;
+				_cacheProviderMock.Setup(x => x.GetStringAsync(It.Is<string>(key => key.Contains(":access:")))).ReturnsAsync("1");
+				_incidentCommandServiceMock.Setup(x => x.GetAssignmentsForCallAsync(1, 42)).ReturnsAsync(new List<ResourceAssignment>());
+
+				var result = await _chatPermissionService.CanAccessChannelAsync(channel, TestData.Users.TestUser1Id, null);
+
+				result.Should().BeFalse();
+				_cacheProviderMock.Verify(x => x.GetStringAsync(It.Is<string>(key => key.Contains(":access:"))), Times.Never);
+			}
+
+			[Test]
+			public async Task incident_from_another_department_should_be_denied_before_dispatch_override()
+			{
+				var channel = CreateChannel(ChatChannelType.Incident);
+				channel.CallId = 42;
+				_callsServiceMock.Setup(x => x.GetCallByIdAsync(42, It.IsAny<bool>())).ReturnsAsync(new Call
+				{
+					CallId = 42,
+					DepartmentId = 2
+				});
+				_dispatchAccessServiceMock.Setup(x => x.CanUseDispatchAsync(1, TestData.Users.TestUser1Id)).ReturnsAsync(true);
+
+				var result = await _chatPermissionService.CanAccessChannelAsync(channel, TestData.Users.TestUser1Id, null);
+
+				result.Should().BeFalse();
+			}
+
+			[Test]
+			public async Task department_admin_not_assigned_to_the_incident_should_be_denied()
+			{
+				var channel = CreateChannel(ChatChannelType.Incident);
+				channel.CallId = 42;
+				_authorizationServiceMock.Setup(x => x.CanUserModifyDepartmentAsync(TestData.Users.TestUser1Id, 1)).ReturnsAsync(true);
+				_incidentCommandServiceMock.Setup(x => x.GetAssignmentsForCallAsync(1, 42)).ReturnsAsync(new List<ResourceAssignment>());
+
+				var result = await _chatPermissionService.CanAccessChannelAsync(channel, TestData.Users.TestUser1Id, null);
+
+				result.Should().BeFalse();
+			}
+
 			[Test]
 			public async Task dispatched_user_should_have_access_to_incident_channel()
 			{
@@ -476,6 +648,34 @@ namespace Resgrid.Tests.Services
 			}
 
 			[Test]
+			public async Task foreign_department_group_dispatch_should_not_grant_access_to_incident_channel()
+			{
+				var channel = CreateChannel(ChatChannelType.Incident);
+				channel.CallId = 42;
+				_callsServiceMock.Setup(x => x.GetCallByIdAsync(42, It.IsAny<bool>())).ReturnsAsync(new Call
+				{
+					CallId = 42,
+					DepartmentId = 1,
+					GroupDispatches = new List<CallDispatchGroup>
+					{
+						new CallDispatchGroup { CallId = 42, DepartmentGroupId = 77 }
+					}
+				});
+				_departmentGroupsServiceMock.Setup(x => x.GetGroupByIdAsync(77, It.IsAny<bool>()))
+					.ReturnsAsync(new DepartmentGroup { DepartmentGroupId = 77, DepartmentId = 2 });
+				_departmentGroupsServiceMock.Setup(x => x.GetAllMembersForGroupAsync(77)).ReturnsAsync(new List<DepartmentGroupMember>
+				{
+					new DepartmentGroupMember { DepartmentGroupId = 77, DepartmentId = 2, UserId = TestData.Users.TestUser1Id }
+				});
+				_incidentCommandServiceMock.Setup(x => x.GetAssignmentsForCallAsync(1, 42)).ReturnsAsync(new List<ResourceAssignment>());
+
+				var result = await _chatPermissionService.CanAccessChannelAsync(channel, TestData.Users.TestUser1Id, null);
+
+				result.Should().BeFalse();
+				_departmentGroupsServiceMock.Verify(x => x.GetAllMembersForGroupAsync(77), Times.Never);
+			}
+
+			[Test]
 			public async Task lane_assigned_personnel_should_have_access_to_lane_channel()
 			{
 				var channel = CreateChannel(ChatChannelType.IncidentLane);
@@ -489,6 +689,8 @@ namespace Resgrid.Tests.Services
 				{
 					new ResourceAssignment
 					{
+						DepartmentId = 1,
+						CallId = 42,
 						CommandStructureNodeId = "node-1",
 						ResourceKind = (int)ResourceAssignmentKind.RealPersonnel,
 						ResourceId = TestData.Users.TestUser1Id
@@ -498,6 +700,63 @@ namespace Resgrid.Tests.Services
 				var result = await _chatPermissionService.CanAccessChannelAsync(channel, TestData.Users.TestUser1Id, null);
 
 				result.Should().BeTrue();
+			}
+
+			[Test]
+			public async Task banned_dispatched_user_should_not_have_access_to_incident_channel()
+			{
+				var channel = CreateChannel(ChatChannelType.Incident);
+				channel.CallId = 42;
+				_callsServiceMock.Setup(x => x.GetCallByIdAsync(42, It.IsAny<bool>())).ReturnsAsync(new Call
+				{
+					CallId = 42,
+					DepartmentId = 1,
+					Dispatches = new List<CallDispatch> { new CallDispatch { CallId = 42, UserId = TestData.Users.TestUser1Id } }
+				});
+				_chatChannelMemberRepositoryMock.Setup(x => x.GetUserMemberAsync(channel.ChatChannelId, TestData.Users.TestUser1Id))
+					.ReturnsAsync(new ChatChannelMember
+					{
+						ChatChannelId = channel.ChatChannelId,
+						DepartmentId = 1,
+						UserId = TestData.Users.TestUser1Id,
+						IsBanned = true
+					});
+
+				var result = await _chatPermissionService.CanAccessChannelAsync(channel, TestData.Users.TestUser1Id, null);
+
+				result.Should().BeFalse();
+			}
+
+			[Test]
+			public async Task lane_assigned_unit_should_not_grant_access_to_a_user_who_does_not_crew_it()
+			{
+				var channel = CreateChannel(ChatChannelType.IncidentLane);
+				channel.CallId = 42;
+				channel.CommandStructureNodeId = "node-1";
+				_incidentCommandServiceMock.Setup(x => x.GetNodesForCallAsync(1, 42)).ReturnsAsync(new List<CommandStructureNode>
+				{
+					new CommandStructureNode { CommandStructureNodeId = "node-1", DepartmentId = 1, CallId = 42 }
+				});
+				_incidentCommandServiceMock.Setup(x => x.GetAssignmentsForCallAsync(1, 42)).ReturnsAsync(new List<ResourceAssignment>
+				{
+					new ResourceAssignment
+					{
+						DepartmentId = 1,
+						CallId = 42,
+						CommandStructureNodeId = "node-1",
+						ResourceKind = (int)ResourceAssignmentKind.RealUnit,
+						ResourceId = "7"
+					}
+				});
+				_unitsServiceMock.Setup(x => x.GetUnitByIdAsync(7)).ReturnsAsync(new Unit { UnitId = 7, DepartmentId = 1 });
+				_unitsServiceMock.Setup(x => x.GetActiveRolesForUnitAsync(7)).ReturnsAsync(new List<UnitActiveRole>
+				{
+					new UnitActiveRole { UnitId = 7, UserId = TestData.Users.TestUser2Id }
+				});
+
+				var result = await _chatPermissionService.CanAccessChannelAsync(channel, TestData.Users.TestUser1Id, 7);
+
+				result.Should().BeFalse();
 			}
 
 			[Test]
@@ -538,6 +797,8 @@ namespace Resgrid.Tests.Services
 				{
 					new ResourceAssignment
 					{
+						DepartmentId = 1,
+						CallId = 42,
 						CommandStructureNodeId = "node-1",
 						ResourceKind = (int)ResourceAssignmentKind.RealPersonnel,
 						ResourceId = TestData.Users.TestUser2Id
@@ -555,6 +816,10 @@ namespace Resgrid.Tests.Services
 				var channel = CreateChannel(ChatChannelType.IncidentLane);
 				channel.CallId = 42;
 				channel.CommandStructureNodeId = "node-1";
+				_incidentCommandServiceMock.Setup(x => x.GetNodesForCallAsync(1, 42)).ReturnsAsync(new List<CommandStructureNode>
+				{
+					new CommandStructureNode { CommandStructureNodeId = "node-1", DepartmentId = 1, CallId = 42 }
+				});
 				_incidentCommandServiceMock.Setup(x => x.GetIncidentRolesAsync(1, 42)).ReturnsAsync(new List<IncidentRoleAssignment>
 				{
 					new IncidentRoleAssignment { CallId = 42, UserId = TestData.Users.TestUser1Id }
@@ -606,10 +871,8 @@ namespace Resgrid.Tests.Services
 			}
 
 			[Test]
-			public async Task an_authorized_dispatcher_should_not_have_access_to_command_channel()
+			public async Task an_authorized_dispatcher_should_have_access_to_command_channel()
 			{
-				// The command channel stays internal to the people running the incident so they can talk
-				// candidly. Dispatch reaches command through the incident's dispatch channel instead.
 				var channel = CreateChannel(ChatChannelType.IncidentCommand);
 				channel.CallId = 42;
 				_incidentCommandServiceMock.Setup(x => x.GetCommandForCallAsync(1, 42)).ReturnsAsync((IncidentCommand)null);
@@ -618,7 +881,7 @@ namespace Resgrid.Tests.Services
 
 				var result = await _chatPermissionService.CanAccessChannelAsync(channel, TestData.Users.TestUser1Id, null);
 
-				result.Should().BeFalse();
+				result.Should().BeTrue();
 			}
 
 			[Test]
@@ -767,7 +1030,7 @@ namespace Resgrid.Tests.Services
 				channel.GroupId = 9;
 				_departmentGroupsServiceMock.Setup(x => x.GetAllMembersForGroupAsync(9)).ReturnsAsync(new List<DepartmentGroupMember>
 				{
-					new DepartmentGroupMember { DepartmentGroupId = 9, UserId = TestData.Users.TestUser1Id, IsAdmin = true }
+					new DepartmentGroupMember { DepartmentGroupId = 9, DepartmentId = 1, UserId = TestData.Users.TestUser1Id, IsAdmin = true }
 				});
 
 				var result = await _chatPermissionService.CanModerateChannelAsync(channel, TestData.Users.TestUser1Id);
@@ -782,7 +1045,7 @@ namespace Resgrid.Tests.Services
 				channel.GroupId = 9;
 				_departmentGroupsServiceMock.Setup(x => x.GetAllMembersForGroupAsync(9)).ReturnsAsync(new List<DepartmentGroupMember>
 				{
-					new DepartmentGroupMember { DepartmentGroupId = 9, UserId = TestData.Users.TestUser1Id, IsAdmin = false }
+					new DepartmentGroupMember { DepartmentGroupId = 9, DepartmentId = 1, UserId = TestData.Users.TestUser1Id, IsAdmin = false }
 				});
 
 				var result = await _chatPermissionService.CanModerateChannelAsync(channel, TestData.Users.TestUser1Id);
@@ -951,6 +1214,7 @@ namespace Resgrid.Tests.Services
 					JoinedOn = DateTime.UtcNow
 				};
 				_chatChannelMemberRepositoryMock.Setup(x => x.GetByChannelIdAsync(channel.ChatChannelId)).ReturnsAsync(new List<ChatChannelMember> { userMember, unitMember });
+				_unitsServiceMock.Setup(x => x.GetUnitByIdAsync(7)).ReturnsAsync(new Unit { UnitId = 7, DepartmentId = 1, Name = "Engine 6" });
 				_unitsServiceMock.Setup(x => x.GetActiveRolesForUnitAsync(7)).ReturnsAsync(new List<UnitActiveRole>
 				{
 					new UnitActiveRole { UnitId = 7, UserId = TestData.Users.TestUser2Id },
@@ -960,6 +1224,20 @@ namespace Resgrid.Tests.Services
 				var audience = await _chatPermissionService.ResolveChannelAudienceUserIdsAsync(channel);
 
 				audience.Should().BeEquivalentTo(new[] { TestData.Users.TestUser1Id, TestData.Users.TestUser2Id, TestData.Users.TestUser3Id });
+			}
+
+			[Test]
+			public async Task member_rows_from_another_department_should_not_enter_the_audience()
+			{
+				var channel = CreateChannel(ChatChannelType.AdHocGroup);
+				var member = CreateUserMember(channel, TestData.Users.TestUser1Id);
+				member.DepartmentId = 2;
+				_chatChannelMemberRepositoryMock.Setup(x => x.GetByChannelIdAsync(channel.ChatChannelId))
+					.ReturnsAsync(new List<ChatChannelMember> { member });
+
+				var audience = await _chatPermissionService.ResolveChannelAudienceUserIdsAsync(channel);
+
+				audience.Should().BeEmpty();
 			}
 
 			[Test]
@@ -1233,6 +1511,7 @@ namespace Resgrid.Tests.Services
 		{
 			private ChatChannel BuildUnitDispatchChannel()
 			{
+				_unitsServiceMock.Setup(x => x.GetUnitByIdAsync(7)).ReturnsAsync(new Unit { UnitId = 7, DepartmentId = 1, Name = "Engine 6" });
 				var channel = CreateChannel(ChatChannelType.UnitDispatch);
 				channel.Name = "Engine 6 Dispatch";
 				channel.DmKey = "unitdispatch:7";

--- a/Tests/Resgrid.Tests/Services/ChatPermissionServiceTests.cs
+++ b/Tests/Resgrid.Tests/Services/ChatPermissionServiceTests.cs
@@ -70,6 +70,15 @@ namespace Resgrid.Tests.Services
 					.ReturnsAsync((int _, IEnumerable<string> ids) => ids == null
 						? new HashSet<string>()
 						: new HashSet<string>(ids, StringComparer.OrdinalIgnoreCase));
+				_departmentsServiceMock
+					.Setup(x => x.GetAllMembersForDepartmentUnlimitedAsync(1, It.IsAny<bool>()))
+					.ReturnsAsync(new List<DepartmentMember>
+					{
+						new DepartmentMember { DepartmentId = 1, UserId = TestData.Users.TestUser1Id },
+						new DepartmentMember { DepartmentId = 1, UserId = TestData.Users.TestUser2Id },
+						new DepartmentMember { DepartmentId = 1, UserId = TestData.Users.TestUser3Id },
+						new DepartmentMember { DepartmentId = 1, UserId = TestData.Users.TestUser4Id }
+					});
 				_departmentGroupsServiceMock.Setup(x => x.GetGroupByIdAsync(It.IsAny<int>(), It.IsAny<bool>()))
 					.ReturnsAsync((int groupId, bool _) => new DepartmentGroup { DepartmentGroupId = groupId, DepartmentId = 1 });
 				_callsServiceMock.Setup(x => x.GetCallByIdAsync(It.IsAny<int>(), It.IsAny<bool>()))
@@ -115,6 +124,18 @@ namespace Resgrid.Tests.Services
 					UserId = userId,
 					JoinedOn = DateTime.UtcNow
 				};
+			}
+		}
+
+		[TestFixture]
+		public class when_resolving_the_channel_access_version : with_the_chat_permission_service
+		{
+			[Test]
+			public async Task a_missing_cache_epoch_should_remain_null()
+			{
+				var version = await _chatPermissionService.GetChannelAccessVersionAsync("channel-1");
+
+				version.Should().BeNull();
 			}
 		}
 
@@ -1255,6 +1276,35 @@ namespace Resgrid.Tests.Services
 				var audience = await _chatPermissionService.ResolveChannelAudienceUserIdsAsync(channel);
 
 				audience.Should().BeEquivalentTo(new[] { TestData.Users.TestUser1Id, TestData.Users.TestUser4Id });
+			}
+
+			[Test]
+			public async Task audience_should_bulk_filter_disabled_and_deleted_members_case_insensitively()
+			{
+				var channel = CreateChannel(ChatChannelType.AdHocGroup);
+				var upperCaseUserId = TestData.Users.TestUser4Id.ToUpperInvariant();
+				_chatChannelMemberRepositoryMock.Setup(x => x.GetByChannelIdAsync(channel.ChatChannelId))
+					.ReturnsAsync(new List<ChatChannelMember>
+					{
+						CreateUserMember(channel, TestData.Users.TestUser1Id),
+						CreateUserMember(channel, TestData.Users.TestUser2Id),
+						CreateUserMember(channel, TestData.Users.TestUser3Id),
+						CreateUserMember(channel, upperCaseUserId)
+					});
+				_departmentsServiceMock.Setup(x => x.GetAllMembersForDepartmentUnlimitedAsync(1, It.IsAny<bool>()))
+					.ReturnsAsync(new List<DepartmentMember>
+					{
+						new DepartmentMember { DepartmentId = 1, UserId = TestData.Users.TestUser1Id },
+						new DepartmentMember { DepartmentId = 1, UserId = TestData.Users.TestUser2Id, IsDisabled = true },
+						new DepartmentMember { DepartmentId = 1, UserId = TestData.Users.TestUser3Id, IsDeleted = true },
+						new DepartmentMember { DepartmentId = 1, UserId = TestData.Users.TestUser4Id }
+					});
+
+				var audience = await _chatPermissionService.ResolveChannelAudienceUserIdsAsync(channel);
+
+				audience.Should().BeEquivalentTo(new[] { TestData.Users.TestUser1Id, upperCaseUserId });
+				_departmentsServiceMock.Verify(x => x.GetAllMembersForDepartmentUnlimitedAsync(1, It.IsAny<bool>()), Times.Once);
+				_authorizationServiceMock.Verify(x => x.IsUserValidWithinLimitsAsync(It.IsAny<string>(), It.IsAny<int>()), Times.Never);
 			}
 
 			[Test]

--- a/Tests/Resgrid.Tests/Services/ChatProvisioningEventServiceTests.cs
+++ b/Tests/Resgrid.Tests/Services/ChatProvisioningEventServiceTests.cs
@@ -1,0 +1,26 @@
+using System;
+using Autofac;
+using Moq;
+using NUnit.Framework;
+using Resgrid.Model.Events;
+using Resgrid.Model.Providers;
+using Resgrid.Services;
+
+namespace Resgrid.Tests.Services
+{
+	[TestFixture]
+	public class ChatProvisioningEventServiceTests
+	{
+		[Test]
+		public void constructor_should_leave_incident_authorization_updates_to_the_eventing_worker()
+		{
+			var eventAggregator = new Mock<IEventAggregator>();
+			var lifetimeScope = new Mock<ILifetimeScope>();
+
+			_ = new ChatProvisioningEventService(eventAggregator.Object, lifetimeScope.Object);
+
+			eventAggregator.Verify(x => x.AddListener(
+				It.IsAny<Action<IncidentCommandUpdatedEvent>>()), Times.Never);
+		}
+	}
+}

--- a/Tests/Resgrid.Tests/Services/DispatchAccessServiceTests.cs
+++ b/Tests/Resgrid.Tests/Services/DispatchAccessServiceTests.cs
@@ -84,6 +84,19 @@ namespace Resgrid.Tests.Services
 		}
 
 		[Test]
+		public async Task cached_allow_should_not_outlive_dispatch_permission()
+		{
+			var permission = new Permission { DepartmentId = DepartmentId, Action = (int)PermissionActions.DepartmentAdminsOnly };
+			GivenPermission(permission);
+			_cacheProvider.Setup(x => x.GetStringAsync(It.IsAny<string>())).ReturnsAsync("1");
+			_permissionsService.Setup(x => x.IsUserAllowed(permission, false, false, It.IsAny<List<PersonnelRole>>())).Returns(false);
+
+			var result = await BuildService().CanUseDispatchAsync(DepartmentId, UserId);
+
+			result.Should().BeFalse();
+		}
+
+		[Test]
 		public async Task the_departments_managing_user_counts_as_an_admin()
 		{
 			var permission = new Permission { DepartmentId = DepartmentId, Action = (int)PermissionActions.DepartmentAdminsOnly };

--- a/Tests/Resgrid.Tests/Services/PushServiceModernApplicationSoundTests.cs
+++ b/Tests/Resgrid.Tests/Services/PushServiceModernApplicationSoundTests.cs
@@ -63,7 +63,8 @@ namespace Resgrid.Tests.Services
 				new Mock<IUserProfileService>().Object,
 				new Mock<IUnitNotificationProvider>().Object,
 				_novuProvider.Object,
-				_departmentSettingsService.Object);
+				_departmentSettingsService.Object,
+				new Mock<IUnitsService>().Object);
 		}
 
 		[TearDown]

--- a/Tests/Resgrid.Tests/Services/PushServiceNotificationEventCodeTests.cs
+++ b/Tests/Resgrid.Tests/Services/PushServiceNotificationEventCodeTests.cs
@@ -1,4 +1,4 @@
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
@@ -60,7 +60,8 @@ namespace Resgrid.Tests.Services
 				new Mock<IUserProfileService>().Object,
 				new Mock<IUnitNotificationProvider>().Object,
 				_novuProvider.Object,
-				_departmentSettingsService.Object);
+				_departmentSettingsService.Object,
+				new Mock<IUnitsService>().Object);
 		}
 
 		[TearDown]

--- a/Tests/Resgrid.Tests/Services/PushServiceUnitRegistrationTests.cs
+++ b/Tests/Resgrid.Tests/Services/PushServiceUnitRegistrationTests.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using Resgrid.Model;
+using Resgrid.Model.Providers;
+using Resgrid.Model.Services;
+using Resgrid.Services;
+
+namespace Resgrid.Tests.Services
+{
+	[TestFixture]
+	public class PushServiceUnitRegistrationTests
+	{
+		private const int UnitId = 9;
+		private const int DepartmentId = 7;
+		private const string Code = "DEPT";
+		private const string DeviceId = "device-token";
+
+		private Mock<INovuProvider> _novuProvider;
+		private Mock<IUnitsService> _unitsService;
+		private PushService _pushService;
+
+		[SetUp]
+		public void SetUp()
+		{
+			_novuProvider = new Mock<INovuProvider>();
+			_unitsService = new Mock<IUnitsService>();
+			_pushService = new PushService(
+				Mock.Of<IPushLogsService>(),
+				Mock.Of<INotificationProvider>(),
+				Mock.Of<IUserProfileService>(),
+				Mock.Of<IUnitNotificationProvider>(),
+				_novuProvider.Object,
+				Mock.Of<IDepartmentSettingsService>(),
+				_unitsService.Object);
+		}
+
+		[Test]
+		public async Task RegisterUnit_should_stop_before_credentials_when_unit_is_missing()
+		{
+			_unitsService.Setup(x => x.GetUnitByIdAsync(UnitId)).ReturnsAsync((Unit)null);
+
+			var result = await _pushService.RegisterUnit(CreatePushUri());
+
+			result.Should().BeFalse();
+			VerifyNoCredentialWrite();
+		}
+
+		[Test]
+		public async Task RegisterUnit_should_stop_before_credentials_when_subscriber_creation_is_rejected()
+		{
+			SetupUnit();
+			_novuProvider.Setup(x => x.CreateUnitSubscriber(UnitId, Code, DepartmentId, "Engine 9", DeviceId))
+				.ReturnsAsync(false);
+
+			var result = await _pushService.RegisterUnit(CreatePushUri());
+
+			result.Should().BeFalse();
+			VerifyNoCredentialWrite();
+		}
+
+		[Test]
+		public async Task RegisterUnit_should_stop_before_credentials_when_subscriber_creation_throws()
+		{
+			SetupUnit();
+			_novuProvider.Setup(x => x.CreateUnitSubscriber(UnitId, Code, DepartmentId, "Engine 9", DeviceId))
+				.ThrowsAsync(new InvalidOperationException("Novu unavailable"));
+
+			var result = await _pushService.RegisterUnit(CreatePushUri());
+
+			result.Should().BeFalse();
+			VerifyNoCredentialWrite();
+		}
+
+		[Test]
+		public async Task RegisterUnit_should_write_credentials_after_subscriber_creation_succeeds()
+		{
+			SetupUnit();
+			_novuProvider.Setup(x => x.CreateUnitSubscriber(UnitId, Code, DepartmentId, "Engine 9", DeviceId))
+				.ReturnsAsync(true);
+			_novuProvider.Setup(x => x.UpdateUnitSubscriberFcm(UnitId, Code, DeviceId)).ReturnsAsync(true);
+
+			var result = await _pushService.RegisterUnit(CreatePushUri());
+
+			result.Should().BeTrue();
+			_novuProvider.Verify(x => x.UpdateUnitSubscriberFcm(UnitId, Code, DeviceId), Times.Once);
+		}
+
+		private void SetupUnit()
+		{
+			_unitsService.Setup(x => x.GetUnitByIdAsync(UnitId)).ReturnsAsync(new Unit
+			{
+				UnitId = UnitId,
+				DepartmentId = DepartmentId,
+				Name = "Engine 9"
+			});
+		}
+
+		private static PushUri CreatePushUri()
+		{
+			return new PushUri
+			{
+				UnitId = UnitId,
+				PlatformType = (int)Platforms.Android,
+				PushLocation = Code,
+				DeviceId = DeviceId
+			};
+		}
+
+		private void VerifyNoCredentialWrite()
+		{
+			_novuProvider.Verify(x => x.UpdateUnitSubscriberApns(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+			_novuProvider.Verify(x => x.UpdateUnitSubscriberFcm(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+		}
+	}
+}

--- a/Tests/Resgrid.Tests/Web/Services/ChatAuthorizationTests.cs
+++ b/Tests/Resgrid.Tests/Web/Services/ChatAuthorizationTests.cs
@@ -1,0 +1,123 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using Resgrid.Providers.Claims;
+using Resgrid.Web.Services.Controllers.v4;
+
+namespace Resgrid.Tests.Web.Services
+{
+	[TestFixture]
+	public class ChatAuthorizationTests
+	{
+		[TestCase(true, "user-1", "1", true, true)]
+		[TestCase(false, "user-1", "1", true, false)]
+		[TestCase(true, null, "1", true, false)]
+		[TestCase(true, "", "1", true, false)]
+		[TestCase(true, "user-1", null, true, false)]
+		[TestCase(true, "user-1", "0", true, false)]
+		[TestCase(true, "user-1", "not-a-department", true, false)]
+		[TestCase(true, "user-1", "1", false, false)]
+		public async Task chat_policy_requires_authenticated_principal_and_all_required_claims(
+			bool isAuthenticated, string userId, string departmentId, bool hasMessagesView, bool expected)
+		{
+			var claims = new List<Claim>();
+			if (userId != null)
+				claims.Add(new Claim(ClaimTypes.PrimarySid, userId));
+			if (departmentId != null)
+				claims.Add(new Claim(ClaimTypes.PrimaryGroupSid, departmentId));
+			if (hasMessagesView)
+				claims.Add(new Claim(ResgridClaimTypes.Resources.Messages, ResgridClaimTypes.Actions.View));
+
+			var principal = new ClaimsPrincipal(new ClaimsIdentity(claims, isAuthenticated ? "Test" : null));
+			var policy = new AuthorizationPolicyBuilder().RequireChatAccessClaims().Build();
+			var services = new ServiceCollection().AddLogging().AddAuthorization().BuildServiceProvider();
+			var authorizationService = services.GetRequiredService<IAuthorizationService>();
+
+			var result = await authorizationService.AuthorizeAsync(principal, null, policy);
+
+			result.Succeeded.Should().Be(expected);
+		}
+
+		[Test]
+		public void chat_controller_requires_messages_view_claim()
+		{
+			var authorize = typeof(ChatController).GetCustomAttributes<AuthorizeAttribute>()
+				.Single(x => x.Policy == ResgridResources.Messages_View);
+
+			authorize.Policy.Should().Be(ResgridResources.Messages_View);
+		}
+
+		[Test]
+		public void chat_moderation_controller_requires_messages_view_claim()
+		{
+			var authorize = typeof(ChatModerationController).GetCustomAttributes<AuthorizeAttribute>()
+				.Single(x => x.Policy == ResgridResources.Messages_View);
+
+			authorize.Policy.Should().Be(ResgridResources.Messages_View);
+		}
+
+		[TestCase(nameof(ChatbotController.GetChatChannel), ResgridResources.Messages_View)]
+		[TestCase(nameof(ChatbotController.SendChatMessage), ResgridResources.Messages_View)]
+		[TestCase(nameof(ChatbotController.SendChatMessage), ResgridResources.Messages_Create)]
+		[TestCase(nameof(ChatbotController.NewChatSession), ResgridResources.Messages_View)]
+		[TestCase(nameof(ChatbotController.NewChatSession), ResgridResources.Messages_Create)]
+		[TestCase(nameof(ChatbotController.AskIncident), ResgridResources.Messages_View)]
+		[TestCase(nameof(ChatbotController.AskIncident), ResgridResources.Messages_Create)]
+		[TestCase(nameof(ChatbotController.IncidentSuggestions), ResgridResources.Messages_View)]
+		public void chatbot_chat_actions_require_message_claims(string methodName, string policy)
+		{
+			var method = typeof(ChatbotController).GetMethod(methodName, BindingFlags.Instance | BindingFlags.Public);
+
+			method.Should().NotBeNull();
+			method.GetCustomAttributes<AuthorizeAttribute>().Should().ContainSingle(x => x.Policy == policy);
+		}
+
+		[TestCase(nameof(ChatController.CreateDirectMessage), ResgridResources.Messages_Create)]
+		[TestCase(nameof(ChatController.CreateIncidentCommanderLine), ResgridResources.Messages_Create)]
+		[TestCase(nameof(ChatController.CreateAdHocChannel), ResgridResources.Messages_Create)]
+		[TestCase(nameof(ChatController.CreateCustomChannel), ResgridResources.Messages_Create)]
+		[TestCase(nameof(ChatController.SendMessage), ResgridResources.Messages_Create)]
+		[TestCase(nameof(ChatController.AddReaction), ResgridResources.Messages_Create)]
+		[TestCase(nameof(ChatController.UploadAttachment), ResgridResources.Messages_Create)]
+		[TestCase(nameof(ChatController.FlagMessage), ResgridResources.Messages_Create)]
+		[TestCase(nameof(ChatController.UpdateChannel), ResgridResources.Messages_Update)]
+		[TestCase(nameof(ChatController.AddMembers), ResgridResources.Messages_Update)]
+		[TestCase(nameof(ChatController.RemoveMember), ResgridResources.Messages_Update)]
+		[TestCase(nameof(ChatController.SetNotificationPreference), ResgridResources.Messages_Update)]
+		[TestCase(nameof(ChatController.EditMessage), ResgridResources.Messages_Update)]
+		[TestCase(nameof(ChatController.RemoveReaction), ResgridResources.Messages_Update)]
+		[TestCase(nameof(ChatController.Ack), ResgridResources.Messages_Update)]
+		[TestCase(nameof(ChatController.MarkRead), ResgridResources.Messages_Update)]
+		[TestCase(nameof(ChatController.PinMessage), ResgridResources.Messages_Update)]
+		[TestCase(nameof(ChatController.UnpinMessage), ResgridResources.Messages_Update)]
+		[TestCase(nameof(ChatController.ArchiveChannel), ResgridResources.Messages_Delete)]
+		[TestCase(nameof(ChatController.DeleteMessage), ResgridResources.Messages_Delete)]
+		public void mutating_chat_actions_require_the_corresponding_message_claim(string methodName, string policy)
+		{
+			var method = typeof(ChatController).GetMethod(methodName, BindingFlags.Instance | BindingFlags.Public);
+
+			method.Should().NotBeNull();
+			method.GetCustomAttributes<AuthorizeAttribute>().Should().ContainSingle(x => x.Policy == policy);
+		}
+
+		[TestCase(nameof(ChatModerationController.ResolveFlag), ResgridResources.Messages_Update)]
+		[TestCase(nameof(ChatModerationController.MuteUser), ResgridResources.Messages_Update)]
+		[TestCase(nameof(ChatModerationController.BanUser), ResgridResources.Messages_Update)]
+		[TestCase(nameof(ChatModerationController.LockChannel), ResgridResources.Messages_Update)]
+		[TestCase(nameof(ChatModerationController.UpdateSettings), ResgridResources.Messages_Update)]
+		[TestCase(nameof(ChatModerationController.DeleteMessage), ResgridResources.Messages_Delete)]
+		public void mutating_chat_moderation_actions_require_the_corresponding_message_claim(string methodName, string policy)
+		{
+			var method = typeof(ChatModerationController).GetMethod(methodName, BindingFlags.Instance | BindingFlags.Public);
+
+			method.Should().NotBeNull();
+			method.GetCustomAttributes<AuthorizeAttribute>().Should().ContainSingle(x => x.Policy == policy);
+		}
+	}
+}

--- a/Tests/Resgrid.Tests/Web/Services/ChatAuthorizationTests.cs
+++ b/Tests/Resgrid.Tests/Web/Services/ChatAuthorizationTests.cs
@@ -45,31 +45,64 @@ namespace Resgrid.Tests.Web.Services
 		}
 
 		[Test]
-		public void chat_controller_requires_messages_view_claim()
+		public async Task messages_view_policy_allows_client_credentials_department_zero()
 		{
-			var authorize = typeof(ChatController).GetCustomAttributes<AuthorizeAttribute>()
-				.Single(x => x.Policy == ResgridResources.Messages_View);
+			var principal = new ClaimsPrincipal(new ClaimsIdentity(new[]
+				{
+					new Claim(ClaimTypes.PrimaryGroupSid, "0"),
+					new Claim(ResgridClaimTypes.Resources.Messages, ResgridClaimTypes.Actions.View)
+				}, "Test"));
+			var policy = new AuthorizationPolicyBuilder()
+				.RequireClaim(ResgridClaimTypes.Resources.Messages, ResgridClaimTypes.Actions.View)
+				.Build();
+			var services = new ServiceCollection().AddLogging().AddAuthorization().BuildServiceProvider();
+			var authorizationService = services.GetRequiredService<IAuthorizationService>();
 
-			authorize.Policy.Should().Be(ResgridResources.Messages_View);
+			var result = await authorizationService.AuthorizeAsync(principal, null, policy);
+
+			result.Succeeded.Should().BeTrue();
+		}
+
+		[TestCase(nameof(MessagesController.GetInboxMessages))]
+		[TestCase(nameof(MessagesController.GetOutboxMessages))]
+		[TestCase(nameof(MessagesController.GetMessage))]
+		[TestCase(nameof(MessagesController.GetRecipients))]
+		[TestCase(nameof(MessagesController.RespondToMessage))]
+		public void messaging_actions_preserve_messages_view_policy(string methodName)
+		{
+			var method = typeof(MessagesController).GetMethod(methodName, BindingFlags.Instance | BindingFlags.Public);
+
+			method.Should().NotBeNull();
+			method.GetCustomAttributes<AuthorizeAttribute>().Should()
+				.ContainSingle(x => x.Policy == ResgridResources.Messages_View);
 		}
 
 		[Test]
-		public void chat_moderation_controller_requires_messages_view_claim()
+		public void chat_controller_requires_chat_view_policy()
 		{
-			var authorize = typeof(ChatModerationController).GetCustomAttributes<AuthorizeAttribute>()
-				.Single(x => x.Policy == ResgridResources.Messages_View);
+			var authorize = typeof(ChatController).GetCustomAttributes<AuthorizeAttribute>()
+				.Single(x => x.Policy == ResgridResources.Chat_View);
 
-			authorize.Policy.Should().Be(ResgridResources.Messages_View);
+			authorize.Policy.Should().Be(ResgridResources.Chat_View);
 		}
 
-		[TestCase(nameof(ChatbotController.GetChatChannel), ResgridResources.Messages_View)]
-		[TestCase(nameof(ChatbotController.SendChatMessage), ResgridResources.Messages_View)]
+		[Test]
+		public void chat_moderation_controller_requires_chat_view_policy()
+		{
+			var authorize = typeof(ChatModerationController).GetCustomAttributes<AuthorizeAttribute>()
+				.Single(x => x.Policy == ResgridResources.Chat_View);
+
+			authorize.Policy.Should().Be(ResgridResources.Chat_View);
+		}
+
+		[TestCase(nameof(ChatbotController.GetChatChannel), ResgridResources.Chat_View)]
+		[TestCase(nameof(ChatbotController.SendChatMessage), ResgridResources.Chat_View)]
 		[TestCase(nameof(ChatbotController.SendChatMessage), ResgridResources.Messages_Create)]
-		[TestCase(nameof(ChatbotController.NewChatSession), ResgridResources.Messages_View)]
+		[TestCase(nameof(ChatbotController.NewChatSession), ResgridResources.Chat_View)]
 		[TestCase(nameof(ChatbotController.NewChatSession), ResgridResources.Messages_Create)]
-		[TestCase(nameof(ChatbotController.AskIncident), ResgridResources.Messages_View)]
+		[TestCase(nameof(ChatbotController.AskIncident), ResgridResources.Chat_View)]
 		[TestCase(nameof(ChatbotController.AskIncident), ResgridResources.Messages_Create)]
-		[TestCase(nameof(ChatbotController.IncidentSuggestions), ResgridResources.Messages_View)]
+		[TestCase(nameof(ChatbotController.IncidentSuggestions), ResgridResources.Chat_View)]
 		public void chatbot_chat_actions_require_message_claims(string methodName, string policy)
 		{
 			var method = typeof(ChatbotController).GetMethod(methodName, BindingFlags.Instance | BindingFlags.Public);
@@ -92,8 +125,6 @@ namespace Resgrid.Tests.Web.Services
 		[TestCase(nameof(ChatController.SetNotificationPreference), ResgridResources.Messages_Update)]
 		[TestCase(nameof(ChatController.EditMessage), ResgridResources.Messages_Update)]
 		[TestCase(nameof(ChatController.RemoveReaction), ResgridResources.Messages_Update)]
-		[TestCase(nameof(ChatController.Ack), ResgridResources.Messages_Update)]
-		[TestCase(nameof(ChatController.MarkRead), ResgridResources.Messages_Update)]
 		[TestCase(nameof(ChatController.PinMessage), ResgridResources.Messages_Update)]
 		[TestCase(nameof(ChatController.UnpinMessage), ResgridResources.Messages_Update)]
 		[TestCase(nameof(ChatController.ArchiveChannel), ResgridResources.Messages_Delete)]
@@ -104,6 +135,16 @@ namespace Resgrid.Tests.Web.Services
 
 			method.Should().NotBeNull();
 			method.GetCustomAttributes<AuthorizeAttribute>().Should().ContainSingle(x => x.Policy == policy);
+		}
+
+		[TestCase(nameof(ChatController.Ack))]
+		[TestCase(nameof(ChatController.MarkRead))]
+		public void read_state_chat_actions_use_the_controller_chat_view_policy(string methodName)
+		{
+			var method = typeof(ChatController).GetMethod(methodName, BindingFlags.Instance | BindingFlags.Public);
+
+			method.Should().NotBeNull();
+			method.GetCustomAttributes<AuthorizeAttribute>().Should().BeEmpty();
 		}
 
 		[TestCase(nameof(ChatModerationController.ResolveFlag), ResgridResources.Messages_Update)]

--- a/Tests/Resgrid.Tests/Web/Services/ChatControllerCommanderLineTests.cs
+++ b/Tests/Resgrid.Tests/Web/Services/ChatControllerCommanderLineTests.cs
@@ -48,6 +48,8 @@ namespace Resgrid.Tests.Web.Services
 			featureToggleService
 				.Setup(x => x.IsEnabledAsync(FeatureFlagKeys.ChatSystem, DepartmentId, It.IsAny<bool>(), It.IsAny<IDictionary<string, string>>()))
 				.ReturnsAsync(true);
+			var authorizationService = new Mock<IAuthorizationService>();
+			authorizationService.Setup(x => x.IsUserValidWithinLimitsAsync(UserId, DepartmentId)).ReturnsAsync(true);
 
 			_chatPermissionService.Setup(x => x.CanSendAsUnitAsync(UserId, UnitId, DepartmentId)).ReturnsAsync(true);
 
@@ -101,7 +103,7 @@ namespace Resgrid.Tests.Web.Services
 				Mock.Of<IChatAttachmentRepository>(),
 				Mock.Of<IGifProvider>(),
 				featureToggleService.Object,
-				Mock.Of<IAuthorizationService>(),
+				authorizationService.Object,
 				Mock.Of<ICacheProvider>(),
 				Mock.Of<IEventAggregator>(),
 				Mock.Of<IQueueService>(),

--- a/Tests/Resgrid.Tests/Web/Services/ChatControllerCommanderLineTests.cs
+++ b/Tests/Resgrid.Tests/Web/Services/ChatControllerCommanderLineTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System;
 using System.Diagnostics;
 using System.Security.Claims;
 using System.Threading;
@@ -35,21 +36,32 @@ namespace Resgrid.Tests.Web.Services
 
 		private Mock<IChatChannelService> _chatChannelService;
 		private Mock<IChatPermissionService> _chatPermissionService;
+		private Mock<IFeatureToggleService> _featureToggleService;
+		private Mock<IAuthorizationService> _authorizationService;
+		private Mock<ICacheProvider> _cacheProvider;
 		private ChatController _controller;
 		private Activity _activity;
+		private string _chatEnabledCacheValue;
 
 		[SetUp]
 		public void SetUp()
 		{
+			_chatEnabledCacheValue = null;
 			_chatChannelService = new Mock<IChatChannelService>();
 			_chatPermissionService = new Mock<IChatPermissionService>();
 
-			var featureToggleService = new Mock<IFeatureToggleService>();
-			featureToggleService
+			_featureToggleService = new Mock<IFeatureToggleService>();
+			_featureToggleService
 				.Setup(x => x.IsEnabledAsync(FeatureFlagKeys.ChatSystem, DepartmentId, It.IsAny<bool>(), It.IsAny<IDictionary<string, string>>()))
 				.ReturnsAsync(true);
-			var authorizationService = new Mock<IAuthorizationService>();
-			authorizationService.Setup(x => x.IsUserValidWithinLimitsAsync(UserId, DepartmentId)).ReturnsAsync(true);
+			_authorizationService = new Mock<IAuthorizationService>();
+			_authorizationService.Setup(x => x.IsUserValidWithinLimitsAsync(UserId, DepartmentId)).ReturnsAsync(true);
+			_cacheProvider = new Mock<ICacheProvider>();
+			_cacheProvider.Setup(x => x.GetStringAsync(It.IsAny<string>())).ReturnsAsync(() => _chatEnabledCacheValue);
+			_cacheProvider
+				.Setup(x => x.SetStringAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan>()))
+				.Callback<string, string, TimeSpan>((key, value, expiration) => _chatEnabledCacheValue = value)
+				.ReturnsAsync(true);
 
 			_chatPermissionService.Setup(x => x.CanSendAsUnitAsync(UserId, UnitId, DepartmentId)).ReturnsAsync(true);
 
@@ -102,9 +114,9 @@ namespace Resgrid.Tests.Web.Services
 				Mock.Of<IChatPresenceService>(),
 				Mock.Of<IChatAttachmentRepository>(),
 				Mock.Of<IGifProvider>(),
-				featureToggleService.Object,
-				authorizationService.Object,
-				Mock.Of<ICacheProvider>(),
+				_featureToggleService.Object,
+				_authorizationService.Object,
+				_cacheProvider.Object,
 				Mock.Of<IEventAggregator>(),
 				Mock.Of<IQueueService>(),
 				Mock.Of<IUserProfileService>(),
@@ -161,6 +173,23 @@ namespace Resgrid.Tests.Web.Services
 			response.Value.Data.NotificationPreference.Should().Be(1);
 
 			_chatChannelService.Verify(x => x.GetUnitMembershipAsync(It.IsAny<string>(), It.IsAny<int>()), Times.Never);
+		}
+
+		[Test]
+		public async Task CreateIncidentCommanderLine_ReusesTheShortLivedChatEnabledResult()
+		{
+			var input = new CreateIncidentCommanderLineInput { CallId = CallId, AsUnitId = UnitId };
+
+			await _controller.CreateIncidentCommanderLine(input, CancellationToken.None);
+			await _controller.CreateIncidentCommanderLine(input, CancellationToken.None);
+
+			_authorizationService.Verify(x => x.IsUserValidWithinLimitsAsync(UserId, DepartmentId), Times.Once);
+			_featureToggleService.Verify(
+				x => x.IsEnabledAsync(FeatureFlagKeys.ChatSystem, DepartmentId, It.IsAny<bool>(), It.IsAny<IDictionary<string, string>>()),
+				Times.Once);
+			_cacheProvider.Verify(
+				x => x.SetStringAsync("chat:enabled:10:requester-user", "1", TimeSpan.FromSeconds(30)),
+				Times.Once);
 		}
 	}
 }

--- a/Tests/Resgrid.Tests/Web/Services/ChatControllerCommanderLineTests.cs
+++ b/Tests/Resgrid.Tests/Web/Services/ChatControllerCommanderLineTests.cs
@@ -41,7 +41,7 @@ namespace Resgrid.Tests.Web.Services
 		private Mock<ICacheProvider> _cacheProvider;
 		private ChatController _controller;
 		private Activity _activity;
-		private string _chatEnabledCacheValue;
+		private bool? _chatEnabledCacheValue;
 
 		[SetUp]
 		public void SetUp()
@@ -57,11 +57,16 @@ namespace Resgrid.Tests.Web.Services
 			_authorizationService = new Mock<IAuthorizationService>();
 			_authorizationService.Setup(x => x.IsUserValidWithinLimitsAsync(UserId, DepartmentId)).ReturnsAsync(true);
 			_cacheProvider = new Mock<ICacheProvider>();
-			_cacheProvider.Setup(x => x.GetStringAsync(It.IsAny<string>())).ReturnsAsync(() => _chatEnabledCacheValue);
 			_cacheProvider
-				.Setup(x => x.SetStringAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan>()))
-				.Callback<string, string, TimeSpan>((key, value, expiration) => _chatEnabledCacheValue = value)
-				.ReturnsAsync(true);
+				.Setup(x => x.RetrieveAsync<bool>(It.IsAny<string>(), It.IsAny<Func<Task<bool>>>(), It.IsAny<TimeSpan>()))
+				.Returns(async (string key, Func<Task<bool>> fallback, TimeSpan expiration) =>
+				{
+					if (_chatEnabledCacheValue.HasValue)
+						return _chatEnabledCacheValue.Value;
+
+					_chatEnabledCacheValue = await fallback();
+					return _chatEnabledCacheValue.Value;
+				});
 
 			_chatPermissionService.Setup(x => x.CanSendAsUnitAsync(UserId, UnitId, DepartmentId)).ReturnsAsync(true);
 
@@ -188,8 +193,25 @@ namespace Resgrid.Tests.Web.Services
 				x => x.IsEnabledAsync(FeatureFlagKeys.ChatSystem, DepartmentId, It.IsAny<bool>(), It.IsAny<IDictionary<string, string>>()),
 				Times.Once);
 			_cacheProvider.Verify(
-				x => x.SetStringAsync("chat:enabled:10:requester-user", "1", TimeSpan.FromSeconds(30)),
-				Times.Once);
+				x => x.RetrieveAsync<bool>("chat:enabled:10:requester-user", It.IsAny<Func<Task<bool>>>(), TimeSpan.FromSeconds(30)),
+				Times.Exactly(2));
+		}
+
+		[Test]
+		public async Task CreateIncidentCommanderLine_ReusesTheShortLivedChatDisabledResult()
+		{
+			_authorizationService.Setup(x => x.IsUserValidWithinLimitsAsync(UserId, DepartmentId)).ReturnsAsync(false);
+			var input = new CreateIncidentCommanderLineInput { CallId = CallId, AsUnitId = UnitId };
+
+			var first = await _controller.CreateIncidentCommanderLine(input, CancellationToken.None);
+			var second = await _controller.CreateIncidentCommanderLine(input, CancellationToken.None);
+
+			first.Result.Should().BeOfType<NotFoundResult>();
+			second.Result.Should().BeOfType<NotFoundResult>();
+			_authorizationService.Verify(x => x.IsUserValidWithinLimitsAsync(UserId, DepartmentId), Times.Once);
+			_featureToggleService.Verify(
+				x => x.IsEnabledAsync(FeatureFlagKeys.ChatSystem, DepartmentId, It.IsAny<bool>(), It.IsAny<IDictionary<string, string>>()),
+				Times.Never);
 		}
 	}
 }

--- a/Tests/Resgrid.Tests/Web/User/SecurityControllerTests.cs
+++ b/Tests/Resgrid.Tests/Web/User/SecurityControllerTests.cs
@@ -1,0 +1,197 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using NUnit.Framework;
+using Resgrid.Model;
+using Resgrid.Model.Identity;
+using Resgrid.Model.Providers;
+using Resgrid.Model.Services;
+using Resgrid.Providers.Claims;
+using Resgrid.Web.Areas.User.Controllers;
+using Resgrid.Web.Areas.User.Models.Security;
+
+namespace Resgrid.Tests.Web.User
+{
+	[TestFixture]
+	[NonParallelizable]
+	public class SecurityControllerTests
+	{
+		private const int DepartmentId = 10;
+		private const string UserId = "audit-admin";
+		private Mock<IDepartmentsService> _departmentsService;
+		private Mock<IAuditService> _auditService;
+		private SecurityController _controller;
+
+		[SetUp]
+		public void SetUp()
+		{
+			_departmentsService = new Mock<IDepartmentsService>();
+			_auditService = new Mock<IAuditService>();
+
+			var httpContext = new DefaultHttpContext
+			{
+				User = new ClaimsPrincipal(new ClaimsIdentity(new[]
+				{
+					new Claim(ClaimTypes.PrimarySid, UserId),
+					new Claim(ClaimTypes.PrimaryGroupSid, DepartmentId.ToString()),
+					new Claim(
+						ResgridClaimTypes.Resources.Department,
+						ResgridClaimTypes.Actions.Update)
+				}, "test"))
+			};
+			Resgrid.Web.Helpers.ClaimsAuthorizationHelper._httpContextAccessor =
+				new HttpContextAccessor { HttpContext = httpContext };
+
+			_controller = new SecurityController(
+				_departmentsService.Object,
+				_auditService.Object,
+				Mock.Of<IPermissionsService>(),
+				Mock.Of<IEventAggregator>(),
+				Mock.Of<IDepartmentSettingsService>(),
+				Mock.Of<ISystemAuditsService>(),
+				null,
+				null,
+				Mock.Of<IDepartmentSsoService>(),
+				Mock.Of<IEncryptionService>())
+			{
+				ControllerContext = new ControllerContext { HttpContext = httpContext }
+			};
+		}
+
+		[TearDown]
+		public void TearDown()
+		{
+			Resgrid.Web.Helpers.ClaimsAuthorizationHelper._httpContextAccessor = null;
+		}
+
+		[Test]
+		public async Task GetAuditLogsList_ProvidesChronologicalSortKeyAndDecisionColumns()
+		{
+			var older = new AuditLog
+			{
+				AuditLogId = 1,
+				DepartmentId = DepartmentId,
+				UserId = "actor-1",
+				LoggedOn = new DateTime(2025, 12, 31, 23, 59, 59, DateTimeKind.Utc),
+				Successful = false,
+				LogType = (int)AuditLogTypes.UserRemoved,
+				Message = "Older"
+			};
+			var newer = new AuditLog
+			{
+				AuditLogId = 2,
+				DepartmentId = DepartmentId,
+				UserId = "actor-1",
+				LoggedOn = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+				Successful = true,
+				LogType = (int)AuditLogTypes.UserAdded,
+				Message = "Newer"
+			};
+			var unknownTime = new AuditLog
+			{
+				AuditLogId = 3,
+				DepartmentId = DepartmentId,
+				LogType = (int)AuditLogTypes.PermissionsChanged,
+				Message = "Unknown time"
+			};
+
+			_auditService.Setup(x => x.GetAllAuditLogsForDepartmentAsync(DepartmentId))
+				.ReturnsAsync(new List<AuditLog> { older, newer, unknownTime });
+			_auditService.Setup(x => x.GetAuditLogTypeString(It.IsAny<AuditLogTypes>()))
+				.Returns((AuditLogTypes type) => type.ToString());
+			_departmentsService.Setup(x => x.GetDepartmentByIdAsync(DepartmentId, false))
+				.ReturnsAsync(new Department
+				{
+					DepartmentId = DepartmentId,
+					TimeZone = "UTC",
+					Use24HourTime = true
+				});
+			_departmentsService.Setup(x => x.GetAllPersonnelNamesForDepartmentAsync(DepartmentId))
+				.ReturnsAsync(new List<PersonName>
+				{
+					new PersonName { UserId = "actor-1", FirstName = "Alex", LastName = "Morgan" }
+				});
+			_departmentsService.Setup(x => x.GetAllUsersForDepartmentAsync(DepartmentId, true, false))
+				.ReturnsAsync(new List<IdentityUser>
+				{
+					new IdentityUser
+					{
+						UserId = "actor-1",
+						UserName = "alex.morgan",
+						Email = "alex.morgan@example.com"
+					}
+				});
+
+			var result = await _controller.GetAuditLogsList();
+
+			var entries = result.Should().BeOfType<JsonResult>().Subject.Value
+				.Should().BeAssignableTo<IEnumerable<AuditLogJson>>().Subject.ToList();
+			entries.OrderByDescending(x => x.TimestampSort ?? -1).Select(x => x.AuditLogId)
+				.Should().Equal(2, 1, 3);
+			entries.Single(x => x.AuditLogId == 2).Name.Should().Be("Alex Morgan");
+			entries.Single(x => x.AuditLogId == 2).Successful.Should().BeTrue();
+			entries.Single(x => x.AuditLogId == 2).SearchTerms.Should().ContainAll(
+				"Alex Morgan",
+				"actor-1",
+				"alex.morgan",
+				"alex.morgan@example.com",
+				"2",
+				"2026-01-01 00:00:00",
+				AuditLogTypes.UserAdded.ToString());
+			entries.Single(x => x.AuditLogId == 3).TimestampSort.Should().BeNull();
+		}
+
+		[Test]
+		public async Task ViewAudit_ReturnsCompleteAuditEntryAndFriendlyTypeName()
+		{
+			var auditLog = new AuditLog
+			{
+				AuditLogId = 42,
+				DepartmentId = DepartmentId,
+				UserId = "actor-1",
+				LoggedOn = DateTime.UtcNow,
+				Successful = true,
+				LogType = (int)AuditLogTypes.UserAdded,
+				Message = "User added",
+				Data = "{\"userId\":\"new-user\"}",
+				IpAddress = "192.0.2.10",
+				ServerName = "web-1",
+				ObjectId = "new-user",
+				ObjectDepartmentId = DepartmentId,
+				UserAgent = "Test Agent"
+			};
+			_auditService.Setup(x => x.GetAuditLogByIdAsync(42)).ReturnsAsync(auditLog);
+			_auditService.Setup(x => x.GetAuditLogTypeString(AuditLogTypes.UserAdded))
+				.Returns("User Added");
+			_departmentsService.Setup(x => x.GetDepartmentByIdAsync(DepartmentId, false))
+				.ReturnsAsync(new Department { DepartmentId = DepartmentId });
+
+			var result = await _controller.ViewAudit(42);
+
+			var model = result.Should().BeOfType<ViewResult>().Subject.Model
+				.Should().BeOfType<ViewAuditLogView>().Subject;
+			model.AuditLog.Should().BeSameAs(auditLog);
+			model.Type.Should().Be(AuditLogTypes.UserAdded);
+			model.TypeName.Should().Be("User Added");
+		}
+
+		[Test]
+		public async Task ViewAudit_MissingEntry_ReturnsNotFound()
+		{
+			_auditService.Setup(x => x.GetAuditLogByIdAsync(404)).ReturnsAsync((AuditLog)null);
+
+			var result = await _controller.ViewAudit(404);
+
+			result.Should().BeOfType<NotFoundResult>();
+			_departmentsService.Verify(
+				x => x.GetDepartmentByIdAsync(It.IsAny<int>(), It.IsAny<bool>()),
+				Times.Never);
+		}
+	}
+}

--- a/Web/Resgrid.Web.Eventing/Hubs/ChatHub.cs
+++ b/Web/Resgrid.Web.Eventing/Hubs/ChatHub.cs
@@ -3,21 +3,24 @@ using System.Collections.Concurrent;
 using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
 using Resgrid.Config;
 using Resgrid.Model;
 using Resgrid.Model.Services;
+using Resgrid.Providers.Claims;
 
 namespace Resgrid.Web.Eventing.Hubs
 {
 	/// <summary>
 	/// Realtime chat hub. Carries only ephemeral traffic (channel group membership, typing, presence,
 	/// read/delivered pointers) — message writes go through the REST API and fan back out via the
-	/// RabbitMQ eventing topic and this host's Worker. Group naming: chat:{channelId} per channel,
+	/// RabbitMQ eventing topic and this host's Worker. Group naming: chat:{channelId}:{accessVersion}
+	/// per channel (the version rotates on authorization changes),
 	/// chatuser:{deptId}:{userId} for personal events, chatdept:{deptId} for channel-list updates.
 	/// </summary>
-	[Authorize(AuthenticationSchemes = OpenIddict.Validation.AspNetCore.OpenIddictValidationAspNetCoreDefaults.AuthenticationScheme)]
+	[Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme, Policy = ResgridResources.Messages_View)]
 	public class ChatHub : Hub
 	{
 		private readonly IChatChannelService _chatChannelService;
@@ -70,12 +73,17 @@ namespace Resgrid.Web.Eventing.Hubs
 			var departmentId = GetDepartmentId();
 			var userId = GetUserId();
 
-			if (departmentId > 0 && !string.IsNullOrWhiteSpace(userId))
+			if (departmentId > 0 && !string.IsNullOrWhiteSpace(userId) &&
+				await _chatPermissionService.IsActiveDepartmentUserAsync(departmentId, userId))
 			{
 				Context.Items[DepartmentIdContextKey] = departmentId;
 				Context.Items[UserIdContextKey] = userId;
 
 				AddUserConnection(userId, Context.ConnectionId);
+			}
+			else
+			{
+				Context.Abort();
 			}
 
 			await base.OnConnectedAsync();
@@ -150,7 +158,8 @@ namespace Resgrid.Web.Eventing.Hubs
 			var departmentId = GetDepartmentId();
 			var userId = GetUserId();
 
-			if (departmentId <= 0 || string.IsNullOrWhiteSpace(userId))
+			if (departmentId <= 0 || string.IsNullOrWhiteSpace(userId) ||
+				!await _chatPermissionService.IsActiveDepartmentUserAsync(departmentId, userId))
 				return;
 
 			await Groups.AddToGroupAsync(Context.ConnectionId, $"chatuser:{departmentId}:{userId.ToLowerInvariant()}");
@@ -165,16 +174,21 @@ namespace Resgrid.Web.Eventing.Hubs
 
 		public async Task JoinChannel(string channelId, int? asUnitId = null)
 		{
-			await ResolveAccessibleChannelOrThrowAsync(channelId, asUnitId);
+			var channel = await ResolveAccessibleChannelOrThrowAsync(channelId, asUnitId);
+			var groupName = await GetCurrentChannelGroupNameAsync(channel.ChatChannelId);
+			if (groupName == null)
+				throw new HubException("Chat authorization is temporarily unavailable.");
 
-			await Groups.AddToGroupAsync(Context.ConnectionId, $"chat:{channelId}");
+			await Groups.AddToGroupAsync(Context.ConnectionId, groupName);
 
 			await Clients.Caller.SendAsync("onChatChannelJoined", channelId);
 		}
 
 		public async Task LeaveChannel(string channelId)
 		{
-			await Groups.RemoveFromGroupAsync(Context.ConnectionId, $"chat:{channelId}");
+			var groupName = await GetCurrentChannelGroupNameAsync(channelId);
+			if (groupName != null)
+				await Groups.RemoveFromGroupAsync(Context.ConnectionId, groupName);
 		}
 
 		public async Task Typing(string channelId, string displayName = null, bool isTyping = true, int? asUnitId = null)
@@ -199,7 +213,11 @@ namespace Resgrid.Web.Eventing.Hubs
 				LastTypingTimestamps[throttleKey] = now;
 			}
 
-			await Clients.OthersInGroup($"chat:{channelId}").SendAsync("chatTyping", new
+			var groupName = await GetCurrentChannelGroupNameAsync(channelId);
+			if (groupName == null)
+				return;
+
+			await Clients.OthersInGroup(groupName).SendAsync("chatTyping", new
 			{
 				ChannelId = channelId,
 				UserId = userId,
@@ -285,13 +303,32 @@ namespace Resgrid.Web.Eventing.Hubs
 			return access.Value.Channel;
 		}
 
+		public static string BuildChannelGroupName(string channelId, string accessVersion)
+		{
+			return string.IsNullOrWhiteSpace(channelId) || string.IsNullOrWhiteSpace(accessVersion)
+				? null
+				: $"chat:{channelId}:{accessVersion}";
+		}
+
+		private async Task<string> GetCurrentChannelGroupNameAsync(string channelId)
+		{
+			return BuildChannelGroupName(channelId,
+				await _chatPermissionService.GetChannelAccessVersionAsync(channelId));
+		}
+
 		public async Task Heartbeat()
 		{
 			var departmentId = GetDepartmentId();
 			var userId = GetUserId();
 
-			if (departmentId > 0 && !string.IsNullOrWhiteSpace(userId))
-				await _chatPresenceService.TouchAsync(departmentId, userId);
+			if (departmentId <= 0 || string.IsNullOrWhiteSpace(userId) ||
+				!await _chatPermissionService.IsActiveDepartmentUserAsync(departmentId, userId))
+			{
+				Context.Abort();
+				return;
+			}
+
+			await _chatPresenceService.TouchAsync(departmentId, userId);
 		}
 
 		/// <summary>

--- a/Web/Resgrid.Web.Eventing/Hubs/ChatHub.cs
+++ b/Web/Resgrid.Web.Eventing/Hubs/ChatHub.cs
@@ -20,7 +20,7 @@ namespace Resgrid.Web.Eventing.Hubs
 	/// per channel (the version rotates on authorization changes),
 	/// chatuser:{deptId}:{userId} for personal events, chatdept:{deptId} for channel-list updates.
 	/// </summary>
-	[Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme, Policy = ResgridResources.Messages_View)]
+	[Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme, Policy = ResgridResources.Chat_View)]
 	public class ChatHub : Hub
 	{
 		private readonly IChatChannelService _chatChannelService;
@@ -30,6 +30,9 @@ namespace Resgrid.Web.Eventing.Hubs
 
 		private const string UserIdContextKey = "chatUserId";
 		private const string DepartmentIdContextKey = "chatDepartmentId";
+		private const string LastMembershipValidationContextKey = "chatLastMembershipValidation";
+		private const string JoinedChannelGroupContextKeyPrefix = "chatJoinedChannelGroup:";
+		private static readonly TimeSpan MembershipValidationInterval = TimeSpan.FromMinutes(2);
 
 		/// <summary>userId -> connectionIds on this host; used by the Worker to evict revoked users from channel groups.</summary>
 		public static readonly ConcurrentDictionary<string, ConcurrentDictionary<string, byte>> UserConnections =
@@ -78,6 +81,7 @@ namespace Resgrid.Web.Eventing.Hubs
 			{
 				Context.Items[DepartmentIdContextKey] = departmentId;
 				Context.Items[UserIdContextKey] = userId;
+				Context.Items[LastMembershipValidationContextKey] = Environment.TickCount64;
 
 				AddUserConnection(userId, Context.ConnectionId);
 			}
@@ -180,15 +184,22 @@ namespace Resgrid.Web.Eventing.Hubs
 				throw new HubException("Chat authorization is temporarily unavailable.");
 
 			await Groups.AddToGroupAsync(Context.ConnectionId, groupName);
+			Context.Items[GetJoinedChannelGroupContextKey(channel.ChatChannelId)] = groupName;
 
 			await Clients.Caller.SendAsync("onChatChannelJoined", channelId);
 		}
 
 		public async Task LeaveChannel(string channelId)
 		{
-			var groupName = await GetCurrentChannelGroupNameAsync(channelId);
+			var contextKey = GetJoinedChannelGroupContextKey(channelId);
+			var groupName = Context.Items.TryGetValue(contextKey, out var trackedGroupName)
+				? trackedGroupName as string
+				: await GetCurrentChannelGroupNameAsync(channelId);
 			if (groupName != null)
+			{
 				await Groups.RemoveFromGroupAsync(Context.ConnectionId, groupName);
+				Context.Items.Remove(contextKey);
+			}
 		}
 
 		public async Task Typing(string channelId, string displayName = null, bool isTyping = true, int? asUnitId = null)
@@ -310,6 +321,11 @@ namespace Resgrid.Web.Eventing.Hubs
 				: $"chat:{channelId}:{accessVersion}";
 		}
 
+		private static string GetJoinedChannelGroupContextKey(string channelId)
+		{
+			return $"{JoinedChannelGroupContextKeyPrefix}{channelId?.ToLowerInvariant()}";
+		}
+
 		private async Task<string> GetCurrentChannelGroupNameAsync(string channelId)
 		{
 			return BuildChannelGroupName(channelId,
@@ -321,11 +337,26 @@ namespace Resgrid.Web.Eventing.Hubs
 			var departmentId = GetDepartmentId();
 			var userId = GetUserId();
 
-			if (departmentId <= 0 || string.IsNullOrWhiteSpace(userId) ||
-				!await _chatPermissionService.IsActiveDepartmentUserAsync(departmentId, userId))
+			if (departmentId <= 0 || string.IsNullOrWhiteSpace(userId))
 			{
 				Context.Abort();
 				return;
+			}
+
+			var membershipValidationDue =
+				!Context.Items.TryGetValue(LastMembershipValidationContextKey, out var lastValidationValue) ||
+				lastValidationValue is not long lastValidation ||
+				Environment.TickCount64 - lastValidation >= MembershipValidationInterval.TotalMilliseconds;
+
+			if (membershipValidationDue)
+			{
+				if (!await _chatPermissionService.IsActiveDepartmentUserAsync(departmentId, userId))
+				{
+					Context.Abort();
+					return;
+				}
+
+				Context.Items[LastMembershipValidationContextKey] = Environment.TickCount64;
 			}
 
 			await _chatPresenceService.TouchAsync(departmentId, userId);

--- a/Web/Resgrid.Web.Eventing/Startup.cs
+++ b/Web/Resgrid.Web.Eventing/Startup.cs
@@ -247,7 +247,7 @@ namespace Resgrid.Web.Eventing
 				//IssuerSigningKey = signingKey,
 
 				// Validate the JWT Issuer (iss) claim
-				ValidateIssuer = false,
+				ValidateIssuer = true,
 				ValidIssuer = JwtConfig.Issuer,
 
 				// Validate the JWT Audience (aud) claim
@@ -309,6 +309,13 @@ namespace Resgrid.Web.Eventing
 						return Task.CompletedTask;
 					}
 				};
+			});
+
+			services.AddAuthorization(options =>
+			{
+				options.AddPolicy(ResgridResources.Messages_View, policy => policy
+					.AddAuthenticationSchemes(JwtBearerDefaults.AuthenticationScheme)
+					.RequireChatAccessClaims());
 			});
 
 			//services.AddHostedService<Worker>();
@@ -397,7 +404,7 @@ namespace Resgrid.Web.Eventing
 
 				endpoints.MapHub<EventingHub>("/eventingHub");
 				endpoints.MapHub<GeolocationHub>("/geolocationHub");
-				endpoints.MapHub<ChatHub>("/chatHub");
+				endpoints.MapHub<ChatHub>("/chatHub", options => options.CloseOnAuthenticationExpiration = true);
 			});
 		}
 

--- a/Web/Resgrid.Web.Eventing/Startup.cs
+++ b/Web/Resgrid.Web.Eventing/Startup.cs
@@ -313,7 +313,7 @@ namespace Resgrid.Web.Eventing
 
 			services.AddAuthorization(options =>
 			{
-				options.AddPolicy(ResgridResources.Messages_View, policy => policy
+				options.AddPolicy(ResgridResources.Chat_View, policy => policy
 					.AddAuthenticationSchemes(JwtBearerDefaults.AuthenticationScheme)
 					.RequireChatAccessClaims());
 			});

--- a/Web/Resgrid.Web.Eventing/Worker.cs
+++ b/Web/Resgrid.Web.Eventing/Worker.cs
@@ -177,7 +177,17 @@ namespace Resgrid.Web.Eventing
 			// receive incident chat. Rotate every call-scoped SignalR group before notifying clients;
 			// old connections remain in an obsolete group that receives no future message payloads.
 			if (int.TryParse(id, out var callId))
-				await InvalidateIncidentChatAccessAsync(departmentId, callId);
+			{
+				try
+				{
+					await InvalidateIncidentChatAccessAsync(departmentId, callId);
+				}
+				catch (Exception ex)
+				{
+					Resgrid.Framework.Logging.LogException(ex,
+						$"Failed to invalidate incident chat access for department {departmentId} and call {callId}.");
+				}
+			}
 
 			var group = _eventingHub.Clients.Group(departmentId.ToString());
 

--- a/Web/Resgrid.Web.Eventing/Worker.cs
+++ b/Web/Resgrid.Web.Eventing/Worker.cs
@@ -11,6 +11,8 @@ using Resgrid.Model.Providers;
 using Resgrid.Providers.Bus.Rabbit;
 using Resgrid.Web.Eventing.Hubs.Models;
 using Resgrid.Model.Events;
+using Resgrid.Model.Repositories;
+using Resgrid.Model.Services;
 using Microsoft.AspNetCore.SignalR;
 using Resgrid.Web.Eventing.Hubs;
 
@@ -171,10 +173,20 @@ namespace Resgrid.Web.Eventing
 		{
 			Console.WriteLine($"Processing RabbitMQ IncidentCommandUpdated Event For {departmentId}");
 
+			// Resource releases, lane moves, lead changes and command transfers all change who may
+			// receive incident chat. Rotate every call-scoped SignalR group before notifying clients;
+			// old connections remain in an obsolete group that receives no future message payloads.
+			if (int.TryParse(id, out var callId))
+				await InvalidateIncidentChatAccessAsync(departmentId, callId);
+
 			var group = _eventingHub.Clients.Group(departmentId.ToString());
 
 			if (group != null)
 				await group.SendAsync("incidentCommandUpdated", id);
+
+			await _chatHub.Clients.Group($"chatdept:{departmentId}").SendAsync(
+				ChatEventKinds.ChannelUpdated,
+				Newtonsoft.Json.JsonConvert.SerializeObject(new { DepartmentId = departmentId, CallId = id, AuthorizationChanged = true }));
 		}
 
 		public async Task DepartmentUpdated(int departmentId)
@@ -252,7 +264,8 @@ namespace Resgrid.Web.Eventing
 					return;
 
 				var chatEvent = Newtonsoft.Json.JsonConvert.DeserializeObject<ChatEventRaised>(payloadJson);
-				if (chatEvent == null || string.IsNullOrWhiteSpace(chatEvent.Kind))
+				if (chatEvent == null || string.IsNullOrWhiteSpace(chatEvent.Kind) || departmentId <= 0 ||
+					chatEvent.DepartmentId != departmentId)
 					return;
 
 				if (chatEvent.Kind == ChatEventKinds.AccessRevoked)
@@ -268,7 +281,8 @@ namespace Resgrid.Web.Eventing
 					return;
 				}
 
-				if (chatEvent.Kind == ChatEventKinds.ChannelUpdated || chatEvent.Kind == ChatEventKinds.ChannelProvisioned)
+				if (chatEvent.Kind == ChatEventKinds.ChannelUpdated || chatEvent.Kind == ChatEventKinds.ChannelProvisioned ||
+					chatEvent.Kind == ChatEventKinds.ModerationApplied)
 				{
 					var hint = Newtonsoft.Json.JsonConvert.SerializeObject(new
 					{
@@ -282,8 +296,10 @@ namespace Resgrid.Web.Eventing
 
 					if (!string.IsNullOrWhiteSpace(chatEvent.ChatChannelId))
 					{
-						await _chatHub.Clients.Group($"chat:{chatEvent.ChatChannelId}")
-							.SendAsync(chatEvent.Kind, GuardChatPayloadSize(chatEvent));
+						var channelGroupName = await GetCurrentChannelGroupNameAsync(chatEvent.ChatChannelId);
+						if (channelGroupName != null)
+							await _chatHub.Clients.Group(channelGroupName)
+								.SendAsync(chatEvent.Kind, GuardChatPayloadSize(chatEvent));
 					}
 
 					return;
@@ -291,8 +307,10 @@ namespace Resgrid.Web.Eventing
 
 				if (!string.IsNullOrWhiteSpace(chatEvent.ChatChannelId))
 				{
-					await _chatHub.Clients.Group($"chat:{chatEvent.ChatChannelId}")
-						.SendAsync(chatEvent.Kind, GuardChatPayloadSize(chatEvent));
+					var channelGroupName = await GetCurrentChannelGroupNameAsync(chatEvent.ChatChannelId);
+					if (channelGroupName != null)
+						await _chatHub.Clients.Group(channelGroupName)
+							.SendAsync(chatEvent.Kind, GuardChatPayloadSize(chatEvent));
 				}
 			}
 			catch (Exception ex)
@@ -326,13 +344,14 @@ namespace Resgrid.Web.Eventing
 			if (string.IsNullOrWhiteSpace(userId))
 				return;
 
-			if (!string.IsNullOrWhiteSpace(channelId) && ChatHub.UserConnections.TryGetValue(userId, out var connections))
+			var channelGroupName = await GetCurrentChannelGroupNameAsync(channelId);
+			if (channelGroupName != null && ChatHub.UserConnections.TryGetValue(userId, out var connections))
 			{
 				foreach (var connectionId in connections.Keys)
 				{
 					try
 					{
-						await _chatHub.Groups.RemoveFromGroupAsync(connectionId, $"chat:{channelId}");
+						await _chatHub.Groups.RemoveFromGroupAsync(connectionId, channelGroupName);
 					}
 					catch (Exception ex)
 					{
@@ -343,6 +362,37 @@ namespace Resgrid.Web.Eventing
 
 			await _chatHub.Clients.Group($"chatuser:{chatEvent.DepartmentId}:{userId.ToLowerInvariant()}")
 				.SendAsync(chatEvent.Kind, chatEvent.PayloadJson);
+		}
+
+		private async Task<string> GetCurrentChannelGroupNameAsync(string channelId)
+		{
+			if (string.IsNullOrWhiteSpace(channelId))
+				return null;
+
+			using var scope = _serviceProvider.CreateScope();
+			var permissionService = scope.ServiceProvider.GetRequiredService<IChatPermissionService>();
+			var version = await permissionService.GetChannelAccessVersionAsync(channelId);
+			return ChatHub.BuildChannelGroupName(channelId, version);
+		}
+
+		private async Task InvalidateIncidentChatAccessAsync(int departmentId, int callId)
+		{
+			if (departmentId <= 0 || callId <= 0)
+				return;
+
+			using var scope = _serviceProvider.CreateScope();
+			var channelRepository = scope.ServiceProvider.GetRequiredService<IChatChannelRepository>();
+			var permissionService = scope.ServiceProvider.GetRequiredService<IChatPermissionService>();
+			var channels = await channelRepository.GetByCallIdAsync(callId);
+
+			if (channels == null)
+				return;
+
+			foreach (var channel in channels)
+			{
+				if (channel != null && channel.DepartmentId == departmentId)
+					await permissionService.InvalidateChannelCacheAsync(channel.ChatChannelId);
+			}
 		}
 
 		/// <summary>

--- a/Web/Resgrid.Web.Services/Controllers/ChatbotTelegramController.cs
+++ b/Web/Resgrid.Web.Services/Controllers/ChatbotTelegramController.cs
@@ -48,15 +48,15 @@ namespace Resgrid.Web.Services.Controllers
 		public async Task<IActionResult> Webhook()
 		{
 			// Verify the secret token Telegram echoes back in the X-Telegram-Bot-Api-Secret-Token
-			// header (configured via setWebhook). When a secret is configured, requests without a
-			// matching token are rejected so the webhook cannot be driven by arbitrary callers.
+			// header (configured via setWebhook). Fail closed when the secret is missing: otherwise an
+			// arbitrary caller could forge a linked Telegram user id and drive authenticated chatbot work.
 			var configuredSecret = ChatbotConfig.TelegramWebhookSecretToken;
-			if (!string.IsNullOrEmpty(configuredSecret))
-			{
-				var providedSecret = Request.Headers["X-Telegram-Bot-Api-Secret-Token"].ToString();
-				if (!SecretMatches(providedSecret, configuredSecret))
-					return Unauthorized();
-			}
+			if (string.IsNullOrWhiteSpace(configuredSecret))
+				return StatusCode(StatusCodes.Status503ServiceUnavailable);
+
+			var providedSecret = Request.Headers["X-Telegram-Bot-Api-Secret-Token"].ToString();
+			if (!SecretMatches(providedSecret, configuredSecret))
+				return Unauthorized();
 
 			try
 			{

--- a/Web/Resgrid.Web.Services/Controllers/v4/ChatController.cs
+++ b/Web/Resgrid.Web.Services/Controllers/v4/ChatController.cs
@@ -30,12 +30,13 @@ namespace Resgrid.Web.Services.Controllers.v4
 	[Route("api/v{VersionId:apiVersion}/[controller]")]
 	[ApiVersion("4.0")]
 	[ApiExplorerSettings(GroupName = "v4")]
-	[Authorize(Policy = ResgridResources.Messages_View)]
+	[Authorize(Policy = ResgridResources.Chat_View)]
 	public class ChatController : V4AuthenticatedApiControllerbase
 	{
 		#region Members and Constructors
 
 		private const long MaxAttachmentRequestBytes = 26_214_400;
+		private static readonly TimeSpan ChatEnabledCacheLength = TimeSpan.FromSeconds(30);
 
 		private static readonly string[] AllowedAttachmentContentTypes = new[]
 		{
@@ -1194,7 +1195,6 @@ namespace Resgrid.Web.Services.Controllers.v4
 		/// <param name="messageId">Chat message identifier</param>
 		/// <returns>ChatActionResult; Success is true when a pending acknowledgment was stamped</returns>
 		[HttpPost("Ack")]
-		[Authorize(Policy = ResgridResources.Messages_Update)]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
 		[ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -1322,7 +1322,6 @@ namespace Resgrid.Web.Services.Controllers.v4
 		/// <param name="input">Sequence read and optional unit identity</param>
 		/// <returns>ChatActionResult indicating whether the pointer advanced</returns>
 		[HttpPut("MarkRead")]
-		[Authorize(Policy = ResgridResources.Messages_Update)]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		[ProducesResponseType(StatusCodes.Status400BadRequest)]
 		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -1749,8 +1748,25 @@ namespace Resgrid.Web.Services.Controllers.v4
 
 		private async Task<bool> ChatEnabledAsync()
 		{
-			return await _authorizationService.IsUserValidWithinLimitsAsync(UserId, DepartmentId) &&
-				await _featureToggleService.IsEnabledAsync(FeatureFlagKeys.ChatSystem, DepartmentId);
+			var userId = UserId;
+			var departmentId = DepartmentId;
+
+			if (departmentId <= 0 || String.IsNullOrWhiteSpace(userId))
+				return false;
+
+			var cacheKey = $"chat:enabled:{departmentId}:{userId.ToLowerInvariant()}";
+			var cached = await _cacheProvider.GetStringAsync(cacheKey);
+
+			if (String.Equals(cached, "1", StringComparison.Ordinal))
+				return true;
+			if (String.Equals(cached, "0", StringComparison.Ordinal))
+				return false;
+
+			var enabled = await _authorizationService.IsUserValidWithinLimitsAsync(userId, departmentId) &&
+				await _featureToggleService.IsEnabledAsync(FeatureFlagKeys.ChatSystem, departmentId);
+
+			await _cacheProvider.SetStringAsync(cacheKey, enabled ? "1" : "0", ChatEnabledCacheLength);
+			return enabled;
 		}
 
 		/// <summary>

--- a/Web/Resgrid.Web.Services/Controllers/v4/ChatController.cs
+++ b/Web/Resgrid.Web.Services/Controllers/v4/ChatController.cs
@@ -1755,18 +1755,14 @@ namespace Resgrid.Web.Services.Controllers.v4
 				return false;
 
 			var cacheKey = $"chat:enabled:{departmentId}:{userId.ToLowerInvariant()}";
-			var cached = await _cacheProvider.GetStringAsync(cacheKey);
 
-			if (String.Equals(cached, "1", StringComparison.Ordinal))
-				return true;
-			if (String.Equals(cached, "0", StringComparison.Ordinal))
-				return false;
+			async Task<bool> isChatEnabled()
+			{
+				return await _authorizationService.IsUserValidWithinLimitsAsync(userId, departmentId) &&
+					await _featureToggleService.IsEnabledAsync(FeatureFlagKeys.ChatSystem, departmentId);
+			}
 
-			var enabled = await _authorizationService.IsUserValidWithinLimitsAsync(userId, departmentId) &&
-				await _featureToggleService.IsEnabledAsync(FeatureFlagKeys.ChatSystem, departmentId);
-
-			await _cacheProvider.SetStringAsync(cacheKey, enabled ? "1" : "0", ChatEnabledCacheLength);
-			return enabled;
+			return await _cacheProvider.RetrieveAsync<bool>(cacheKey, isChatEnabled, ChatEnabledCacheLength);
 		}
 
 		/// <summary>

--- a/Web/Resgrid.Web.Services/Controllers/v4/ChatController.cs
+++ b/Web/Resgrid.Web.Services/Controllers/v4/ChatController.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Resgrid.Config;
@@ -15,6 +16,7 @@ using Resgrid.Model.Events;
 using Resgrid.Model.Providers;
 using Resgrid.Model.Repositories;
 using Resgrid.Model.Services;
+using Resgrid.Providers.Claims;
 using Resgrid.Web.Services.Helpers;
 using Resgrid.Web.Services.Models.v4;
 using Resgrid.Web.Services.Models.v4.Chat;
@@ -28,6 +30,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 	[Route("api/v{VersionId:apiVersion}/[controller]")]
 	[ApiVersion("4.0")]
 	[ApiExplorerSettings(GroupName = "v4")]
+	[Authorize(Policy = ResgridResources.Messages_View)]
 	public class ChatController : V4AuthenticatedApiControllerbase
 	{
 		#region Members and Constructors
@@ -219,6 +222,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 		/// <param name="input">Target user or unit for the direct message</param>
 		/// <returns>ChatChannelCreatedResult with the existing or newly created channel</returns>
 		[HttpPost("CreateDirectMessage")]
+		[Authorize(Policy = ResgridResources.Messages_Create)]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		[ProducesResponseType(StatusCodes.Status400BadRequest)]
 		[ProducesResponseType(StatusCodes.Status403Forbidden)]
@@ -279,6 +283,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 		/// <param name="input">The call to reach command on, and optionally the unit to speak as</param>
 		/// <returns>ChatChannelCreatedResult with the existing or newly created commander line</returns>
 		[HttpPost("CreateIncidentCommanderLine")]
+		[Authorize(Policy = ResgridResources.Messages_Create)]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		[ProducesResponseType(StatusCodes.Status400BadRequest)]
 		[ProducesResponseType(StatusCodes.Status403Forbidden)]
@@ -342,6 +347,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 		/// <param name="input">Name and initial members of the channel</param>
 		/// <returns>ChatChannelCreatedResult with the newly created channel</returns>
 		[HttpPost("CreateAdHocChannel")]
+		[Authorize(Policy = ResgridResources.Messages_Create)]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		[ProducesResponseType(StatusCodes.Status400BadRequest)]
 		[ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -356,13 +362,20 @@ namespace Resgrid.Web.Services.Controllers.v4
 			if (input == null || input.MemberUserIds == null || input.MemberUserIds.Count <= 0)
 				return BadRequest();
 
-			// No name supplied: name the group after its members (Slack-style), capped to the column length.
+			// The service derives an unnamed group only after it validates every supplied member belongs to
+			// this department, so profile lookups cannot be driven across the tenant boundary.
 			var name = input.Name?.Trim();
-			if (String.IsNullOrWhiteSpace(name))
-				name = await BuildGroupNameFromMembersAsync(input.MemberUserIds);
 
 			var result = new ChatChannelCreatedResult();
-			var channel = await _chatChannelService.CreateAdHocGroupChannelAsync(DepartmentId, UserId, name, input.MemberUserIds, cancellationToken);
+			ChatChannel channel;
+			try
+			{
+				channel = await _chatChannelService.CreateAdHocGroupChannelAsync(DepartmentId, UserId, name, input.MemberUserIds, cancellationToken);
+			}
+			catch (UnauthorizedAccessException)
+			{
+				return StatusCode(StatusCodes.Status403Forbidden);
+			}
 
 			if (channel != null)
 			{
@@ -386,6 +399,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 		/// <param name="input">Name, topic and OR-evaluated access rules for the channel</param>
 		/// <returns>ChatChannelCreatedResult with the newly created channel</returns>
 		[HttpPost("CreateCustomChannel")]
+		[Authorize(Policy = ResgridResources.Messages_Create)]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		[ProducesResponseType(StatusCodes.Status400BadRequest)]
 		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -420,7 +434,15 @@ namespace Resgrid.Web.Services.Controllers.v4
 			}
 
 			var result = new ChatChannelCreatedResult();
-			var channel = await _chatChannelService.CreateCustomChannelAsync(DepartmentId, UserId, input.Name, input.Topic, rules, cancellationToken);
+			ChatChannel channel;
+			try
+			{
+				channel = await _chatChannelService.CreateCustomChannelAsync(DepartmentId, UserId, input.Name, input.Topic, rules, cancellationToken);
+			}
+			catch (UnauthorizedAccessException)
+			{
+				return StatusCode(StatusCodes.Status403Forbidden);
+			}
 
 			if (channel != null)
 			{
@@ -445,6 +467,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 		/// <param name="input">New name and topic</param>
 		/// <returns>GetChatChannelResult with the updated channel</returns>
 		[HttpPut("UpdateChannel")]
+		[Authorize(Policy = ResgridResources.Messages_Update)]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
 		[ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -464,7 +487,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 				return Unauthorized();
 
 			var result = new GetChatChannelResult();
-			var updated = await _chatChannelService.UpdateChannelAsync(channelId, input?.Name, input?.Topic, UserId, cancellationToken);
+			var updated = await _chatChannelService.UpdateChannelAsync(DepartmentId, channelId, input?.Name, input?.Topic, UserId, cancellationToken);
 
 			if (updated != null)
 			{
@@ -488,6 +511,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 		/// <param name="channelId">Chat channel identifier</param>
 		/// <returns>ChatActionResult indicating whether the channel was archived</returns>
 		[HttpDelete("ArchiveChannel")]
+		[Authorize(Policy = ResgridResources.Messages_Delete)]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
 		[ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -504,7 +528,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 				return Unauthorized();
 
 			var result = new ChatActionResult();
-			result.Success = await _chatChannelService.SetChannelArchivedAsync(channelId, true, UserId, cancellationToken);
+			result.Success = await _chatChannelService.SetChannelArchivedAsync(DepartmentId, channelId, true, UserId, cancellationToken);
 			result.Status = result.Success ? ResponseHelper.Success : ResponseHelper.Failure;
 
 			if (result.Success)
@@ -583,6 +607,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 		/// <param name="input">UserIds to add</param>
 		/// <returns>Array of ChatMemberResultData objects for the added members</returns>
 		[HttpPost("AddMembers")]
+		[Authorize(Policy = ResgridResources.Messages_Update)]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		[ProducesResponseType(StatusCodes.Status400BadRequest)]
 		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -624,7 +649,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 
 			try
 			{
-				added = await _chatChannelService.AddMembersAsync(channelId, input.UserIds, UserId, cancellationToken);
+				added = await _chatChannelService.AddMembersAsync(DepartmentId, channelId, input.UserIds, UserId, cancellationToken);
 			}
 			catch (UnauthorizedAccessException)
 			{
@@ -663,6 +688,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 		/// <param name="userId">UserId of the member to remove</param>
 		/// <returns>ChatActionResult indicating whether the member was removed</returns>
 		[HttpDelete("RemoveMember")]
+		[Authorize(Policy = ResgridResources.Messages_Update)]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		[ProducesResponseType(StatusCodes.Status400BadRequest)]
 		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -684,7 +710,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 				return Unauthorized();
 
 			var result = new ChatActionResult();
-			result.Success = await _chatChannelService.RemoveMemberAsync(channelId, userId, UserId, cancellationToken);
+			result.Success = await _chatChannelService.RemoveMemberAsync(DepartmentId, channelId, userId, UserId, cancellationToken);
 			result.Status = result.Success ? ResponseHelper.Deleted : ResponseHelper.Failure;
 
 			ResponseHelper.PopulateV4ResponseData(result);
@@ -698,6 +724,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 		/// <param name="input">Notification preference to apply</param>
 		/// <returns>ChatActionResult indicating whether the preference was saved</returns>
 		[HttpPut("SetNotificationPreference")]
+		[Authorize(Policy = ResgridResources.Messages_Update)]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
 		[ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -880,6 +907,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 		/// <param name="input">Message content and options</param>
 		/// <returns>ChatMessageSentResult with the persisted message</returns>
 		[HttpPost("SendMessage")]
+		[Authorize(Policy = ResgridResources.Messages_Create)]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		[ProducesResponseType(StatusCodes.Status400BadRequest)]
 		[ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -900,6 +928,9 @@ namespace Resgrid.Web.Services.Controllers.v4
 			// Assistant conversations are plain text only: no threads, no attachments/GIFs, no urgent
 			// priority. Enforced here so every client (web and mobile) gets the same behavior.
 			var channel = await _chatChannelService.GetChannelByIdAsync(channelId);
+			if (channel == null || channel.DepartmentId != DepartmentId)
+				return NotFound();
+
 			var isChatbotChannel = channel != null && channel.ChannelType == (int)ChatChannelType.Chatbot;
 			if (isChatbotChannel && ((ChatMessageType)input.MessageType != ChatMessageType.Text || !String.IsNullOrWhiteSpace(input.ThreadRootMessageId)))
 				return BadRequest("Assistant conversations only support plain text messages.");
@@ -944,7 +975,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 
 			try
 			{
-				message = await _chatMessageService.SendMessageAsync(UserId, request, cancellationToken);
+				message = await _chatMessageService.SendMessageAsync(DepartmentId, UserId, request, cancellationToken);
 			}
 			catch (UnauthorizedAccessException)
 			{
@@ -1012,6 +1043,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 		/// <param name="input">New message body</param>
 		/// <returns>GetChatMessageResult with the updated message</returns>
 		[HttpPut("EditMessage")]
+		[Authorize(Policy = ResgridResources.Messages_Update)]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		[ProducesResponseType(StatusCodes.Status400BadRequest)]
 		[ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -1026,10 +1058,14 @@ namespace Resgrid.Web.Services.Controllers.v4
 			if (input == null || String.IsNullOrWhiteSpace(input.Body))
 				return BadRequest();
 
+			var accessCheck = await CheckMessageChannelAccessAsync(messageId);
+			if (accessCheck != null)
+				return accessCheck;
+
 			if (await IsChatbotMessageChannelAsync(messageId))
 				return BadRequest("Messages can't be edited in assistant conversations.");
 
-			var message = await _chatMessageService.EditMessageAsync(messageId, UserId, input.Body, cancellationToken);
+			var message = await _chatMessageService.EditMessageAsync(DepartmentId, messageId, UserId, input.Body, cancellationToken);
 
 			if (message == null)
 				return BadRequest();
@@ -1049,6 +1085,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 		/// <param name="messageId">Chat message identifier</param>
 		/// <returns>ChatActionResult indicating whether the message was deleted</returns>
 		[HttpDelete("DeleteMessage")]
+		[Authorize(Policy = ResgridResources.Messages_Delete)]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		[ProducesResponseType(StatusCodes.Status404NotFound)]
 		public async Task<ActionResult<ChatActionResult>> DeleteMessage(string messageId, CancellationToken cancellationToken)
@@ -1056,11 +1093,15 @@ namespace Resgrid.Web.Services.Controllers.v4
 			if (!await ChatEnabledAsync())
 				return NotFound();
 
+			var accessCheck = await CheckMessageChannelAccessAsync(messageId);
+			if (accessCheck != null)
+				return accessCheck;
+
 			if (await IsChatbotMessageChannelAsync(messageId))
 				return BadRequest("Messages can't be deleted in assistant conversations.");
 
 			var result = new ChatActionResult();
-			result.Success = await _chatMessageService.DeleteMessageAsync(messageId, UserId, false, null, cancellationToken);
+			result.Success = await _chatMessageService.DeleteMessageAsync(DepartmentId, messageId, UserId, false, null, cancellationToken);
 			result.Status = result.Success ? ResponseHelper.Deleted : ResponseHelper.Failure;
 
 			ResponseHelper.PopulateV4ResponseData(result);
@@ -1078,6 +1119,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 		/// <param name="input">Emoji to react with</param>
 		/// <returns>ChatActionResult indicating whether the reaction was added</returns>
 		[HttpPost("AddReaction")]
+		[Authorize(Policy = ResgridResources.Messages_Create)]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		[ProducesResponseType(StatusCodes.Status400BadRequest)]
 		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -1104,7 +1146,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 				return BadRequest("Reactions aren't available in assistant conversations.");
 
 			var result = new ChatActionResult();
-			result.Success = await _chatMessageService.AddReactionAsync(messageId, UserId, null, input.Emoji, cancellationToken);
+			result.Success = await _chatMessageService.AddReactionAsync(DepartmentId, messageId, UserId, null, input.Emoji, cancellationToken);
 			result.Status = result.Success ? ResponseHelper.Created : ResponseHelper.Failure;
 
 			ResponseHelper.PopulateV4ResponseData(result);
@@ -1118,6 +1160,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 		/// <param name="emoji">Emoji to remove</param>
 		/// <returns>ChatActionResult indicating whether the reaction was removed</returns>
 		[HttpDelete("RemoveReaction")]
+		[Authorize(Policy = ResgridResources.Messages_Update)]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		[ProducesResponseType(StatusCodes.Status400BadRequest)]
 		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -1138,7 +1181,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 				return BadRequest("Reactions aren't available in assistant conversations.");
 
 			var result = new ChatActionResult();
-			result.Success = await _chatMessageService.RemoveReactionAsync(messageId, UserId, null, emoji, cancellationToken);
+			result.Success = await _chatMessageService.RemoveReactionAsync(DepartmentId, messageId, UserId, null, emoji, cancellationToken);
 			result.Status = result.Success ? ResponseHelper.Deleted : ResponseHelper.Failure;
 
 			ResponseHelper.PopulateV4ResponseData(result);
@@ -1151,6 +1194,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 		/// <param name="messageId">Chat message identifier</param>
 		/// <returns>ChatActionResult; Success is true when a pending acknowledgment was stamped</returns>
 		[HttpPost("Ack")]
+		[Authorize(Policy = ResgridResources.Messages_Update)]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
 		[ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -1164,7 +1208,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 				return accessCheck;
 
 			var result = new ChatActionResult();
-			var acknowledged = await _chatMessageService.AcknowledgeMessageAsync(messageId, UserId, cancellationToken);
+			var acknowledged = await _chatMessageService.AcknowledgeMessageAsync(DepartmentId, messageId, UserId, cancellationToken);
 
 			result.Success = acknowledged > 0;
 			result.Status = result.Success ? ResponseHelper.Success : ResponseHelper.NotFound;
@@ -1192,12 +1236,17 @@ namespace Resgrid.Web.Services.Controllers.v4
 			if (message == null || message.DepartmentId != DepartmentId)
 				return NotFound();
 
-			if (!String.Equals(message.SenderUserId, UserId, StringComparison.OrdinalIgnoreCase))
-			{
-				var channel = await _chatChannelService.GetChannelByIdAsync(message.ChatChannelId);
-				if (channel == null || !await _chatPermissionService.CanModerateChannelAsync(channel, UserId))
-					return Unauthorized();
-			}
+			var channel = await _chatChannelService.GetChannelByIdAsync(message.ChatChannelId);
+			if (channel == null || channel.DepartmentId != DepartmentId)
+				return NotFound();
+
+			var canModerate = await _chatPermissionService.CanModerateChannelAsync(channel, UserId);
+			var canAccess = await _chatPermissionService.CanAccessChannelAsync(channel, UserId, null);
+			if (!canAccess && !canModerate)
+				return Unauthorized();
+
+			if (!String.Equals(message.SenderUserId, UserId, StringComparison.OrdinalIgnoreCase) && !canModerate)
+				return Unauthorized();
 
 			var result = new GetChatAcksResult();
 			var acks = await _chatMessageService.GetAcksForMessageAsync(messageId);
@@ -1273,6 +1322,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 		/// <param name="input">Sequence read and optional unit identity</param>
 		/// <returns>ChatActionResult indicating whether the pointer advanced</returns>
 		[HttpPut("MarkRead")]
+		[Authorize(Policy = ResgridResources.Messages_Update)]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		[ProducesResponseType(StatusCodes.Status400BadRequest)]
 		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -1309,6 +1359,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 		/// <param name="messageId">Chat message identifier</param>
 		/// <returns>ChatActionResult indicating whether the message was pinned</returns>
 		[HttpPost("PinMessage")]
+		[Authorize(Policy = ResgridResources.Messages_Update)]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
 		[ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -1323,6 +1374,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 		/// <param name="messageId">Chat message identifier</param>
 		/// <returns>ChatActionResult indicating whether the message was unpinned</returns>
 		[HttpDelete("UnpinMessage")]
+		[Authorize(Policy = ResgridResources.Messages_Update)]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
 		[ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -1374,6 +1426,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 		/// <param name="file">The file being uploaded</param>
 		/// <returns>ChatAttachmentUploadedResult with the new attachment identifier</returns>
 		[HttpPost("UploadAttachment")]
+		[Authorize(Policy = ResgridResources.Messages_Create)]
 		[Consumes("multipart/form-data")]
 		[RequestSizeLimit(MaxAttachmentRequestBytes)]
 		[RequestFormLimits(MultipartBodyLengthLimit = MaxAttachmentRequestBytes)]
@@ -1419,7 +1472,8 @@ namespace Resgrid.Web.Services.Controllers.v4
 				return Unauthorized();
 
 			var message = await _chatMessageService.GetMessageByIdAsync(messageId);
-			if (message == null || message.ChatChannelId != channelId || !String.Equals(message.SenderUserId, UserId, StringComparison.OrdinalIgnoreCase))
+			if (message == null || message.DepartmentId != DepartmentId || message.ChatChannelId != channelId ||
+				message.DeletedOn.HasValue || !String.Equals(message.SenderUserId, UserId, StringComparison.OrdinalIgnoreCase))
 				return BadRequest();
 
 			byte[] data;
@@ -1483,7 +1537,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 				return NotFound();
 
 			var message = await _chatMessageService.GetMessageByIdAsync(attachment.ChatMessageId);
-			if (message == null || message.DeletedOn.HasValue)
+			if (message == null || message.DepartmentId != DepartmentId || message.ChatChannelId != attachment.ChatChannelId || message.DeletedOn.HasValue)
 				return NotFound();
 
 			var channel = await _chatChannelService.GetChannelByIdAsync(attachment.ChatChannelId);
@@ -1515,7 +1569,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 				return NotFound();
 
 			var message = await _chatMessageService.GetMessageByIdAsync(attachment.ChatMessageId);
-			if (message == null || message.DeletedOn.HasValue)
+			if (message == null || message.DepartmentId != DepartmentId || message.ChatChannelId != attachment.ChatChannelId || message.DeletedOn.HasValue)
 				return NotFound();
 
 			var channel = await _chatChannelService.GetChannelByIdAsync(attachment.ChatChannelId);
@@ -1657,6 +1711,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 		/// <param name="input">Reason and optional note for the flag</param>
 		/// <returns>ChatActionResult indicating whether the flag was recorded</returns>
 		[HttpPost("FlagMessage")]
+		[Authorize(Policy = ResgridResources.Messages_Create)]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		[ProducesResponseType(StatusCodes.Status400BadRequest)]
 		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -1692,9 +1747,10 @@ namespace Resgrid.Web.Services.Controllers.v4
 
 		#region Private Helpers
 
-		private Task<bool> ChatEnabledAsync()
+		private async Task<bool> ChatEnabledAsync()
 		{
-			return _featureToggleService.IsEnabledAsync(FeatureFlagKeys.ChatSystem, DepartmentId);
+			return await _authorizationService.IsUserValidWithinLimitsAsync(UserId, DepartmentId) &&
+				await _featureToggleService.IsEnabledAsync(FeatureFlagKeys.ChatSystem, DepartmentId);
 		}
 
 		/// <summary>
@@ -1744,11 +1800,13 @@ namespace Resgrid.Web.Services.Controllers.v4
 		private async Task<bool> IsChatbotMessageChannelAsync(string messageId)
 		{
 			var message = await _chatMessageService.GetMessageByIdAsync(messageId);
-			if (message == null)
+			if (message == null || message.DepartmentId != DepartmentId)
 				return false;
 
 			var channel = await _chatChannelService.GetChannelByIdAsync(message.ChatChannelId);
-			return channel != null && channel.ChannelType == (int)ChatChannelType.Chatbot;
+			return channel != null && channel.DepartmentId == DepartmentId &&
+				await _chatPermissionService.CanAccessChannelAsync(channel, UserId, null) &&
+				channel.ChannelType == (int)ChatChannelType.Chatbot;
 		}
 
 		/// <summary>
@@ -1788,7 +1846,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 				return Unauthorized();
 
 			var result = new ChatActionResult();
-			result.Success = await _chatMessageService.SetMessagePinnedAsync(messageId, UserId, pinned, cancellationToken);
+			result.Success = await _chatMessageService.SetMessagePinnedAsync(DepartmentId, messageId, UserId, pinned, cancellationToken);
 			result.Status = result.Success ? ResponseHelper.Updated : ResponseHelper.Failure;
 
 			ResponseHelper.PopulateV4ResponseData(result);
@@ -1913,58 +1971,6 @@ namespace Resgrid.Web.Services.Controllers.v4
 			}
 
 			return data;
-		}
-
-		private const int MaxDerivedGroupNameLength = 100;
-
-		// "Alice Smith, Bob Jones" from the invited members (creator excluded — matches how Slack labels
-		// unnamed group DMs). Falls back to "New group" only if no profile resolves.
-		private async Task<string> BuildGroupNameFromMembersAsync(List<string> memberUserIds)
-		{
-			var ids = memberUserIds?
-				.Where(id => !String.IsNullOrWhiteSpace(id) && !String.Equals(id, UserId, StringComparison.OrdinalIgnoreCase))
-				.Distinct(StringComparer.OrdinalIgnoreCase)
-				.ToList() ?? new List<string>();
-
-			var names = new List<string>();
-			if (ids.Count > 0)
-			{
-				var profiles = await _userProfileService.GetSelectedUserProfilesAsync(ids);
-				foreach (var profile in profiles ?? new List<UserProfile>())
-				{
-					var name = profile?.FullName?.AsFirstNameLastName;
-					if (!String.IsNullOrWhiteSpace(name))
-						names.Add(name);
-				}
-			}
-
-			if (names.Count == 0)
-				return "New group";
-
-			names.Sort(StringComparer.OrdinalIgnoreCase);
-
-			var joined = String.Join(", ", names);
-			if (joined.Length <= MaxDerivedGroupNameLength)
-				return joined;
-
-			// Too long: keep whole names and count the rest ("Alice Smith, Bob Jones +3").
-			var kept = new List<string>();
-			var length = 0;
-			foreach (var name in names)
-			{
-				var addition = (kept.Count == 0 ? 0 : 2) + name.Length;
-				if (length + addition + 6 > MaxDerivedGroupNameLength)
-					break;
-
-				kept.Add(name);
-				length += addition;
-			}
-
-			if (kept.Count == 0)
-				kept.Add(names[0].Length > MaxDerivedGroupNameLength - 6 ? names[0].Substring(0, MaxDerivedGroupNameLength - 6) : names[0]);
-
-			var remaining = names.Count - kept.Count;
-			return remaining > 0 ? $"{String.Join(", ", kept)} +{remaining}" : String.Join(", ", kept);
 		}
 
 		// DM channels have no stored Name; label each with the counterpart participant so multiple

--- a/Web/Resgrid.Web.Services/Controllers/v4/ChatModerationController.cs
+++ b/Web/Resgrid.Web.Services/Controllers/v4/ChatModerationController.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
@@ -13,6 +14,7 @@ using Resgrid.Model;
 using Resgrid.Model.Events;
 using Resgrid.Model.Providers;
 using Resgrid.Model.Services;
+using Resgrid.Providers.Claims;
 using Resgrid.Web.Services.Helpers;
 using Resgrid.Web.Services.Models.v4.Chat;
 using IAuthorizationService = Resgrid.Model.Services.IAuthorizationService;
@@ -26,6 +28,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 	[Route("api/v{VersionId:apiVersion}/[controller]")]
 	[ApiVersion("4.0")]
 	[ApiExplorerSettings(GroupName = "v4")]
+	[Authorize(Policy = ResgridResources.Messages_View)]
 	public class ChatModerationController : V4AuthenticatedApiControllerbase
 	{
 		#region Members and Constructors
@@ -100,7 +103,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 				return Unauthorized();
 
 			var result = new GetChatFlagsResult();
-			var flags = await _chatModerationService.GetFlagsAsync(DepartmentId, (ChatFlagStatus)status, page, pageSize);
+			var flags = await _chatModerationService.GetFlagsAsync(DepartmentId, UserId, (ChatFlagStatus)status, page, pageSize);
 
 			if (flags != null && flags.Any())
 			{
@@ -130,6 +133,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 		/// <param name="input">Resolution status and note</param>
 		/// <returns>ChatActionResult indicating whether the flag was resolved</returns>
 		[HttpPut("ResolveFlag")]
+		[Authorize(Policy = ResgridResources.Messages_Update)]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		[ProducesResponseType(StatusCodes.Status400BadRequest)]
 		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -182,6 +186,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 		/// <param name="reason">Reason for the deletion</param>
 		/// <returns>ChatActionResult indicating whether the message was deleted</returns>
 		[HttpDelete("DeleteMessage")]
+		[Authorize(Policy = ResgridResources.Messages_Delete)]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
 		[ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -205,7 +210,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 
 			try
 			{
-				result.Success = await _chatModerationService.ModeratorDeleteMessageAsync(messageId, UserId, reason, cancellationToken, BuildModerationContext("ChannelModerator"));
+				result.Success = await _chatModerationService.ModeratorDeleteMessageAsync(DepartmentId, messageId, UserId, reason, cancellationToken, BuildModerationContext("ChannelModerator"));
 			}
 			catch (UnauthorizedAccessException)
 			{
@@ -229,6 +234,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 		/// <param name="input">Target user and mute expiration (null MutedUntil = unmute)</param>
 		/// <returns>ChatActionResult indicating whether the mute was applied</returns>
 		[HttpPost("MuteUser")]
+		[Authorize(Policy = ResgridResources.Messages_Update)]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		[ProducesResponseType(StatusCodes.Status400BadRequest)]
 		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -255,7 +261,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 
 			try
 			{
-				result.Success = await _chatModerationService.SetUserMutedAsync(channelId, input.TargetUserId, input.MutedUntil, UserId, null, cancellationToken, BuildModerationContext("ChannelModerator"));
+				result.Success = await _chatModerationService.SetUserMutedAsync(DepartmentId, channelId, input.TargetUserId, input.MutedUntil, UserId, null, cancellationToken, BuildModerationContext("ChannelModerator"));
 			}
 			catch (UnauthorizedAccessException)
 			{
@@ -279,6 +285,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 		/// <param name="input">Target user and whether they are banned</param>
 		/// <returns>ChatActionResult indicating whether the ban was applied</returns>
 		[HttpPost("BanUser")]
+		[Authorize(Policy = ResgridResources.Messages_Update)]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		[ProducesResponseType(StatusCodes.Status400BadRequest)]
 		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -305,7 +312,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 
 			try
 			{
-				result.Success = await _chatModerationService.SetUserBannedAsync(channelId, input.TargetUserId, input.Banned, UserId, null, cancellationToken, BuildModerationContext("ChannelModerator"));
+				result.Success = await _chatModerationService.SetUserBannedAsync(DepartmentId, channelId, input.TargetUserId, input.Banned, UserId, null, cancellationToken, BuildModerationContext("ChannelModerator"));
 			}
 			catch (UnauthorizedAccessException)
 			{
@@ -329,6 +336,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 		/// <param name="input">Whether to lock and the reason</param>
 		/// <returns>ChatActionResult indicating whether the lock state was changed</returns>
 		[HttpPost("LockChannel")]
+		[Authorize(Policy = ResgridResources.Messages_Update)]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		[ProducesResponseType(StatusCodes.Status400BadRequest)]
 		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -355,7 +363,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 
 			try
 			{
-				result.Success = await _chatModerationService.SetChannelLockedAsync(channelId, input.Locked, UserId, input.Reason, cancellationToken, BuildModerationContext("ChannelModerator"));
+				result.Success = await _chatModerationService.SetChannelLockedAsync(DepartmentId, channelId, input.Locked, UserId, input.Reason, cancellationToken, BuildModerationContext("ChannelModerator"));
 			}
 			catch (UnauthorizedAccessException)
 			{
@@ -393,7 +401,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 				return Unauthorized();
 
 			var result = new GetChatModerationActionsResult();
-			var actions = await _chatModerationService.GetModerationActionsAsync(DepartmentId, channelId, page, pageSize);
+			var actions = await _chatModerationService.GetModerationActionsAsync(DepartmentId, UserId, channelId, page, pageSize);
 
 			if (actions != null && actions.Any())
 			{
@@ -461,6 +469,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 		/// <param name="input">New settings values</param>
 		/// <returns>GetChatSettingsResult with the saved settings</returns>
 		[HttpPut("UpdateSettings")]
+		[Authorize(Policy = ResgridResources.Messages_Update)]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		[ProducesResponseType(StatusCodes.Status400BadRequest)]
 		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -492,7 +501,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 			settings.ChatbotEnabled = input.ChatbotEnabled;
 
 			var result = new GetChatSettingsResult();
-			var saved = await _chatChannelService.SaveDepartmentSettingsAsync(settings, cancellationToken);
+			var saved = await _chatChannelService.SaveDepartmentSettingsAsync(DepartmentId, UserId, settings, cancellationToken);
 
 			if (saved != null)
 			{
@@ -705,7 +714,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 				return Unauthorized();
 
 			var result = new GetChatExportsResult();
-			var exports = await _chatModerationService.GetExportsAsync(DepartmentId);
+			var exports = await _chatModerationService.GetExportsAsync(DepartmentId, UserId);
 
 			if (exports != null && exports.Any())
 			{
@@ -775,9 +784,10 @@ namespace Resgrid.Web.Services.Controllers.v4
 
 		#region Private Helpers
 
-		private Task<bool> ChatEnabledAsync()
+		private async Task<bool> ChatEnabledAsync()
 		{
-			return _featureToggleService.IsEnabledAsync(FeatureFlagKeys.ChatSystem, DepartmentId);
+			return await _authorizationService.IsUserValidWithinLimitsAsync(UserId, DepartmentId) &&
+				await _featureToggleService.IsEnabledAsync(FeatureFlagKeys.ChatSystem, DepartmentId);
 		}
 
 		/// <summary>

--- a/Web/Resgrid.Web.Services/Controllers/v4/ChatModerationController.cs
+++ b/Web/Resgrid.Web.Services/Controllers/v4/ChatModerationController.cs
@@ -28,7 +28,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 	[Route("api/v{VersionId:apiVersion}/[controller]")]
 	[ApiVersion("4.0")]
 	[ApiExplorerSettings(GroupName = "v4")]
-	[Authorize(Policy = ResgridResources.Messages_View)]
+	[Authorize(Policy = ResgridResources.Chat_View)]
 	public class ChatModerationController : V4AuthenticatedApiControllerbase
 	{
 		#region Members and Constructors

--- a/Web/Resgrid.Web.Services/Controllers/v4/ChatbotController.cs
+++ b/Web/Resgrid.Web.Services/Controllers/v4/ChatbotController.cs
@@ -328,7 +328,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 		/// Gets (creating if needed) the caller's chatbot conversation channel.
 		/// </summary>
 		[HttpGet("GetChatChannel")]
-		[Authorize(Policy = ResgridResources.Messages_View)]
+		[Authorize(Policy = ResgridResources.Chat_View)]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		public async Task<ActionResult<ChatbotChannelResult>> GetChatChannel()
 		{
@@ -362,7 +362,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 		/// SignalR (chatMessageReceived). Idempotent via clientMessageId.
 		/// </summary>
 		[HttpPost("SendChatMessage")]
-		[Authorize(Policy = ResgridResources.Messages_View)]
+		[Authorize(Policy = ResgridResources.Chat_View)]
 		[Authorize(Policy = ResgridResources.Messages_Create)]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		public async Task<ActionResult<ChatbotMessageSentResult>> SendChatMessage([FromBody] ChatbotChatMessageRequest request)
@@ -449,7 +449,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 		/// Resets the chatbot conversational session (context/pending intents). Message history remains.
 		/// </summary>
 		[HttpPost("NewChatSession")]
-		[Authorize(Policy = ResgridResources.Messages_View)]
+		[Authorize(Policy = ResgridResources.Chat_View)]
 		[Authorize(Policy = ResgridResources.Messages_Create)]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		public async Task<ActionResult<ChatbotSessionResetResult>> NewChatSession()
@@ -502,7 +502,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 		/// not a bypass of it.
 		/// </summary>
 		[HttpPost("AskIncident")]
-		[Authorize(Policy = ResgridResources.Messages_View)]
+		[Authorize(Policy = ResgridResources.Chat_View)]
 		[Authorize(Policy = ResgridResources.Messages_Create)]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		[ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -560,7 +560,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 		/// can build these offline; this endpoint keeps a server-side department in sync with them.
 		/// </summary>
 		[HttpGet("IncidentSuggestions")]
-		[Authorize(Policy = ResgridResources.Messages_View)]
+		[Authorize(Policy = ResgridResources.Chat_View)]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		public async Task<ActionResult<IncidentAssistantSuggestionsResult>> IncidentSuggestions([FromQuery] int callId)
 		{

--- a/Web/Resgrid.Web.Services/Controllers/v4/ChatbotController.cs
+++ b/Web/Resgrid.Web.Services/Controllers/v4/ChatbotController.cs
@@ -12,6 +12,7 @@ using Resgrid.Chatbot.Services;
 using Resgrid.Framework;
 using Resgrid.Model;
 using Resgrid.Model.Services;
+using Resgrid.Providers.Claims;
 using Resgrid.Web.Services.Helpers;
 using Resgrid.Web.Services.Models.v4.Chat;
 using IAuthorizationService = Resgrid.Model.Services.IAuthorizationService;
@@ -327,6 +328,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 		/// Gets (creating if needed) the caller's chatbot conversation channel.
 		/// </summary>
 		[HttpGet("GetChatChannel")]
+		[Authorize(Policy = ResgridResources.Messages_View)]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		public async Task<ActionResult<ChatbotChannelResult>> GetChatChannel()
 		{
@@ -360,6 +362,8 @@ namespace Resgrid.Web.Services.Controllers.v4
 		/// SignalR (chatMessageReceived). Idempotent via clientMessageId.
 		/// </summary>
 		[HttpPost("SendChatMessage")]
+		[Authorize(Policy = ResgridResources.Messages_View)]
+		[Authorize(Policy = ResgridResources.Messages_Create)]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		public async Task<ActionResult<ChatbotMessageSentResult>> SendChatMessage([FromBody] ChatbotChatMessageRequest request)
 		{
@@ -375,7 +379,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 				if (channel == null)
 					return NotFound();
 
-				var message = await _chatMessageService.SendMessageAsync(UserId, new ChatMessageSendRequest
+				var message = await _chatMessageService.SendMessageAsync(DepartmentId, UserId, new ChatMessageSendRequest
 				{
 					ChatChannelId = channel.ChatChannelId,
 					DepartmentId = DepartmentId,
@@ -445,6 +449,8 @@ namespace Resgrid.Web.Services.Controllers.v4
 		/// Resets the chatbot conversational session (context/pending intents). Message history remains.
 		/// </summary>
 		[HttpPost("NewChatSession")]
+		[Authorize(Policy = ResgridResources.Messages_View)]
+		[Authorize(Policy = ResgridResources.Messages_Create)]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		public async Task<ActionResult<ChatbotSessionResetResult>> NewChatSession()
 		{
@@ -453,17 +459,19 @@ namespace Resgrid.Web.Services.Controllers.v4
 
 			try
 			{
+				var channel = await _chatChannelService.EnsureChatbotChannelAsync(DepartmentId, UserId);
+				if (channel == null)
+					return NotFound();
+
 				var session = await _chatbotSessionManager.GetOrCreateSessionAsync(UserId, DepartmentId, Resgrid.Chatbot.Models.ChatbotPlatform.WebChat, UserId);
 				if (session != null)
 					await _chatbotSessionManager.EndSessionAsync(session.SessionId);
 
 				// Visible confirmation in the conversation (fans out over SignalR to every client);
 				// without it the reset is silent and looks like the button did nothing.
-				var channel = await _chatChannelService.EnsureChatbotChannelAsync(DepartmentId, UserId);
-				if (channel != null)
-					await _chatMessageService.SendBotMessageAsync(channel.ChatChannelId,
-						DepartmentId.ToString(System.Globalization.CultureInfo.InvariantCulture),
-						"Starting a new conversation — your previous context has been cleared.", "Resgrid Assistant");
+				await _chatMessageService.SendBotMessageAsync(channel.ChatChannelId,
+					DepartmentId.ToString(System.Globalization.CultureInfo.InvariantCulture),
+					"Starting a new conversation — your previous context has been cleared.", "Resgrid Assistant");
 
 				var result = new ChatbotSessionResetResult
 				{
@@ -494,6 +502,8 @@ namespace Resgrid.Web.Services.Controllers.v4
 		/// not a bypass of it.
 		/// </summary>
 		[HttpPost("AskIncident")]
+		[Authorize(Policy = ResgridResources.Messages_View)]
+		[Authorize(Policy = ResgridResources.Messages_Create)]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		[ProducesResponseType(StatusCodes.Status400BadRequest)]
 		public async Task<ActionResult<IncidentAssistantAnswerResult>> AskIncident([FromBody] AskIncidentAssistantInput input)
@@ -550,6 +560,7 @@ namespace Resgrid.Web.Services.Controllers.v4
 		/// can build these offline; this endpoint keeps a server-side department in sync with them.
 		/// </summary>
 		[HttpGet("IncidentSuggestions")]
+		[Authorize(Policy = ResgridResources.Messages_View)]
 		[ProducesResponseType(StatusCodes.Status200OK)]
 		public async Task<ActionResult<IncidentAssistantSuggestionsResult>> IncidentSuggestions([FromQuery] int callId)
 		{
@@ -598,6 +609,9 @@ namespace Resgrid.Web.Services.Controllers.v4
 
 		private async Task<bool> ChatbotChatEnabledAsync()
 		{
+			if (!await _authorizationService.IsUserValidWithinLimitsAsync(UserId, DepartmentId))
+				return false;
+
 			if (!await _featureToggleService.IsEnabledAsync(FeatureFlagKeys.ChatSystem, DepartmentId))
 				return false;
 

--- a/Web/Resgrid.Web.Services/Startup.cs
+++ b/Web/Resgrid.Web.Services/Startup.cs
@@ -312,7 +312,7 @@ namespace Resgrid.Web.ServicesCore
 				options.AddPolicy(ResgridResources.UnitLog_Create, policy => policy.RequireClaim(ResgridClaimTypes.Resources.UnitLog, ResgridClaimTypes.Actions.Create));
 				options.AddPolicy(ResgridResources.UnitLog_Delete, policy => policy.RequireClaim(ResgridClaimTypes.Resources.UnitLog, ResgridClaimTypes.Actions.Delete));
 
-				options.AddPolicy(ResgridResources.Messages_View, policy => policy.RequireClaim(ResgridClaimTypes.Resources.Messages, ResgridClaimTypes.Actions.View));
+				options.AddPolicy(ResgridResources.Messages_View, policy => policy.RequireChatAccessClaims());
 				options.AddPolicy(ResgridResources.Messages_Update, policy => policy.RequireClaim(ResgridClaimTypes.Resources.Messages, ResgridClaimTypes.Actions.Update));
 				options.AddPolicy(ResgridResources.Messages_Create, policy => policy.RequireClaim(ResgridClaimTypes.Resources.Messages, ResgridClaimTypes.Actions.Create));
 				options.AddPolicy(ResgridResources.Messages_Delete, policy => policy.RequireClaim(ResgridClaimTypes.Resources.Messages, ResgridClaimTypes.Actions.Delete));

--- a/Web/Resgrid.Web.Services/Startup.cs
+++ b/Web/Resgrid.Web.Services/Startup.cs
@@ -312,7 +312,8 @@ namespace Resgrid.Web.ServicesCore
 				options.AddPolicy(ResgridResources.UnitLog_Create, policy => policy.RequireClaim(ResgridClaimTypes.Resources.UnitLog, ResgridClaimTypes.Actions.Create));
 				options.AddPolicy(ResgridResources.UnitLog_Delete, policy => policy.RequireClaim(ResgridClaimTypes.Resources.UnitLog, ResgridClaimTypes.Actions.Delete));
 
-				options.AddPolicy(ResgridResources.Messages_View, policy => policy.RequireChatAccessClaims());
+				options.AddPolicy(ResgridResources.Messages_View, policy => policy.RequireClaim(ResgridClaimTypes.Resources.Messages, ResgridClaimTypes.Actions.View));
+				options.AddPolicy(ResgridResources.Chat_View, policy => policy.RequireChatAccessClaims());
 				options.AddPolicy(ResgridResources.Messages_Update, policy => policy.RequireClaim(ResgridClaimTypes.Resources.Messages, ResgridClaimTypes.Actions.Update));
 				options.AddPolicy(ResgridResources.Messages_Create, policy => policy.RequireClaim(ResgridClaimTypes.Resources.Messages, ResgridClaimTypes.Actions.Create));
 				options.AddPolicy(ResgridResources.Messages_Delete, policy => policy.RequireClaim(ResgridClaimTypes.Resources.Messages, ResgridClaimTypes.Actions.Delete));

--- a/Web/Resgrid.Web/Areas/User/Apps/src/components/chat/chatHub.ts
+++ b/Web/Resgrid.Web/Areas/User/Apps/src/components/chat/chatHub.ts
@@ -80,6 +80,7 @@ class ChatHub {
   private joinedChannels = new Map<string, number | undefined>();
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
   private channelsRefreshHandlers = new Set<() => void>();
+  private authorizationRefreshPromise: Promise<void> | null = null;
 
   public subscribeChannelsRefresh(handler: () => void): () => void {
     this.channelsRefreshHandlers.add(handler);
@@ -207,13 +208,13 @@ class ChatHub {
       }
     });
     connection.on(CHAT_HUB_EVENTS.ChannelUpdated, () => {
-      this.notifyChannelsRefresh();
+      void this.refreshChannelAuthorizations();
     });
     connection.on(CHAT_HUB_EVENTS.ChannelProvisioned, () => {
-      this.notifyChannelsRefresh();
+      void this.refreshChannelAuthorizations();
     });
     connection.on(CHAT_HUB_EVENTS.ModerationApplied, () => {
-      this.notifyChannelsRefresh();
+      void this.refreshChannelAuthorizations();
     });
     connection.on(CHAT_HUB_EVENTS.AccessRevoked, (arg: unknown) => {
       const payload = parsePayload<HubAccessRevokedPayload>(arg);
@@ -279,6 +280,31 @@ class ChatHub {
       this.notifyChannelsRefresh();
     } catch (error) {
       console.error('Chat hub reconnect sync failed.', error);
+    }
+  }
+
+  // Channel SignalR groups are authorization-epoch scoped. Membership/rule/moderation and
+  // incident-board changes rotate the epoch server-side before the refresh hint is broadcast;
+  // rejoining here performs a fresh server authorization check and moves eligible connections
+  // into the new group. A forged/stale client that ignores the hint stays in an obsolete group.
+  private async refreshChannelAuthorizations(): Promise<void> {
+    if (this.authorizationRefreshPromise) {
+      return this.authorizationRefreshPromise;
+    }
+
+    this.authorizationRefreshPromise = (async () => {
+      if (this.connection && this.connection.state === HubConnectionState.Connected) {
+        for (const [channelId, asUnitId] of this.joinedChannels.entries()) {
+          await this.invokeJoin(channelId, asUnitId);
+        }
+      }
+      this.notifyChannelsRefresh();
+    })();
+
+    try {
+      await this.authorizationRefreshPromise;
+    } finally {
+      this.authorizationRefreshPromise = null;
     }
   }
 

--- a/Web/Resgrid.Web/Areas/User/Apps/src/components/chat/chatHub.ts
+++ b/Web/Resgrid.Web/Areas/User/Apps/src/components/chat/chatHub.ts
@@ -207,14 +207,14 @@ class ChatHub {
         addPendingAck(payload.ChatMessageId);
       }
     });
-    connection.on(CHAT_HUB_EVENTS.ChannelUpdated, () => {
-      void this.refreshChannelAuthorizations();
+    connection.on(CHAT_HUB_EVENTS.ChannelUpdated, (arg: unknown) => {
+      this.refreshChannelAuthorizationFromPayload(arg);
     });
-    connection.on(CHAT_HUB_EVENTS.ChannelProvisioned, () => {
-      void this.refreshChannelAuthorizations();
+    connection.on(CHAT_HUB_EVENTS.ChannelProvisioned, (arg: unknown) => {
+      this.refreshChannelAuthorizationFromPayload(arg);
     });
-    connection.on(CHAT_HUB_EVENTS.ModerationApplied, () => {
-      void this.refreshChannelAuthorizations();
+    connection.on(CHAT_HUB_EVENTS.ModerationApplied, (arg: unknown) => {
+      this.refreshChannelAuthorizationFromPayload(arg);
     });
     connection.on(CHAT_HUB_EVENTS.AccessRevoked, (arg: unknown) => {
       const payload = parsePayload<HubAccessRevokedPayload>(arg);
@@ -283,6 +283,25 @@ class ChatHub {
     }
   }
 
+  private refreshChannelAuthorizationFromPayload(arg: unknown): void {
+    const source = parsePayload<Record<string, unknown>>(arg);
+    const channelId = source ? pick<string>(source, 'chatChannelId', 'ChatChannelId')?.trim() : undefined;
+
+    if (channelId) {
+      void this.refreshChannelAuthorization(channelId);
+      return;
+    }
+
+    void this.refreshChannelAuthorizations();
+  }
+
+  private async refreshChannelAuthorization(channelId: string): Promise<void> {
+    if (this.joinedChannels.has(channelId)) {
+      await this.joinChannel(channelId, this.joinedChannels.get(channelId));
+    }
+    this.notifyChannelsRefresh();
+  }
+
   // Channel SignalR groups are authorization-epoch scoped. Membership/rule/moderation and
   // incident-board changes rotate the epoch server-side before the refresh hint is broadcast;
   // rejoining here performs a fresh server authorization check and moves eligible connections
@@ -295,7 +314,17 @@ class ChatHub {
     this.authorizationRefreshPromise = (async () => {
       if (this.connection && this.connection.state === HubConnectionState.Connected) {
         for (const [channelId, asUnitId] of this.joinedChannels.entries()) {
-          await this.invokeJoin(channelId, asUnitId);
+          try {
+            await this.invokeJoin(channelId, asUnitId, true);
+          } catch (err) {
+            console.error('invokeJoin failed during authorization refresh', {
+              op: 'refreshChannelAuthorizations',
+              channelId,
+              asUnitId,
+              err,
+            });
+            throw err;
+          }
         }
       }
       this.notifyChannelsRefresh();
@@ -347,7 +376,11 @@ class ChatHub {
     }, HEARTBEAT_INTERVAL_MS);
   }
 
-  private async invokeJoin(channelId: string, asUnitId: number | undefined): Promise<void> {
+  private async invokeJoin(
+    channelId: string,
+    asUnitId: number | undefined,
+    throwOnError = false,
+  ): Promise<void> {
     if (!this.connection || this.connection.state !== HubConnectionState.Connected) {
       return;
     }
@@ -355,6 +388,9 @@ class ChatHub {
       await this.connection.invoke(CHAT_HUB_METHODS.JoinChannel, channelId, asUnitId ?? null);
     } catch (error) {
       console.error('Chat join channel failed.', error);
+      if (throwOnError) {
+        throw error;
+      }
     }
   }
 

--- a/Web/Resgrid.Web/Areas/User/Controllers/SecurityController.cs
+++ b/Web/Resgrid.Web/Areas/User/Controllers/SecurityController.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Threading;
@@ -450,23 +451,62 @@ namespace Resgrid.Web.Areas.User.Controllers
 
 		public async Task<IActionResult> GetAuditLogsList()
 		{
+			if (!ClaimsAuthorizationHelper.IsUserDepartmentAdmin())
+				return Unauthorized();
+
 			var auditLogsJson = new List<AuditLogJson>();
 			var auditLogs = await _auditService.GetAllAuditLogsForDepartmentAsync(DepartmentId);
 			var department = await _departmentsService.GetDepartmentByIdAsync(DepartmentId, false);
+			var personnelNames = await _departmentsService.GetAllPersonnelNamesForDepartmentAsync(DepartmentId);
+			var users = await _departmentsService.GetAllUsersForDepartmentAsync(DepartmentId, true);
+			var personnelNamesByUserId = personnelNames
+				.Where(x => x != null && !String.IsNullOrWhiteSpace(x.UserId))
+				.GroupBy(x => x.UserId, StringComparer.OrdinalIgnoreCase)
+				.ToDictionary(x => x.Key, x => x.First(), StringComparer.OrdinalIgnoreCase);
+			var usersByUserId = users
+				.Where(x => x != null && !String.IsNullOrWhiteSpace(x.UserId))
+				.GroupBy(x => x.UserId, StringComparer.OrdinalIgnoreCase)
+				.ToDictionary(x => x.Key, x => x.First(), StringComparer.OrdinalIgnoreCase);
 
 			foreach (var auditLog in auditLogs)
 			{
 				var auditJson = new AuditLogJson();
 				auditJson.AuditLogId = auditLog.AuditLogId;
-				//auditJson.Name = UserHelper.GetFullNameForUser(null, auditLog.UserId);
+				personnelNamesByUserId.TryGetValue(auditLog.UserId ?? String.Empty, out var personName);
+				usersByUserId.TryGetValue(auditLog.UserId ?? String.Empty, out var user);
+				auditJson.Name = personName != null && !String.IsNullOrWhiteSpace(personName.Name)
+					? personName.Name
+					: (!String.IsNullOrWhiteSpace(auditLog.UserId) ? auditLog.UserId : "System");
 				auditJson.Message = auditLog.Message;
+				auditJson.Successful = auditLog.Successful;
 
 				if (auditLog.LoggedOn.HasValue)
+				{
 					auditJson.Timestamp = auditLog.LoggedOn.Value.TimeConverterToString(department);
+					auditJson.TimestampSort = auditLog.LoggedOn.Value.Ticks / TimeSpan.TicksPerMillisecond;
+				}
 				else
 					auditJson.Timestamp = "Unknown";
 
 				auditJson.Type = _auditService.GetAuditLogTypeString((AuditLogTypes)auditLog.LogType);
+				auditJson.SearchTerms = String.Join(" ", new[]
+				{
+					auditJson.Name,
+					auditLog.UserId,
+					user?.UserName,
+					user?.Email,
+					auditLog.AuditLogId.ToString(CultureInfo.InvariantCulture),
+					auditLog.DepartmentId.ToString(CultureInfo.InvariantCulture),
+					auditLog.LogType.ToString(CultureInfo.InvariantCulture),
+					auditLog.ObjectId,
+					auditLog.ObjectDepartmentId.ToString(CultureInfo.InvariantCulture),
+					auditLog.IpAddress,
+					auditLog.ServerName,
+					auditJson.Timestamp,
+					auditLog.LoggedOn?.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture),
+					auditJson.Type,
+					((AuditLogTypes)auditLog.LogType).ToString()
+				}.Where(x => !String.IsNullOrWhiteSpace(x)));
 
 				auditLogsJson.Add(auditJson);
 			}
@@ -479,14 +519,20 @@ namespace Resgrid.Web.Areas.User.Controllers
 			if (!ClaimsAuthorizationHelper.IsUserDepartmentAdmin())
 				return Unauthorized();
 
-			var model = new ViewAuditLogView();
-			model.AuditLog = await _auditService.GetAuditLogByIdAsync(auditLogId);
-			model.Department = await _departmentsService.GetDepartmentByIdAsync(DepartmentId);
-			model.Type = (AuditLogTypes)model.AuditLog.LogType;
+			var auditLog = await _auditService.GetAuditLogByIdAsync(auditLogId);
+			if (auditLog == null)
+				return NotFound();
 
-			if (model.AuditLog.DepartmentId != DepartmentId)
+			if (auditLog.DepartmentId != DepartmentId)
 				return Unauthorized();
 
+			var model = new ViewAuditLogView
+			{
+				AuditLog = auditLog,
+				Department = await _departmentsService.GetDepartmentByIdAsync(DepartmentId),
+				Type = (AuditLogTypes)auditLog.LogType,
+				TypeName = _auditService.GetAuditLogTypeString((AuditLogTypes)auditLog.LogType)
+			};
 
 			return View(model);
 		}

--- a/Web/Resgrid.Web/Areas/User/Models/Security/AuditLogJson.cs
+++ b/Web/Resgrid.Web/Areas/User/Models/Security/AuditLogJson.cs
@@ -5,7 +5,10 @@
 		public int AuditLogId { get; set; }
 		public string Type { get; set; }
 		public string Timestamp { get; set; }
+		public long? TimestampSort { get; set; }
 		public string Name { get; set; }
 		public string Message { get; set; }
+		public bool Successful { get; set; }
+		public string SearchTerms { get; set; }
 	}
 }

--- a/Web/Resgrid.Web/Areas/User/Models/Security/ViewAuditLogView.cs
+++ b/Web/Resgrid.Web/Areas/User/Models/Security/ViewAuditLogView.cs
@@ -7,5 +7,6 @@ namespace Resgrid.Web.Areas.User.Models.Security
 		public AuditLog AuditLog {get;set;}
 		public Department Department {get;set;}
 		public AuditLogTypes Type {get;set;}
+		public string TypeName { get; set; }
 	}
 }

--- a/Web/Resgrid.Web/Areas/User/Views/Security/Audits.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Security/Audits.cshtml
@@ -32,7 +32,23 @@
             </div>
           </div>
           <div class="ibox-content">
-            <table id="auditLogsList" class="table table-striped table-hover"></table>
+            <div class="row m-b-md">
+              <div class="col-md-5">
+                <label for="auditLogTypeFilter">Filter by audit type</label>
+                <select id="auditLogTypeFilter" class="form-control">
+                  <option value="">All audit types</option>
+                </select>
+              </div>
+              <div class="col-md-7">
+                <p class="help-block m-t-lg">
+                  Search by user name, user or audit ID, email address, date/time, or audit type.
+                  Search and sorting apply within the selected audit type.
+                </p>
+              </div>
+            </div>
+            <div class="table-responsive">
+              <table id="auditLogsList" class="table table-striped table-hover"></table>
+            </div>
           </div>
         </div>
       </div>

--- a/Web/Resgrid.Web/Areas/User/Views/Security/ViewAudit.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Security/ViewAudit.cshtml
@@ -1,10 +1,30 @@
 @model Resgrid.Web.Areas.User.Models.Security.ViewAuditLogView
+@functions {
+  public string DisplayValue(string value)
+  {
+    return String.IsNullOrWhiteSpace(value) ? "Not recorded" : value;
+  }
+}
 @{
   ViewBag.Title = "Resgrid | View Audit Log";
+  var loggedBy = await UserHelper.GetFullNameForUser(Model.AuditLog.UserId);
+  if (String.IsNullOrWhiteSpace(loggedBy))
+  {
+    loggedBy = "Not recorded";
+  }
 }
 @section Styles
 {
-
+  <style>
+    .audit-log-value {
+      margin: 0;
+      max-height: 24rem;
+      overflow: auto;
+      padding: 0.75rem;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+  </style>
 }
 
 <div class="row wrapper border-bottom white-bg page-heading">
@@ -38,53 +58,142 @@
         </div>
         <div class="ibox-content">
           <div class="row">
-            <div class="col-lg-12">
+            <div class="col-lg-6">
+              <dl class="dl-horizontal">
+                <dt>Audit Log ID:</dt>
+                <dd>@Model.AuditLog.AuditLogId</dd>
+              </dl>
+            </div>
+            <div class="col-lg-6">
+              <dl class="dl-horizontal">
+                <dt>Department ID:</dt>
+                <dd>@Model.AuditLog.DepartmentId</dd>
+              </dl>
+            </div>
+          </div>
+          <div class="row">
+            <div class="col-lg-6">
               <dl class="dl-horizontal">
                 <dt>Audit Type:</dt>
                 <dd>@Model.Type.ToString()</dd>
               </dl>
             </div>
+            <div class="col-lg-6">
+              <dl class="dl-horizontal">
+                <dt>Log Type ID:</dt>
+                <dd>@Model.AuditLog.LogType</dd>
+              </dl>
+            </div>
           </div>
           <div class="row">
-            <div class="col-lg-12">
+            <div class="col-lg-6">
+              <dl class="dl-horizontal">
+                <dt>Type Description:</dt>
+                <dd>@DisplayValue(Model.TypeName)</dd>
+              </dl>
+            </div>
+            <div class="col-lg-6">
+              <dl class="dl-horizontal">
+                <dt>Result:</dt>
+                <dd>
+                  @if (Model.AuditLog.Successful)
+                  {
+                    <span class="label label-success">Successful</span>
+                  }
+                  else
+                  {
+                    <span class="label label-danger">Failed</span>
+                  }
+                </dd>
+              </dl>
+            </div>
+          </div>
+          <div class="row">
+            <div class="col-lg-6">
               <dl class="dl-horizontal">
                 <dt>Logged By:</dt>
-                <dd>@(await UserHelper.GetFullNameForUser(Model.AuditLog.UserId))</dd>
+                <dd>@loggedBy</dd>
+              </dl>
+            </div>
+            <div class="col-lg-6">
+              <dl class="dl-horizontal">
+                <dt>User ID:</dt>
+                <dd>@DisplayValue(Model.AuditLog.UserId)</dd>
+              </dl>
+            </div>
+          </div>
+          <div class="row">
+            <div class="col-lg-6">
+              <dl class="dl-horizontal">
+                <dt>Logged On (Local):</dt>
+                <dd>@(Model.AuditLog.LoggedOn.HasValue ? Model.AuditLog.LoggedOn.Value.TimeConverterToString(Model.Department) : "Unknown")</dd>
+              </dl>
+            </div>
+            <div class="col-lg-6">
+              <dl class="dl-horizontal">
+                <dt>Logged On (UTC):</dt>
+                <dd>
+                  @if (Model.AuditLog.LoggedOn.HasValue)
+                  {
+                    @DateTime.SpecifyKind(Model.AuditLog.LoggedOn.Value, DateTimeKind.Utc).ToString("yyyy-MM-dd HH:mm:ss.fffffff 'UTC'")
+                  }
+                  else
+                  {
+                    @:Unknown
+                  }
+                </dd>
+              </dl>
+            </div>
+          </div>
+          <div class="row">
+            <div class="col-lg-6">
+              <dl class="dl-horizontal">
+                <dt>IP Address:</dt>
+                <dd>@DisplayValue(Model.AuditLog.IpAddress)</dd>
+              </dl>
+            </div>
+            <div class="col-lg-6">
+              <dl class="dl-horizontal">
+                <dt>Server Name:</dt>
+                <dd>@DisplayValue(Model.AuditLog.ServerName)</dd>
+              </dl>
+            </div>
+          </div>
+          <div class="row">
+            <div class="col-lg-6">
+              <dl class="dl-horizontal">
+                <dt>Object ID:</dt>
+                <dd>@DisplayValue(Model.AuditLog.ObjectId)</dd>
+              </dl>
+            </div>
+            <div class="col-lg-6">
+              <dl class="dl-horizontal">
+                <dt>Object Department ID:</dt>
+                <dd>@Model.AuditLog.ObjectDepartmentId</dd>
               </dl>
             </div>
           </div>
           <div class="row">
             <div class="col-lg-12">
               <dl class="dl-horizontal">
-                <dt>Logged On:</dt>
-                @if (Model.AuditLog.LoggedOn.HasValue)
-                {
-                  <dd>@Model.AuditLog.LoggedOn.Value.TimeConverterToString(Model.Department)</dd>
-                }
-                else
-                {
-                  <dd>Unknown</dd>
-                }
+                <dt>User Agent:</dt>
+                <dd>@DisplayValue(Model.AuditLog.UserAgent)</dd>
               </dl>
             </div>
           </div>
           <div class="row">
             <div class="col-lg-12">
-              <dl class="dl-horizontal">
+              <dl>
                 <dt>Message:</dt>
-                <dd>
-                  @Model.AuditLog.Message
-                </dd>
+                <dd><pre class="audit-log-value">@DisplayValue(Model.AuditLog.Message)</pre></dd>
               </dl>
             </div>
           </div>
           <div class="row">
             <div class="col-lg-12">
-              <dl class="dl-horizontal">
+              <dl>
                 <dt>Data:</dt>
-                <dd>
-                  @Model.AuditLog.Data
-                </dd>
+                <dd><pre class="audit-log-value">@DisplayValue(Model.AuditLog.Data)</pre></dd>
               </dl>
             </div>
           </div>

--- a/Web/Resgrid.Web/wwwroot/js/app/internal/security/resgrid.security.audits.js
+++ b/Web/Resgrid.Web/wwwroot/js/app/internal/security/resgrid.security.audits.js
@@ -7,12 +7,29 @@ var resgrid;
             $(document).ready(function () {
                 resgrid.common.analytics.track('Security Audits');
 
+                var textRenderer = $.fn.dataTable.render.text();
                 var table = $("#auditLogsList").DataTable({
                     ajax: {
                         url: resgrid.absoluteBaseUrl + '/User/Security/GetAuditLogsList',
                         dataSrc: ''
                     },
                     pageLength: 50,
+                    order: [[1, 'desc']],
+                    language: {
+                        search: 'Search audit logs:',
+                        searchPlaceholder: 'Name, ID, email, date/time, or type'
+                    },
+                    initComplete: function () {
+                        var api = this.api();
+                        var typeColumn = api.column('auditType:name');
+                        var typeFilter = $('#auditLogTypeFilter');
+
+                        typeColumn.data().unique().sort().each(function (type) {
+                            if (type) {
+                                $('<option>').val(type).text(type).appendTo(typeFilter);
+                            }
+                        });
+                    },
                     columns: [
                         {
                             data: 'AuditLogId',
@@ -23,9 +40,48 @@ var resgrid;
                                 return '<input type="checkbox" id="selectAuditLog_' + data + '" name="selectAuditLog_' + data + '" />';
                             }
                         },
-                        { data: 'Timestamp', title: 'Timestamp' },
-                        { data: 'Type', title: 'Type' },
-                        { data: 'Message', title: 'Message' },
+                        {
+                            data: 'Timestamp',
+                            title: 'Timestamp',
+                            render: function (data, type, row) {
+                                if (type === 'sort' || type === 'type') {
+                                    return row.TimestampSort == null ? -1 : row.TimestampSort;
+                                }
+
+                                if (type === 'display' || type === 'filter') {
+                                    return textRenderer[type](data);
+                                }
+
+                                return data;
+                            }
+                        },
+                        { data: 'Type', name: 'auditType', title: 'Type', render: textRenderer },
+                        { data: 'Name', title: 'Logged By', render: textRenderer },
+                        {
+                            data: 'Successful',
+                            title: 'Result',
+                            render: function (data, type) {
+                                if (type === 'display') {
+                                    return data
+                                        ? '<span class="label label-success">Successful</span>'
+                                        : '<span class="label label-danger">Failed</span>';
+                                }
+
+                                if (type === 'filter') {
+                                    return data ? 'Successful' : 'Failed';
+                                }
+
+                                return data ? 1 : 0;
+                            }
+                        },
+                        { data: 'Message', title: 'Message', render: textRenderer },
+                        {
+                            data: 'SearchTerms',
+                            title: 'Search Terms',
+                            visible: false,
+                            searchable: true,
+                            orderable: false
+                        },
                         {
                             data: 'AuditLogId',
                             title: 'Actions',
@@ -44,6 +100,13 @@ var resgrid;
 
                 $(document).on('click', '#checkAllAuditLogs', function () {
                     $('#auditLogsList tbody :checkbox').prop('checked', this.checked);
+                });
+
+                $('#auditLogTypeFilter').on('change', function () {
+                    var selectedType = $.fn.dataTable.util.escapeRegex($(this).val());
+                    table.column('auditType:name')
+                        .search(selectedType ? '^' + selectedType + '$' : '', true, false)
+                        .draw();
                 });
             });
         })(audits = security.audits || (security.audits = {}));

--- a/Workers/Resgrid.Workers.Framework/Logic/SystemQueueLogic.cs
+++ b/Workers/Resgrid.Workers.Framework/Logic/SystemQueueLogic.cs
@@ -82,6 +82,9 @@ namespace Resgrid.Workers.Framework.Logic
 								await pushService.UnRegisterUnit(pushUri);
 								var unitResult = await pushService.RegisterUnit(pushUri);
 
+								if (!unitResult)
+									Logging.LogError($"UnitPushRegistration failed for unit {unitData.UnitId} (platform {unitData.PlatformType}, prefix '{unitData.PushLocation}').");
+
 								pushService = null;
 							}
 						}


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary
This pull request hardens the chat system’s authorization and tenant-boundary enforcement across REST APIs, SignalR, channel management, messaging, moderation, and permission caching, while also improving audit log visibility and fixing unit push registration reliability.

## What changed

### Chat authorization and tenant hardening
- Added a dedicated `Chat_View` authorization policy and applied it to chat-related controllers and the SignalR chat hub.
- Tightened hub authentication by requiring valid JWT issuer validation and closing chat connections when authentication expires.
- Added stricter claim requirements for chat access, including authenticated user identity and a valid department context.
- Ensured chat-enabled checks also verify the user is currently valid within department limits, with short-lived caching.

### Server-side enforcement of chat permissions
- Shifted many chat operations from caller-trusted authorization to service-enforced authorization.
- Updated channel, message, and moderation service methods to require authenticated `departmentId` and `userId` inputs and to validate them internally.
- Prevented cross-department access by rechecking that channels, messages, members, rules, units, calls, and assignments all belong to the authenticated department before acting.
- Added active-department-user validation so disabled or invalid users cannot access or create chat resources.

### Channel access and membership fixes
- Hardened channel listing so stale membership rows no longer keep channels visible after access is lost.
- Revalidated access for unit-based, incident-based, and implicit membership channels before returning them.
- Restricted direct messages, ad hoc groups, custom channels, chatbot channels, and department settings to active department members, with admin enforcement where required.
- Prevented unsupported member additions to non-supported channel types and enforced actor membership/moderator authority when adding or removing members.
- Ensured member lists only return rows from the correct department.
- Added automatic naming for unnamed ad hoc group channels based on member names, with length limits.

### Incident and operational channel permission changes
- Added explicit checks for incident access based on current assignment or dispatch rather than stale membership alone.
- Added support for determining whether a user may access department operational channels.
- Tightened incident commander line creation so only currently involved users can create or access those channels, including unit-identity validation.
- Reworked incident/command/lane audience resolution to remove unauthorized users immediately when assignments, lane roles, or command roles change.

### Message and moderation security hardening
- Message mutations now independently verify tenant scope and current permissions instead of trusting client-supplied context.
- Editing, deleting, reacting, pinning, and acknowledging messages now validate the authenticated department and current channel access.
- Moderator deletes now revalidate moderator authority rather than trusting a caller flag.
- Reactions and acknowledgements are blocked when the user no longer has access or when acting as an unauthorized unit.
- Moderation actions now enforce department-admin or moderator rights internally for flags, deletes, mutes, bans, locks, exports, and settings updates.
- Moderation target handling was improved so existing banned/muted members can still be updated even if they no longer currently have channel access.

### Permission caching and realtime authorization refresh
- Changed permission caching behavior to cache negative access results only, avoiding stale cached allows after access is revoked.
- Added a channel access version/epoch used to isolate SignalR channel groups after authorization changes.
- SignalR channel groups now include an authorization version, so permission changes move clients to new groups and old groups stop receiving future chat events.
- Added refresh handling for department security changes, dispatch permission changes, and incident command changes to invalidate chat authorization caches and notify clients to refresh channel access.
- Updated the web chat client to rejoin channels when authorization-related chat events are received.

### Audit log fixes and improvements
- Improved the user security audit list with:
  - sortable timestamps,
  - success/failure status,
  - user display names,
  - richer search terms,
  - audit-type filtering.
- Improved individual audit log detail pages with fuller metadata, friendly type names, better field rendering, and clearer missing-value handling.
- Added authorization checks and missing-record handling for audit log views.

### Push registration and chatbot webhook fixes
- Fixed unit push registration so unit subscribers are created in Novu before credentials are written.
- Added stronger logging around failed unit push registration and failed Novu subscriber creation.
- Treated Novu subscriber conflicts as a valid existing-subscriber state instead of a failure.
- Hardened the Telegram chatbot webhook to fail closed when no secret is configured and to reject requests with invalid secrets.

### Supporting fixes
- Updated cache provider async retrieval to support non-reference types correctly and added serialization coverage for booleans.
- Added extra validation around moderation evidence attachment loading to ensure attachment/message/channel/department consistency.

## Functional impact
- Users who lose department membership, dispatch rights, incident assignment, or moderation rights should lose chat access more reliably and more quickly.
- Cross-department or forged identifiers are less likely to expose or mutate chat data.
- Realtime chat subscriptions are better isolated after permission changes.
- Audit logs are easier to search, sort, and review.
- Unit push notifications should register more reliably.

<!-- kody-pr-summary:end -->