### PR TITLE
RG-T133 Fixes

### DIFF
--- a/Core/Resgrid.Services/CallEmailTemplates/ResgridEmailTemplate.cs
+++ b/Core/Resgrid.Services/CallEmailTemplates/ResgridEmailTemplate.cs
@@ -80,8 +80,6 @@ namespace Resgrid.Services.CallEmailTemplates
 				}
 				StringBuilder title = new StringBuilder();
 
-				title.Append("Email Call ");
-
 				var priorityName = GetCallPriorityName(c.Priority, activePriorities);
 
 				if (!String.IsNullOrEmpty(priorityName))

--- a/Core/Resgrid.Services/PushService.cs
+++ b/Core/Resgrid.Services/PushService.cs
@@ -48,8 +48,10 @@ namespace Resgrid.Services
 			// IC app registrations target the IC-specific Novu subscriber, keeping its inbox/push separate from the Responder app.
 			var isICApp = string.Equals(pushUri.Source, "IC", StringComparison.OrdinalIgnoreCase);
 
-			if (isICApp)
-				await EnsureICUserSubscriber(pushUri, code);
+			// The credential write below lands on nothing unless the subscriber already exists. The
+			// Responder path used to lean on the security-rights endpoint creating it on every app
+			// launch; registration is the only place that actually needs it, so both apps ensure here.
+			await EnsureUserSubscriber(pushUri, code, isICApp);
 
 			bool registered;
 
@@ -87,13 +89,23 @@ namespace Resgrid.Services
 			return true;
 		}
 
-		private async Task EnsureICUserSubscriber(PushUri pushUri, string code)
+		/// <summary>
+		/// Best-effort by design, unlike the unit path's hard stop: an already-present subscriber is the
+		/// common case (Novu answers it with a conflict the provider reports as success), and a failed
+		/// create surfaces immediately after as a logged credential-write rejection.
+		/// </summary>
+		private async Task EnsureUserSubscriber(PushUri pushUri, string code, bool isICApp)
 		{
 			try
 			{
 				var profile = await _userProfileService.GetProfileByUserIdAsync(pushUri.UserId);
-				await _novuProvider.CreateICUserSubscriber(pushUri.UserId, code, pushUri.DepartmentId,
-					profile?.MembershipEmail, profile?.FirstName, profile?.LastName);
+
+				if (isICApp)
+					await _novuProvider.CreateICUserSubscriber(pushUri.UserId, code, pushUri.DepartmentId,
+						profile?.MembershipEmail, profile?.FirstName, profile?.LastName);
+				else
+					await _novuProvider.CreateUserSubscriber(pushUri.UserId, code, pushUri.DepartmentId,
+						profile?.MembershipEmail, profile?.FirstName, profile?.LastName);
 			}
 			catch (Exception ex)
 			{

--- a/Providers/Resgrid.Providers.Email/PostmarkTemplateProvider.cs
+++ b/Providers/Resgrid.Providers.Email/PostmarkTemplateProvider.cs
@@ -416,7 +416,7 @@ namespace Resgrid.Providers.EmailProvider
 				newEmail.HtmlBody = content;
 				newEmail.Sender = FROM_EMAIL;
 				newEmail.From = FROM_EMAIL;
-				newEmail.Subject = $"Resgrid Password Reset";
+				newEmail.Subject = "Resgrid Receipt";
 				newEmail.To.Add(email);
 
 				return await _emailSender.Send(newEmail);

--- a/Providers/Resgrid.Providers.Messaging/NovuProvider.cs
+++ b/Providers/Resgrid.Providers.Messaging/NovuProvider.cs
@@ -86,6 +86,14 @@ namespace Resgrid.Providers.Messaging
 					}
 				}
 
+				var errors = parsed.SelectToken("errors");
+				if (errors != null)
+				{
+					var described = DescribeValidationErrors(errors);
+					if (!string.IsNullOrWhiteSpace(described))
+						parts.Add($"errors={described}");
+				}
+
 				return string.Join(" ", parts);
 			}
 			catch (JsonException)
@@ -93,6 +101,75 @@ namespace Resgrid.Providers.Messaging
 				return null;
 			}
 		}
+
+		/// <summary>
+		/// Both validation-error shapes Novu emits are handled: class-validator entries
+		/// ({ property, constraints }) and zod issues ({ path, message }), plus the v2 keyed form
+		/// ({ field: { messages: [...] } }). Only field names and rule messages are read out --
+		/// the rejected values themselves are never pulled into the log.
+		/// </summary>
+		private static string DescribeValidationErrors(JToken errors)
+		{
+			var items = new List<string>();
+
+			if (errors.Type == JTokenType.Object)
+			{
+				foreach (var prop in ((JObject)errors).Properties())
+				{
+					var messages = ExtractErrorMessages(prop.Value);
+					items.Add(messages.Count > 0 ? $"{prop.Name}: {string.Join("; ", messages)}" : prop.Name);
+				}
+			}
+			else if (errors.Type == JTokenType.Array)
+			{
+				foreach (var err in errors.Children())
+				{
+					if (err.Type != JTokenType.Object)
+						continue;
+
+					var label = err.SelectToken("property")?.ToString();
+					if (label == null)
+					{
+						var path = err.SelectToken("path");
+						if (path != null)
+							label = path.Type == JTokenType.Array
+								? string.Join(".", path.Children().Select(p => p.ToString()))
+								: path.ToString();
+					}
+
+					var messages = new List<string>();
+					var message = err.SelectToken("message");
+					if (message != null && message.Type == JTokenType.String)
+						messages.Add(message.ToString());
+
+					if (err.SelectToken("constraints") is JObject constraints)
+						messages.AddRange(constraints.Properties().Select(p => p.Value.ToString()));
+
+					if (label == null && messages.Count == 0)
+						continue;
+
+					items.Add(messages.Count > 0 ? $"{label ?? "?"}: {string.Join("; ", messages)}" : label);
+				}
+			}
+
+			return string.Join(" | ", items);
+		}
+
+		private static List<string> ExtractErrorMessages(JToken value)
+		{
+			var result = new List<string>();
+
+			if (value.Type == JTokenType.String)
+				result.Add(value.ToString());
+			else if (value.Type == JTokenType.Array)
+				result.AddRange(value.Children().Where(x => x.Type == JTokenType.String).Select(x => x.ToString()));
+			else if (value.Type == JTokenType.Object && value.SelectToken("messages") is JToken messages && messages.Type == JTokenType.Array)
+				result.AddRange(messages.Children().Where(x => x.Type == JTokenType.String).Select(x => x.ToString()));
+
+			return result;
+		}
+
+		private static string NullIfWhiteSpace(string value) => string.IsNullOrWhiteSpace(value) ? null : value;
 
 		private async Task<bool> CreateSubscriber(string id, int departmentId, string email, string firstName, string lastName, List<AdditionalData> data)
 		{
@@ -104,16 +181,16 @@ namespace Resgrid.Providers.Messaging
 					httpClient.DefaultRequestHeaders.Add("idempotency-key", Guid.NewGuid().ToString());
 					httpClient.DefaultRequestHeaders.Add("Authorization", $"ApiKey {ChatConfig.NovuSecretKey}");
 
+					// The v2 endpoint validates optional fields (@IsEmail, @IsTimeZone, @IsLocale) whenever
+					// they are present -- @IsOptional only skips null/undefined, so an empty string is a 422,
+					// not an omission. Empty values must therefore be null (dropped by NullValueHandling.Ignore)
+					// and the always-empty phone/avatar/timezone/locale keys are not sent at all.
 					var payload = new
 					{
 						subscriberId = id,
-						firstName = firstName,
-						lastName = lastName,
-						email = email,
-						phone = "",
-						avatar = "",
-						timezone = "",
-						locale = "",
+						firstName = NullIfWhiteSpace(firstName),
+						lastName = NullIfWhiteSpace(lastName),
+						email = NullIfWhiteSpace(email),
 						data = new Dictionary<string, object>()
 					};
 

--- a/Repositories/Resgrid.Repositories.DataRepository/DeleteRepository.cs
+++ b/Repositories/Resgrid.Repositories.DataRepository/DeleteRepository.cs
@@ -53,6 +53,9 @@ namespace Resgrid.Repositories.DataRepository
 								DELETE FROM [dbo].[LogUnits] WHERE LogId IN (SELECT LogId FROM [dbo].[Logs] WHERE DepartmentId = @DepartmentId)
 								DELETE FROM [dbo].[LogUsers] WHERE LogId IN (SELECT LogId FROM [dbo].[Logs] WHERE DepartmentId = @DepartmentId)
 
+								-- PushUris has no DepartmentId column; delete by membership while DepartmentMembers rows still exist
+								DELETE FROM [dbo].[PushUris] WHERE UserId IN (SELECT UserId FROM [dbo].[DepartmentMembers] WHERE DepartmentId = @DepartmentId)
+
 								OPEN db_cursor
 								FETCH NEXT FROM db_cursor INTO @UserId
 
@@ -183,8 +186,8 @@ namespace Resgrid.Repositories.DataRepository
 								DELETE FROM [dbo].[POITypes] WHERE DepartmentId = @DepartmentId
 
 								-- Resource orders (ResourceOrders row deleted further down)
-								DELETE FROM [dbo].[ResourceOrderFillUnits] WHERE ResourceOrderFillId IN (SELECT ResourceOrderFillId FROM [dbo].[ResourceOrderFills] WHERE DepartmentId = @DepartmentId OR ResourceOrderId IN (SELECT ResourceOrderId FROM [dbo].[ResourceOrders] WHERE DepartmentId = @DepartmentId))
-								DELETE FROM [dbo].[ResourceOrderFills] WHERE DepartmentId = @DepartmentId OR ResourceOrderId IN (SELECT ResourceOrderId FROM [dbo].[ResourceOrders] WHERE DepartmentId = @DepartmentId)
+								DELETE FROM [dbo].[ResourceOrderFillUnits] WHERE ResourceOrderFillId IN (SELECT ResourceOrderFillId FROM [dbo].[ResourceOrderFills] WHERE DepartmentId = @DepartmentId OR ResourceOrderItemId IN (SELECT ResourceOrderItemId FROM [dbo].[ResourceOrderItems] WHERE ResourceOrderId IN (SELECT ResourceOrderId FROM [dbo].[ResourceOrders] WHERE DepartmentId = @DepartmentId)))
+								DELETE FROM [dbo].[ResourceOrderFills] WHERE DepartmentId = @DepartmentId OR ResourceOrderItemId IN (SELECT ResourceOrderItemId FROM [dbo].[ResourceOrderItems] WHERE ResourceOrderId IN (SELECT ResourceOrderId FROM [dbo].[ResourceOrders] WHERE DepartmentId = @DepartmentId))
 								DELETE FROM [dbo].[ResourceOrderItems] WHERE ResourceOrderId IN (SELECT ResourceOrderId FROM [dbo].[ResourceOrders] WHERE DepartmentId = @DepartmentId)
 								DELETE FROM [dbo].[ResourceOrderSettings] WHERE DepartmentId = @DepartmentId
 
@@ -240,7 +243,6 @@ namespace Resgrid.Repositories.DataRepository
 								DELETE FROM [dbo].[UserStates] WHERE DepartmentId = @DepartmentId
 								DELETE FROM [dbo].[PersonnelCertifications] WHERE DepartmentId = @DepartmentId
 								DELETE FROM [dbo].[PersonnelRoleUsers] WHERE DepartmentId = @DepartmentId
-								DELETE FROM [dbo].[PushUris] WHERE DepartmentId = @DepartmentId
 
 								DELETE FROM [dbo].[Invites] WHERE DepartmentId = @DepartmentId
 								DELETE FROM [dbo].[Payments] WHERE DepartmentId = @DepartmentId

--- a/Tests/Resgrid.Tests/Services/CallEmailFactoryTests.cs
+++ b/Tests/Resgrid.Tests/Services/CallEmailFactoryTests.cs
@@ -609,7 +609,7 @@ namespace Resgrid.Tests.Services
 				call.MapPage.Should().Be("12B");
 				call.NatureOfCall.Should().Be("55 Y/O Male, Chest Pain");
 				call.Notes.Should().Be("Caller is on scene");
-				call.Name.Should().Be("Email Call Emergency MEDICAL 2020-1234 ");
+				call.Name.Should().Be("Emergency MEDICAL 2020-1234 ");
 				call.Dispatches.Count.Should().Be(_dispatchUsers.Count);
 			}
 
@@ -643,7 +643,7 @@ namespace Resgrid.Tests.Services
 
 				call.Should().NotBeNull();
 				call.Priority.Should().Be((int)CallPriority.Medium);
-				call.Name.Should().Be("Email Call Medium MEDICAL 2020-1234 ");
+				call.Name.Should().Be("Medium MEDICAL 2020-1234 ");
 			}
 
 			[Test]
@@ -656,7 +656,7 @@ namespace Resgrid.Tests.Services
 
 				call.Should().NotBeNull();
 				call.Priority.Should().Be(502);
-				call.Name.Should().Be("Email Call Structure Fire MEDICAL 2020-1234 ");
+				call.Name.Should().Be("Structure Fire MEDICAL 2020-1234 ");
 			}
 
 			[Test]

--- a/Tests/Resgrid.Tests/Services/PushServiceUserRegistrationTests.cs
+++ b/Tests/Resgrid.Tests/Services/PushServiceUserRegistrationTests.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using Resgrid.Model;
+using Resgrid.Model.Providers;
+using Resgrid.Model.Services;
+using Resgrid.Services;
+
+namespace Resgrid.Tests.Services
+{
+	[TestFixture]
+	public class PushServiceUserRegistrationTests
+	{
+		private const string UserId = "user-1";
+		private const int DepartmentId = 7;
+		private const string Code = "DEPT";
+		private const string DeviceId = "device-token";
+		private const string Email = "user@example.com";
+		private const string FirstName = "First";
+		private const string LastName = "Last";
+
+		private Mock<INovuProvider> _novuProvider;
+		private Mock<IUserProfileService> _userProfileService;
+		private PushService _pushService;
+
+		[SetUp]
+		public void SetUp()
+		{
+			_novuProvider = new Mock<INovuProvider>();
+			_userProfileService = new Mock<IUserProfileService>();
+			_userProfileService.Setup(x => x.GetProfileByUserIdAsync(UserId, It.IsAny<bool>())).ReturnsAsync(new UserProfile
+			{
+				UserId = UserId,
+				FirstName = FirstName,
+				LastName = LastName,
+				MembershipEmail = Email
+			});
+
+			_pushService = new PushService(
+				Mock.Of<IPushLogsService>(),
+				Mock.Of<INotificationProvider>(),
+				_userProfileService.Object,
+				Mock.Of<IUnitNotificationProvider>(),
+				_novuProvider.Object,
+				Mock.Of<IDepartmentSettingsService>(),
+				Mock.Of<IUnitsService>());
+		}
+
+		[Test]
+		public async Task Register_responder_should_create_subscriber_before_credential_write()
+		{
+			_novuProvider.Setup(x => x.UpdateUserSubscriberFcm(UserId, Code, DeviceId)).ReturnsAsync(true);
+
+			var result = await _pushService.Register(CreatePushUri(source: null));
+
+			result.Should().BeTrue();
+			_novuProvider.Verify(x => x.CreateUserSubscriber(UserId, Code, DepartmentId, Email, FirstName, LastName), Times.Once);
+			_novuProvider.Verify(x => x.CreateICUserSubscriber(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+			_novuProvider.Verify(x => x.UpdateUserSubscriberFcm(UserId, Code, DeviceId), Times.Once);
+		}
+
+		[Test]
+		public async Task Register_ic_should_create_ic_subscriber_before_credential_write()
+		{
+			_novuProvider.Setup(x => x.UpdateICUserSubscriberFcm(UserId, Code, DeviceId)).ReturnsAsync(true);
+
+			var result = await _pushService.Register(CreatePushUri(source: "IC"));
+
+			result.Should().BeTrue();
+			_novuProvider.Verify(x => x.CreateICUserSubscriber(UserId, Code, DepartmentId, Email, FirstName, LastName), Times.Once);
+			_novuProvider.Verify(x => x.CreateUserSubscriber(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+			_novuProvider.Verify(x => x.UpdateICUserSubscriberFcm(UserId, Code, DeviceId), Times.Once);
+		}
+
+		[Test]
+		public async Task Register_should_still_write_credentials_when_subscriber_create_fails()
+		{
+			_novuProvider.Setup(x => x.CreateUserSubscriber(UserId, Code, DepartmentId, Email, FirstName, LastName))
+				.ReturnsAsync(false);
+			_novuProvider.Setup(x => x.UpdateUserSubscriberFcm(UserId, Code, DeviceId)).ReturnsAsync(true);
+
+			var result = await _pushService.Register(CreatePushUri(source: null));
+
+			result.Should().BeTrue();
+			_novuProvider.Verify(x => x.UpdateUserSubscriberFcm(UserId, Code, DeviceId), Times.Once);
+		}
+
+		[Test]
+		public async Task Register_should_still_write_credentials_when_subscriber_create_throws()
+		{
+			_novuProvider.Setup(x => x.CreateUserSubscriber(UserId, Code, DepartmentId, Email, FirstName, LastName))
+				.ThrowsAsync(new InvalidOperationException("Novu unavailable"));
+			_novuProvider.Setup(x => x.UpdateUserSubscriberFcm(UserId, Code, DeviceId)).ReturnsAsync(true);
+
+			var result = await _pushService.Register(CreatePushUri(source: null));
+
+			result.Should().BeTrue();
+			_novuProvider.Verify(x => x.UpdateUserSubscriberFcm(UserId, Code, DeviceId), Times.Once);
+		}
+
+		private static PushUri CreatePushUri(string source)
+		{
+			return new PushUri
+			{
+				UserId = UserId,
+				DepartmentId = DepartmentId,
+				PlatformType = (int)Platforms.Android,
+				PushLocation = Code,
+				DeviceId = DeviceId,
+				Source = source
+			};
+		}
+	}
+}

--- a/Web/Resgrid.Web.Services/Controllers/v4/SecurityController.cs
+++ b/Web/Resgrid.Web.Services/Controllers/v4/SecurityController.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using Resgrid.Web.Services.Helpers;
 using Resgrid.Web.Services.Models.v4.Security;
 using Resgrid.Model;
-using Resgrid.Model.Providers;
 
 namespace Resgrid.Web.Services.Controllers.v4
 {
@@ -24,21 +23,18 @@ namespace Resgrid.Web.Services.Controllers.v4
 		private readonly IPermissionsService _permissionsService;
 		private readonly IPersonnelRolesService _personnelRolesService;
 		private readonly IUserProfileService _userProfileService;
-		private readonly INovuProvider _novuProvider;
 
 		/// <summary>
 		/// Operations to perform against the security sub-system
 		/// </summary>
 		public SecurityController(IDepartmentsService departmentsService, IDepartmentGroupsService departmentGroupsService,
-			IPermissionsService permissionsService, IPersonnelRolesService personnelRolesService, IUserProfileService userProfileService,
-			INovuProvider novuProvider)
+			IPermissionsService permissionsService, IPersonnelRolesService personnelRolesService, IUserProfileService userProfileService)
 		{
 			_departmentsService = departmentsService;
 			_departmentGroupsService = departmentGroupsService;
 			_permissionsService = permissionsService;
 			_personnelRolesService = personnelRolesService;
 			_userProfileService = userProfileService;
-			_novuProvider = novuProvider;
 		}
 		#endregion Members and Constructors
 
@@ -109,8 +105,6 @@ namespace Resgrid.Web.Services.Controllers.v4
 			result.Data.CanViewWorkflowRuns = _permissionsService.IsUserAllowed(viewWorkflowRunsPermission, result.Data.IsAdmin, isGroupAdmin, roles);
 			result.Data.CanLoginToDispatchApp = _permissionsService.IsUserAllowed(dispatchAppLoginPermission, result.Data.IsAdmin, isGroupAdmin, roles);
 			result.Data.CanLoginToCommandApp = _permissionsService.IsUserAllowed(commandAppLoginPermission, result.Data.IsAdmin, isGroupAdmin, roles);
-
-			var novuSuccess = await _novuProvider.CreateUserSubscriber(UserId, department.Code, DepartmentId, profile.MembershipEmail, profile.FirstName, profile.LastName);
 
 			result.PageSize = 1;
 			result.Status = ResponseHelper.Success;

--- a/Web/Resgrid.Web.Services/Resgrid.Web.Services.xml
+++ b/Web/Resgrid.Web.Services/Resgrid.Web.Services.xml
@@ -2560,7 +2560,7 @@
             Call Priorities, for example Low, Medium, High. Call Priorities can be system provided ones or custom for a department
             </summary>
         </member>
-        <member name="M:Resgrid.Web.Services.Controllers.v4.SecurityController.#ctor(Resgrid.Model.Services.IDepartmentsService,Resgrid.Model.Services.IDepartmentGroupsService,Resgrid.Model.Services.IPermissionsService,Resgrid.Model.Services.IPersonnelRolesService,Resgrid.Model.Services.IUserProfileService,Resgrid.Model.Providers.INovuProvider)">
+        <member name="M:Resgrid.Web.Services.Controllers.v4.SecurityController.#ctor(Resgrid.Model.Services.IDepartmentsService,Resgrid.Model.Services.IDepartmentGroupsService,Resgrid.Model.Services.IPermissionsService,Resgrid.Model.Services.IPersonnelRolesService,Resgrid.Model.Services.IUserProfileService)">
             <summary>
             Operations to perform against the security sub-system
             </summary>


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request includes several targeted fixes across email-generated calls, push registration, receipts, deletion cleanup, and Novu error handling.

### What changed

- **Removed the `"Email Call "` prefix from call names created from email imports**
  - Email-generated calls now use the priority/title content directly instead of prepending `"Email Call "`.
  - Tests were updated to reflect the new naming behavior.

- **Fixed push registration to ensure Novu subscribers are created for both Responder and IC apps**
  - Push registration now attempts to create the appropriate Novu subscriber before writing FCM credentials, not just for the IC app.
  - This addresses cases where credential updates would fail because the subscriber did not yet exist.
  - The subscriber creation step is handled as best-effort so registration can still proceed even if subscriber creation fails.

- **Removed subscriber creation from the security rights endpoint**
  - The v4 security controller no longer creates a Novu subscriber when fetching a user’s rights.
  - Subscriber creation is now aligned with push registration, where it is actually needed.

- **Improved Novu validation error logging**
  - Error parsing now captures additional validation error formats returned by Novu and includes clearer field/message details in logs.
  - This improves diagnosability when subscriber creation or updates are rejected.

- **Adjusted Novu subscriber creation payloads to avoid sending empty optional values**
  - Optional subscriber fields such as name and email are now omitted when blank instead of being sent as empty strings.
  - This prevents validation failures from the Novu v2 API for optional fields.

- **Corrected the subject line for payment receipt emails**
  - Payment receipt emails now use the subject **"Resgrid Receipt"** instead of the incorrect password reset subject.

- **Fixed department deletion cleanup for push URIs**
  - Department deletion now removes push URI records by matching users in the department, rather than by a department column that does not exist on the table.
  - This ensures push registration records are properly cleaned up during department deletion.

- **Corrected cleanup of resource order fills during department deletion**
  - Resource order fill deletions now follow the relationship through resource order items, ensuring related fill and fill-unit records tied to the department are properly removed.

### Functional impact

These changes improve:
- the naming of calls created from email,
- reliability of push notification registration,
- correctness of outgoing payment receipt emails,
- cleanup accuracy when deleting departments,
- and visibility into Novu API validation failures.
<!-- kody-pr-summary:end -->