### PR TITLE
RG-T66 UI Cleanup for RMS, Inventory, Work Orders, Checklists

### DIFF
--- a/Core/Resgrid.Localization/Areas/User/Checklists/Checklists.ar.resx
+++ b/Core/Resgrid.Localization/Areas/User/Checklists/Checklists.ar.resx
@@ -694,4 +694,26 @@
   <data name="HistoricalWorkOrdersUnavailable" xml:space="preserve"><value>تعذّر إعادة بناء بعض الحالات التاريخية لأوامر العمل. لا تدّعي الحزمة تغطية الصيانة بالكامل.</value></data>
   <data name="RestrictedWorkOrders" xml:space="preserve"><value>تقتصر أدلة أوامر العمل على النطاق المصرّح للقارئ بالوصول إليه حاليًا.</value></data>
   <data name="ProtectedDataRequired" xml:space="preserve"><value>يجب إلغاء قفل البيانات المحمية للمتابعة.</value></data>
+  <data name="ChecklistsIntro" xml:space="preserve"><value>أنشئ الفحوصات التي تنفّذها أطقمك، وجدولها، وتابع ما تم إنجازه.</value></data>
+  <data name="Close" xml:space="preserve"><value>إغلاق</value></data>
+  <data name="Continue" xml:space="preserve"><value>متابعة</value></data>
+  <data name="Review" xml:space="preserve"><value>مراجعة</value></data>
+  <data name="ReviewHint" xml:space="preserve"><value>راجع الإجابات أدناه ثم احفظ.</value></data>
+  <data name="RequiredFieldsMissing" xml:space="preserve"><value>املأ الحقول المميزة قبل المتابعة.</value></data>
+  <data name="NoRowsHelp" xml:space="preserve"><value>لا يوجد شيء هنا بعد. استخدم الأزرار أعلاه لإنشاء أول واحد.</value></data>
+  <data name="HelpDefinitions" xml:space="preserve"><value>قائمة التحقق هي مجموعة الأسئلة التي يجيب عنها الطاقم. انشرها قبل جدولتها أو تنفيذها.</value></data>
+  <data name="StartRunHint" xml:space="preserve"><value>اختر الهدف الذي يُنفَّذ عليه هذا الفحص.</value></data>
+  <data name="SkipHint" xml:space="preserve"><value>تبقى الفحوصات المعذورة في السجل مع السبب الذي تذكره هنا.</value></data>
+  <data name="RetireHint" xml:space="preserve"><value>الإحالة توقف عمليات التنفيذ الجديدة والفحوصات المجدولة المقبلة. يُحتفظ بالسجل القائم.</value></data>
+  <data name="ReportRangeHint" xml:space="preserve"><value>تُحدَّد الفحوصات بحسب وقت بدايتها لا وقت إتمامها.</value></data>
+  <data name="HelpFieldCallId" xml:space="preserve"><value>البلاغ الذي يُجمَّع الملف من أجله.</value></data>
+  <data name="StepScheduleBasics" xml:space="preserve"><value>سمِّ الجدول</value></data>
+  <data name="StepScheduleBasicsHint" xml:space="preserve"><value>اسم هذا الجدول والهدف الذي يُنفَّذ عليه.</value></data>
+  <data name="StepScheduleTiming" xml:space="preserve"><value>متى يُنفَّذ</value></data>
+  <data name="StepScheduleTimingHint" xml:space="preserve"><value>عدد مرات فتح الفحص، والمنطقة الزمنية التي تُقرأ بها تلك الأوقات.</value></data>
+  <data name="StepScheduleAssignment" xml:space="preserve"><value>من يتولّاه</value></data>
+  <data name="StepScheduleAssignmentHint" xml:space="preserve"><value>من المسؤول عن الفحص وكم من الوقت لديه بعد فتحه.</value></data>
+  <data name="HelpFieldScheduleName" xml:space="preserve"><value>يظهر في قائمة المستحق، فاجعله سهل التمييز بنظرة واحدة.</value></data>
+  <data name="HelpFieldWindowMinutes" xml:space="preserve"><value>المدة المتاحة للطاقم لإنهاء الفحص بعد فتحه. بعدها يُحتسب فائتًا.</value></data>
+  <data name="HelpFieldAssignment" xml:space="preserve"><value>التوجيه التلقائي يرسل الفحص إلى من يحوز الهدف. اختر شخصًا أو دورًا أو مجموعة أو مركبة لتجاوز ذلك.</value></data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Checklists/Checklists.de.resx
+++ b/Core/Resgrid.Localization/Areas/User/Checklists/Checklists.de.resx
@@ -694,4 +694,26 @@
   <data name="HistoricalWorkOrdersUnavailable" xml:space="preserve"><value>Einige historische Arbeitsauftragszustände konnten nicht rekonstruiert werden. Das Paket beansprucht keine vollständige Wartungsabdeckung.</value></data>
   <data name="RestrictedWorkOrders" xml:space="preserve"><value>Arbeitsauftragsnachweise sind auf den aktuell berechtigten Lesebereich beschränkt.</value></data>
   <data name="ProtectedDataRequired" xml:space="preserve"><value>Geschützte Daten müssen zum Fortfahren entsperrt werden.</value></data>
+  <data name="ChecklistsIntro" xml:space="preserve"><value>Erstellen Sie die Prüfungen Ihrer Einsatzkräfte, planen Sie sie und sehen Sie, was erledigt wurde.</value></data>
+  <data name="Close" xml:space="preserve"><value>Schließen</value></data>
+  <data name="Continue" xml:space="preserve"><value>Weiter</value></data>
+  <data name="Review" xml:space="preserve"><value>Prüfen</value></data>
+  <data name="ReviewHint" xml:space="preserve"><value>Prüfen Sie die Angaben unten und speichern Sie dann.</value></data>
+  <data name="RequiredFieldsMissing" xml:space="preserve"><value>Füllen Sie die hervorgehobenen Felder aus, bevor Sie fortfahren.</value></data>
+  <data name="NoRowsHelp" xml:space="preserve"><value>Hier ist noch nichts. Legen Sie über die Schaltflächen oben den ersten Eintrag an.</value></data>
+  <data name="HelpDefinitions" xml:space="preserve"><value>Eine Checkliste ist die Fragenliste, die eine Einsatzkraft beantwortet. Veröffentlichen Sie sie, bevor sie geplant oder ausgeführt werden kann.</value></data>
+  <data name="StartRunHint" xml:space="preserve"><value>Wählen Sie, worauf sich dieser Durchlauf bezieht.</value></data>
+  <data name="SkipHint" xml:space="preserve"><value>Entschuldigte Prüfungen bleiben mit der hier angegebenen Begründung im Nachweis.</value></data>
+  <data name="RetireHint" xml:space="preserve"><value>Das Ausmustern verhindert neue Durchläufe und künftige geplante Prüfungen. Vorhandene Historie bleibt erhalten.</value></data>
+  <data name="ReportRangeHint" xml:space="preserve"><value>Prüfungen werden nach ihrem Startzeitpunkt ausgewählt, nicht nach dem Abschluss.</value></data>
+  <data name="HelpFieldCallId" xml:space="preserve"><value>Der Einsatz, für den das Paket zusammengestellt wird.</value></data>
+  <data name="StepScheduleBasics" xml:space="preserve"><value>Zeitplan benennen</value></data>
+  <data name="StepScheduleBasicsHint" xml:space="preserve"><value>Wie dieser Zeitplan heißt und worauf er sich bezieht.</value></data>
+  <data name="StepScheduleTiming" xml:space="preserve"><value>Wann er ausgeführt wird</value></data>
+  <data name="StepScheduleTimingHint" xml:space="preserve"><value>Wie oft die Prüfung geöffnet wird und in welcher Zeitzone diese Zeiten gelten.</value></data>
+  <data name="StepScheduleAssignment" xml:space="preserve"><value>Wer sie übernimmt</value></data>
+  <data name="StepScheduleAssignmentHint" xml:space="preserve"><value>Wer für die Prüfung zuständig ist und wie viel Zeit nach dem Öffnen bleibt.</value></data>
+  <data name="HelpFieldScheduleName" xml:space="preserve"><value>Erscheint in der Fälligkeitsliste; wählen Sie einen auf einen Blick erkennbaren Namen.</value></data>
+  <data name="HelpFieldWindowMinutes" xml:space="preserve"><value>Wie lange nach dem Öffnen Zeit für die Prüfung bleibt. Danach gilt sie als versäumt.</value></data>
+  <data name="HelpFieldAssignment" xml:space="preserve"><value>Die automatische Zuweisung leitet die Prüfung an die zuständige Stelle. Wählen Sie Person, Rolle, Gruppe oder Fahrzeug, um dies zu übersteuern.</value></data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Checklists/Checklists.el.resx
+++ b/Core/Resgrid.Localization/Areas/User/Checklists/Checklists.el.resx
@@ -694,4 +694,26 @@
   <data name="HistoricalWorkOrdersUnavailable" xml:space="preserve"><value>Δεν ήταν δυνατή η ανακατασκευή ορισμένων ιστορικών καταστάσεων εντολών. Το πακέτο δεν εγγυάται πλήρη κάλυψη συντήρησης.</value></data>
   <data name="RestrictedWorkOrders" xml:space="preserve"><value>Τα τεκμήρια εντολών περιορίζονται στο τρέχον εξουσιοδοτημένο πεδίο πρόσβασης του αναγνώστη.</value></data>
   <data name="ProtectedDataRequired" xml:space="preserve"><value>Τα προστατευμένα δεδομένα πρέπει να ξεκλειδωθούν για να συνεχίσετε.</value></data>
+  <data name="ChecklistsIntro" xml:space="preserve"><value>Δημιουργήστε τους ελέγχους που εκτελούν τα πληρώματα, προγραμματίστε τους και δείτε τι έγινε.</value></data>
+  <data name="Close" xml:space="preserve"><value>Κλείσιμο</value></data>
+  <data name="Continue" xml:space="preserve"><value>Συνέχεια</value></data>
+  <data name="Review" xml:space="preserve"><value>Έλεγχος</value></data>
+  <data name="ReviewHint" xml:space="preserve"><value>Ελέγξτε τις απαντήσεις παρακάτω και αποθηκεύστε.</value></data>
+  <data name="RequiredFieldsMissing" xml:space="preserve"><value>Συμπληρώστε τα επισημασμένα πεδία πριν συνεχίσετε.</value></data>
+  <data name="NoRowsHelp" xml:space="preserve"><value>Δεν υπάρχει τίποτα ακόμη. Χρησιμοποιήστε τα κουμπιά παραπάνω για να δημιουργήσετε το πρώτο.</value></data>
+  <data name="HelpDefinitions" xml:space="preserve"><value>Μια λίστα ελέγχου είναι το σύνολο ερωτήσεων που απαντά ένα πλήρωμα. Δημοσιεύστε την πριν προγραμματιστεί ή εκτελεστεί.</value></data>
+  <data name="StartRunHint" xml:space="preserve"><value>Επιλέξτε σε τι αφορά αυτή η εκτέλεση.</value></data>
+  <data name="SkipHint" xml:space="preserve"><value>Οι δικαιολογημένοι έλεγχοι παραμένουν στο αρχείο με τον λόγο που δίνετε εδώ.</value></data>
+  <data name="RetireHint" xml:space="preserve"><value>Η απόσυρση σταματά νέες εκτελέσεις και μελλοντικούς προγραμματισμένους ελέγχους. Το ιστορικό διατηρείται.</value></data>
+  <data name="ReportRangeHint" xml:space="preserve"><value>Οι έλεγχοι επιλέγονται με βάση την ώρα έναρξης, όχι την ολοκλήρωση.</value></data>
+  <data name="HelpFieldCallId" xml:space="preserve"><value>Το συμβάν για το οποίο συντάσσεται ο φάκελος.</value></data>
+  <data name="StepScheduleBasics" xml:space="preserve"><value>Ονομάστε το πρόγραμμα</value></data>
+  <data name="StepScheduleBasicsHint" xml:space="preserve"><value>Πώς ονομάζεται αυτό το πρόγραμμα και σε τι αφορά.</value></data>
+  <data name="StepScheduleTiming" xml:space="preserve"><value>Πότε εκτελείται</value></data>
+  <data name="StepScheduleTimingHint" xml:space="preserve"><value>Πόσο συχνά ανοίγει ο έλεγχος και σε ποια ζώνη ώρας διαβάζονται αυτές οι ώρες.</value></data>
+  <data name="StepScheduleAssignment" xml:space="preserve"><value>Ποιος την αναλαμβάνει</value></data>
+  <data name="StepScheduleAssignmentHint" xml:space="preserve"><value>Ποιος είναι υπεύθυνος για τον έλεγχο και πόσο χρόνο έχει από τη στιγμή που ανοίγει.</value></data>
+  <data name="HelpFieldScheduleName" xml:space="preserve"><value>Εμφανίζεται στη λίστα εκκρεμοτήτων, οπότε κάντε το αναγνωρίσιμο με μια ματιά.</value></data>
+  <data name="HelpFieldWindowMinutes" xml:space="preserve"><value>Πόσο χρόνο έχει το πλήρωμα να ολοκληρώσει τον έλεγχο μετά το άνοιγμα. Μετά θεωρείται χαμένος.</value></data>
+  <data name="HelpFieldAssignment" xml:space="preserve"><value>Η αυτόματη δρομολόγηση στέλνει τον έλεγχο σε όποιον κατέχει τον στόχο. Επιλέξτε άτομο, ρόλο, ομάδα ή όχημα για παράκαμψη.</value></data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Checklists/Checklists.en.resx
+++ b/Core/Resgrid.Localization/Areas/User/Checklists/Checklists.en.resx
@@ -694,4 +694,26 @@
   <data name="HistoricalWorkOrdersUnavailable" xml:space="preserve"><value>Some historical work-order states could not be reconstructed. The packet does not claim complete maintenance coverage.</value></data>
   <data name="RestrictedWorkOrders" xml:space="preserve"><value>Work-order evidence is limited to the reader’s current authorized scope.</value></data>
   <data name="ProtectedDataRequired" xml:space="preserve"><value>Protected data must be unlocked to continue.</value></data>
+  <data name="ChecklistsIntro" xml:space="preserve"><value>Build the checks your crews run, schedule them, and see what was done.</value></data>
+  <data name="Close" xml:space="preserve"><value>Close</value></data>
+  <data name="Continue" xml:space="preserve"><value>Continue</value></data>
+  <data name="Review" xml:space="preserve"><value>Review</value></data>
+  <data name="ReviewHint" xml:space="preserve"><value>Check the answers below, then save.</value></data>
+  <data name="RequiredFieldsMissing" xml:space="preserve"><value>Fill in the highlighted fields before continuing.</value></data>
+  <data name="NoRowsHelp" xml:space="preserve"><value>Nothing here yet. Use the buttons above to create the first one.</value></data>
+  <data name="HelpDefinitions" xml:space="preserve"><value>A checklist is the set of questions a crew answers. Publish one before it can be scheduled or run.</value></data>
+  <data name="StartRunHint" xml:space="preserve"><value>Choose what this run is being carried out against.</value></data>
+  <data name="SkipHint" xml:space="preserve"><value>Excused checks stay on the record with the reason you give here.</value></data>
+  <data name="RetireHint" xml:space="preserve"><value>Retiring stops new runs and future scheduled checks. Existing history is kept.</value></data>
+  <data name="ReportRangeHint" xml:space="preserve"><value>Checks are selected by their start time, not when they were completed.</value></data>
+  <data name="HelpFieldCallId" xml:space="preserve"><value>The call the packet is being assembled for.</value></data>
+  <data name="StepScheduleBasics" xml:space="preserve"><value>Name the schedule</value></data>
+  <data name="StepScheduleBasicsHint" xml:space="preserve"><value>What this schedule is called and what it runs against.</value></data>
+  <data name="StepScheduleTiming" xml:space="preserve"><value>When it runs</value></data>
+  <data name="StepScheduleTimingHint" xml:space="preserve"><value>How often the check opens, and in which time zone those times are read.</value></data>
+  <data name="StepScheduleAssignment" xml:space="preserve"><value>Who picks it up</value></data>
+  <data name="StepScheduleAssignmentHint" xml:space="preserve"><value>Who is responsible for the check, and how long they have once it opens.</value></data>
+  <data name="HelpFieldScheduleName" xml:space="preserve"><value>Shown on the due list, so make it recognisable at a glance.</value></data>
+  <data name="HelpFieldWindowMinutes" xml:space="preserve"><value>How long the crew has to finish the check once it opens. After that it counts as missed.</value></data>
+  <data name="HelpFieldAssignment" xml:space="preserve"><value>Automatic routing sends the check to whoever holds the target. Pick a person, role, group or unit to override that.</value></data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Checklists/Checklists.es.resx
+++ b/Core/Resgrid.Localization/Areas/User/Checklists/Checklists.es.resx
@@ -694,4 +694,26 @@
   <data name="HistoricalWorkOrdersUnavailable" xml:space="preserve"><value>No se pudieron reconstruir algunos estados históricos de las órdenes. El paquete no garantiza una cobertura completa del mantenimiento.</value></data>
   <data name="RestrictedWorkOrders" xml:space="preserve"><value>Las pruebas de las órdenes se limitan al ámbito autorizado actual del lector.</value></data>
   <data name="ProtectedDataRequired" xml:space="preserve"><value>Debe desbloquear los datos protegidos para continuar.</value></data>
+  <data name="ChecklistsIntro" xml:space="preserve"><value>Cree las comprobaciones que realiza su personal, prográmelas y vea qué se hizo.</value></data>
+  <data name="Close" xml:space="preserve"><value>Cerrar</value></data>
+  <data name="Continue" xml:space="preserve"><value>Continuar</value></data>
+  <data name="Review" xml:space="preserve"><value>Revisar</value></data>
+  <data name="ReviewHint" xml:space="preserve"><value>Revise las respuestas de abajo y guarde.</value></data>
+  <data name="RequiredFieldsMissing" xml:space="preserve"><value>Complete los campos resaltados antes de continuar.</value></data>
+  <data name="NoRowsHelp" xml:space="preserve"><value>Aquí todavía no hay nada. Use los botones de arriba para crear el primero.</value></data>
+  <data name="HelpDefinitions" xml:space="preserve"><value>Una lista de comprobación es el conjunto de preguntas que responde el personal. Publíquela antes de programarla o ejecutarla.</value></data>
+  <data name="StartRunHint" xml:space="preserve"><value>Elija sobre qué se realiza esta ejecución.</value></data>
+  <data name="SkipHint" xml:space="preserve"><value>Las comprobaciones excusadas quedan registradas con el motivo que indique aquí.</value></data>
+  <data name="RetireHint" xml:space="preserve"><value>Retirarla impide nuevas ejecuciones y comprobaciones programadas futuras. El historial existente se conserva.</value></data>
+  <data name="ReportRangeHint" xml:space="preserve"><value>Las comprobaciones se seleccionan por su hora de inicio, no por cuándo se completaron.</value></data>
+  <data name="HelpFieldCallId" xml:space="preserve"><value>El aviso para el que se prepara el paquete.</value></data>
+  <data name="StepScheduleBasics" xml:space="preserve"><value>Nombre la programación</value></data>
+  <data name="StepScheduleBasicsHint" xml:space="preserve"><value>Cómo se llama esta programación y sobre qué se ejecuta.</value></data>
+  <data name="StepScheduleTiming" xml:space="preserve"><value>Cuándo se ejecuta</value></data>
+  <data name="StepScheduleTimingHint" xml:space="preserve"><value>Con qué frecuencia se abre la comprobación y en qué zona horaria se leen esas horas.</value></data>
+  <data name="StepScheduleAssignment" xml:space="preserve"><value>Quién la asume</value></data>
+  <data name="StepScheduleAssignmentHint" xml:space="preserve"><value>Quién es responsable de la comprobación y cuánto tiempo tiene desde que se abre.</value></data>
+  <data name="HelpFieldScheduleName" xml:space="preserve"><value>Aparece en la lista de pendientes, así que hágalo reconocible de un vistazo.</value></data>
+  <data name="HelpFieldWindowMinutes" xml:space="preserve"><value>Cuánto tiempo tiene el personal para terminar la comprobación desde que se abre. Después cuenta como perdida.</value></data>
+  <data name="HelpFieldAssignment" xml:space="preserve"><value>El enrutamiento automático envía la comprobación a quien tenga el objetivo. Elija persona, rol, grupo o unidad para anularlo.</value></data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Checklists/Checklists.fr.resx
+++ b/Core/Resgrid.Localization/Areas/User/Checklists/Checklists.fr.resx
@@ -694,4 +694,26 @@
   <data name="HistoricalWorkOrdersUnavailable" xml:space="preserve"><value>Certains états historiques des ordres n’ont pas pu être reconstitués. Le dossier ne garantit pas une couverture complète de la maintenance.</value></data>
   <data name="RestrictedWorkOrders" xml:space="preserve"><value>Les preuves des ordres sont limitées au périmètre actuellement autorisé du lecteur.</value></data>
   <data name="ProtectedDataRequired" xml:space="preserve"><value>Les données protégées doivent être déverrouillées pour continuer.</value></data>
+  <data name="ChecklistsIntro" xml:space="preserve"><value>Créez les vérifications que réalisent vos équipes, planifiez-les et voyez ce qui a été fait.</value></data>
+  <data name="Close" xml:space="preserve"><value>Fermer</value></data>
+  <data name="Continue" xml:space="preserve"><value>Continuer</value></data>
+  <data name="Review" xml:space="preserve"><value>Vérifier</value></data>
+  <data name="ReviewHint" xml:space="preserve"><value>Vérifiez les réponses ci-dessous, puis enregistrez.</value></data>
+  <data name="RequiredFieldsMissing" xml:space="preserve"><value>Renseignez les champs en surbrillance avant de continuer.</value></data>
+  <data name="NoRowsHelp" xml:space="preserve"><value>Rien pour l'instant. Utilisez les boutons ci-dessus pour créer le premier.</value></data>
+  <data name="HelpDefinitions" xml:space="preserve"><value>Une liste de contrôle est l'ensemble des questions auxquelles répond une équipe. Publiez-la avant de la planifier ou de l'exécuter.</value></data>
+  <data name="StartRunHint" xml:space="preserve"><value>Choisissez sur quoi porte cette exécution.</value></data>
+  <data name="SkipHint" xml:space="preserve"><value>Les vérifications excusées restent au dossier avec le motif indiqué ici.</value></data>
+  <data name="RetireHint" xml:space="preserve"><value>La mise hors service empêche les nouvelles exécutions et les vérifications planifiées à venir. L'historique est conservé.</value></data>
+  <data name="ReportRangeHint" xml:space="preserve"><value>Les vérifications sont sélectionnées d'après leur heure de début, pas leur achèvement.</value></data>
+  <data name="HelpFieldCallId" xml:space="preserve"><value>L'intervention pour laquelle le dossier est constitué.</value></data>
+  <data name="StepScheduleBasics" xml:space="preserve"><value>Nommer la planification</value></data>
+  <data name="StepScheduleBasicsHint" xml:space="preserve"><value>Le nom de cette planification et ce sur quoi elle porte.</value></data>
+  <data name="StepScheduleTiming" xml:space="preserve"><value>Quand elle s'exécute</value></data>
+  <data name="StepScheduleTimingHint" xml:space="preserve"><value>À quelle fréquence la vérification s'ouvre, et dans quel fuseau horaire ces heures sont lues.</value></data>
+  <data name="StepScheduleAssignment" xml:space="preserve"><value>Qui la prend en charge</value></data>
+  <data name="StepScheduleAssignmentHint" xml:space="preserve"><value>Qui est responsable de la vérification, et de combien de temps il dispose une fois ouverte.</value></data>
+  <data name="HelpFieldScheduleName" xml:space="preserve"><value>Affiché dans la liste des échéances : rendez-le reconnaissable d'un coup d'œil.</value></data>
+  <data name="HelpFieldWindowMinutes" xml:space="preserve"><value>Le temps dont dispose l'équipe pour terminer la vérification après son ouverture. Passé ce délai, elle est manquée.</value></data>
+  <data name="HelpFieldAssignment" xml:space="preserve"><value>Le routage automatique envoie la vérification au détenteur de la cible. Choisissez une personne, un rôle, un groupe ou un engin pour l'outrepasser.</value></data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Checklists/Checklists.it.resx
+++ b/Core/Resgrid.Localization/Areas/User/Checklists/Checklists.it.resx
@@ -694,4 +694,26 @@
   <data name="HistoricalWorkOrdersUnavailable" xml:space="preserve"><value>Non è stato possibile ricostruire alcuni stati storici degli ordini. Il pacchetto non garantisce una copertura completa della manutenzione.</value></data>
   <data name="RestrictedWorkOrders" xml:space="preserve"><value>Le prove degli ordini sono limitate all’ambito attualmente autorizzato del lettore.</value></data>
   <data name="ProtectedDataRequired" xml:space="preserve"><value>È necessario sbloccare i dati protetti per continuare.</value></data>
+  <data name="ChecklistsIntro" xml:space="preserve"><value>Crea i controlli che eseguono le tue squadre, pianificali e verifica cosa è stato fatto.</value></data>
+  <data name="Close" xml:space="preserve"><value>Chiudi</value></data>
+  <data name="Continue" xml:space="preserve"><value>Continua</value></data>
+  <data name="Review" xml:space="preserve"><value>Verifica</value></data>
+  <data name="ReviewHint" xml:space="preserve"><value>Controlla le risposte qui sotto, poi salva.</value></data>
+  <data name="RequiredFieldsMissing" xml:space="preserve"><value>Compila i campi evidenziati prima di continuare.</value></data>
+  <data name="NoRowsHelp" xml:space="preserve"><value>Non c'è ancora nulla. Usa i pulsanti sopra per creare il primo.</value></data>
+  <data name="HelpDefinitions" xml:space="preserve"><value>Una checklist è l'insieme di domande a cui risponde una squadra. Pubblicala prima di pianificarla o eseguirla.</value></data>
+  <data name="StartRunHint" xml:space="preserve"><value>Scegli su cosa viene svolta questa esecuzione.</value></data>
+  <data name="SkipHint" xml:space="preserve"><value>I controlli giustificati restano a registro con la motivazione indicata qui.</value></data>
+  <data name="RetireHint" xml:space="preserve"><value>La dismissione blocca nuove esecuzioni e i controlli futuri pianificati. Lo storico resta.</value></data>
+  <data name="ReportRangeHint" xml:space="preserve"><value>I controlli sono selezionati per orario di inizio, non per quando sono stati completati.</value></data>
+  <data name="HelpFieldCallId" xml:space="preserve"><value>L'intervento per cui viene composto il pacchetto.</value></data>
+  <data name="StepScheduleBasics" xml:space="preserve"><value>Assegna un nome alla pianificazione</value></data>
+  <data name="StepScheduleBasicsHint" xml:space="preserve"><value>Come si chiama questa pianificazione e su cosa viene eseguita.</value></data>
+  <data name="StepScheduleTiming" xml:space="preserve"><value>Quando viene eseguita</value></data>
+  <data name="StepScheduleTimingHint" xml:space="preserve"><value>Con quale frequenza si apre il controllo e in quale fuso orario si leggono quegli orari.</value></data>
+  <data name="StepScheduleAssignment" xml:space="preserve"><value>Chi la prende in carico</value></data>
+  <data name="StepScheduleAssignmentHint" xml:space="preserve"><value>Chi è responsabile del controllo e quanto tempo ha una volta aperto.</value></data>
+  <data name="HelpFieldScheduleName" xml:space="preserve"><value>Compare nell'elenco delle scadenze, quindi rendilo riconoscibile a colpo d'occhio.</value></data>
+  <data name="HelpFieldWindowMinutes" xml:space="preserve"><value>Quanto tempo ha la squadra per completare il controllo dopo l'apertura. Oltre, risulta mancato.</value></data>
+  <data name="HelpFieldAssignment" xml:space="preserve"><value>L'instradamento automatico invia il controllo a chi detiene il target. Scegli persona, ruolo, gruppo o mezzo per sovrascriverlo.</value></data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Checklists/Checklists.pl.resx
+++ b/Core/Resgrid.Localization/Areas/User/Checklists/Checklists.pl.resx
@@ -694,4 +694,26 @@
   <data name="HistoricalWorkOrdersUnavailable" xml:space="preserve"><value>Nie udało się odtworzyć niektórych historycznych stanów zleceń. Pakiet nie gwarantuje pełnego pokrycia prac konserwacyjnych.</value></data>
   <data name="RestrictedWorkOrders" xml:space="preserve"><value>Dowody zleceń są ograniczone do bieżącego zakresu uprawnień odbiorcy.</value></data>
   <data name="ProtectedDataRequired" xml:space="preserve"><value>Aby kontynuować, należy odblokować dane chronione.</value></data>
+  <data name="ChecklistsIntro" xml:space="preserve"><value>Twórz kontrole wykonywane przez załogi, planuj je i sprawdzaj, co zostało zrobione.</value></data>
+  <data name="Close" xml:space="preserve"><value>Zamknij</value></data>
+  <data name="Continue" xml:space="preserve"><value>Dalej</value></data>
+  <data name="Review" xml:space="preserve"><value>Podsumowanie</value></data>
+  <data name="ReviewHint" xml:space="preserve"><value>Sprawdź poniższe odpowiedzi, a następnie zapisz.</value></data>
+  <data name="RequiredFieldsMissing" xml:space="preserve"><value>Wypełnij podświetlone pola przed przejściem dalej.</value></data>
+  <data name="NoRowsHelp" xml:space="preserve"><value>Jeszcze nic tu nie ma. Użyj przycisków powyżej, aby utworzyć pierwszy wpis.</value></data>
+  <data name="HelpDefinitions" xml:space="preserve"><value>Lista kontrolna to zestaw pytań, na które odpowiada załoga. Opublikuj ją, zanim zaplanujesz lub uruchomisz.</value></data>
+  <data name="StartRunHint" xml:space="preserve"><value>Wybierz, czego dotyczy to wykonanie.</value></data>
+  <data name="SkipHint" xml:space="preserve"><value>Usprawiedliwione kontrole pozostają w rejestrze wraz z podanym tu powodem.</value></data>
+  <data name="RetireHint" xml:space="preserve"><value>Wycofanie blokuje nowe wykonania i przyszłe zaplanowane kontrole. Historia zostaje zachowana.</value></data>
+  <data name="ReportRangeHint" xml:space="preserve"><value>Kontrole są wybierane według czasu rozpoczęcia, a nie zakończenia.</value></data>
+  <data name="HelpFieldCallId" xml:space="preserve"><value>Zdarzenie, dla którego przygotowywany jest pakiet.</value></data>
+  <data name="StepScheduleBasics" xml:space="preserve"><value>Nazwij harmonogram</value></data>
+  <data name="StepScheduleBasicsHint" xml:space="preserve"><value>Jak nazywa się ten harmonogram i czego dotyczy.</value></data>
+  <data name="StepScheduleTiming" xml:space="preserve"><value>Kiedy jest uruchamiany</value></data>
+  <data name="StepScheduleTimingHint" xml:space="preserve"><value>Jak często otwiera się kontrola i w jakiej strefie czasowej odczytywane są te godziny.</value></data>
+  <data name="StepScheduleAssignment" xml:space="preserve"><value>Kto ją przejmuje</value></data>
+  <data name="StepScheduleAssignmentHint" xml:space="preserve"><value>Kto odpowiada za kontrolę i ile ma czasu od jej otwarcia.</value></data>
+  <data name="HelpFieldScheduleName" xml:space="preserve"><value>Widoczna na liście terminów, więc niech będzie rozpoznawalna na pierwszy rzut oka.</value></data>
+  <data name="HelpFieldWindowMinutes" xml:space="preserve"><value>Ile czasu ma załoga na ukończenie kontroli od jej otwarcia. Po tym czasie liczy się jako pominięta.</value></data>
+  <data name="HelpFieldAssignment" xml:space="preserve"><value>Automatyczne kierowanie wysyła kontrolę do posiadacza obiektu. Wybierz osobę, rolę, grupę lub pojazd, aby to zmienić.</value></data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Checklists/Checklists.resx
+++ b/Core/Resgrid.Localization/Areas/User/Checklists/Checklists.resx
@@ -694,4 +694,26 @@
   <data name="HistoricalWorkOrdersUnavailable" xml:space="preserve"><value>Some historical work-order states could not be reconstructed. The packet does not claim complete maintenance coverage.</value></data>
   <data name="RestrictedWorkOrders" xml:space="preserve"><value>Work-order evidence is limited to the reader’s current authorized scope.</value></data>
   <data name="ProtectedDataRequired" xml:space="preserve"><value>Protected data must be unlocked to continue.</value></data>
+  <data name="ChecklistsIntro" xml:space="preserve"><value>Build the checks your crews run, schedule them, and see what was done.</value></data>
+  <data name="Close" xml:space="preserve"><value>Close</value></data>
+  <data name="Continue" xml:space="preserve"><value>Continue</value></data>
+  <data name="Review" xml:space="preserve"><value>Review</value></data>
+  <data name="ReviewHint" xml:space="preserve"><value>Check the answers below, then save.</value></data>
+  <data name="RequiredFieldsMissing" xml:space="preserve"><value>Fill in the highlighted fields before continuing.</value></data>
+  <data name="NoRowsHelp" xml:space="preserve"><value>Nothing here yet. Use the buttons above to create the first one.</value></data>
+  <data name="HelpDefinitions" xml:space="preserve"><value>A checklist is the set of questions a crew answers. Publish one before it can be scheduled or run.</value></data>
+  <data name="StartRunHint" xml:space="preserve"><value>Choose what this run is being carried out against.</value></data>
+  <data name="SkipHint" xml:space="preserve"><value>Excused checks stay on the record with the reason you give here.</value></data>
+  <data name="RetireHint" xml:space="preserve"><value>Retiring stops new runs and future scheduled checks. Existing history is kept.</value></data>
+  <data name="ReportRangeHint" xml:space="preserve"><value>Checks are selected by their start time, not when they were completed.</value></data>
+  <data name="HelpFieldCallId" xml:space="preserve"><value>The call the packet is being assembled for.</value></data>
+  <data name="StepScheduleBasics" xml:space="preserve"><value>Name the schedule</value></data>
+  <data name="StepScheduleBasicsHint" xml:space="preserve"><value>What this schedule is called and what it runs against.</value></data>
+  <data name="StepScheduleTiming" xml:space="preserve"><value>When it runs</value></data>
+  <data name="StepScheduleTimingHint" xml:space="preserve"><value>How often the check opens, and in which time zone those times are read.</value></data>
+  <data name="StepScheduleAssignment" xml:space="preserve"><value>Who picks it up</value></data>
+  <data name="StepScheduleAssignmentHint" xml:space="preserve"><value>Who is responsible for the check, and how long they have once it opens.</value></data>
+  <data name="HelpFieldScheduleName" xml:space="preserve"><value>Shown on the due list, so make it recognisable at a glance.</value></data>
+  <data name="HelpFieldWindowMinutes" xml:space="preserve"><value>How long the crew has to finish the check once it opens. After that it counts as missed.</value></data>
+  <data name="HelpFieldAssignment" xml:space="preserve"><value>Automatic routing sends the check to whoever holds the target. Pick a person, role, group or unit to override that.</value></data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Checklists/Checklists.sv.resx
+++ b/Core/Resgrid.Localization/Areas/User/Checklists/Checklists.sv.resx
@@ -694,4 +694,26 @@
   <data name="HistoricalWorkOrdersUnavailable" xml:space="preserve"><value>Vissa historiska tillstånd för arbetsorder kunde inte återskapas. Paketet garanterar inte fullständig underhållstäckning.</value></data>
   <data name="RestrictedWorkOrders" xml:space="preserve"><value>Arbetsorderbevisen begränsas till läsarens nuvarande behörighet.</value></data>
   <data name="ProtectedDataRequired" xml:space="preserve"><value>Skyddade data måste låsas upp för att fortsätta.</value></data>
+  <data name="ChecklistsIntro" xml:space="preserve"><value>Skapa de kontroller dina besättningar utför, schemalägg dem och se vad som gjorts.</value></data>
+  <data name="Close" xml:space="preserve"><value>Stäng</value></data>
+  <data name="Continue" xml:space="preserve"><value>Fortsätt</value></data>
+  <data name="Review" xml:space="preserve"><value>Granska</value></data>
+  <data name="ReviewHint" xml:space="preserve"><value>Kontrollera uppgifterna nedan och spara sedan.</value></data>
+  <data name="RequiredFieldsMissing" xml:space="preserve"><value>Fyll i de markerade fälten innan du fortsätter.</value></data>
+  <data name="NoRowsHelp" xml:space="preserve"><value>Inget här ännu. Använd knapparna ovan för att skapa den första.</value></data>
+  <data name="HelpDefinitions" xml:space="preserve"><value>En checklista är de frågor en besättning svarar på. Publicera den innan den kan schemaläggas eller köras.</value></data>
+  <data name="StartRunHint" xml:space="preserve"><value>Välj vad den här körningen gäller.</value></data>
+  <data name="SkipHint" xml:space="preserve"><value>Ursäktade kontroller står kvar i journalen med skälet du anger här.</value></data>
+  <data name="RetireHint" xml:space="preserve"><value>Utrangering stoppar nya körningar och framtida schemalagda kontroller. Befintlig historik behålls.</value></data>
+  <data name="ReportRangeHint" xml:space="preserve"><value>Kontroller väljs utifrån sin starttid, inte när de slutfördes.</value></data>
+  <data name="HelpFieldCallId" xml:space="preserve"><value>Larmet som paketet sammanställs för.</value></data>
+  <data name="StepScheduleBasics" xml:space="preserve"><value>Namnge schemat</value></data>
+  <data name="StepScheduleBasicsHint" xml:space="preserve"><value>Vad schemat heter och vad det gäller.</value></data>
+  <data name="StepScheduleTiming" xml:space="preserve"><value>När det körs</value></data>
+  <data name="StepScheduleTimingHint" xml:space="preserve"><value>Hur ofta kontrollen öppnas, och i vilken tidszon tiderna läses.</value></data>
+  <data name="StepScheduleAssignment" xml:space="preserve"><value>Vem som tar den</value></data>
+  <data name="StepScheduleAssignmentHint" xml:space="preserve"><value>Vem som ansvarar för kontrollen och hur lång tid de har när den öppnats.</value></data>
+  <data name="HelpFieldScheduleName" xml:space="preserve"><value>Visas i förfallolistan, så gör det igenkännbart vid en snabb blick.</value></data>
+  <data name="HelpFieldWindowMinutes" xml:space="preserve"><value>Hur lång tid besättningen har på sig att slutföra kontrollen efter att den öppnats. Därefter räknas den som missad.</value></data>
+  <data name="HelpFieldAssignment" xml:space="preserve"><value>Automatisk routning skickar kontrollen till den som innehar objektet. Välj person, roll, grupp eller fordon för att åsidosätta.</value></data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Checklists/Checklists.uk.resx
+++ b/Core/Resgrid.Localization/Areas/User/Checklists/Checklists.uk.resx
@@ -694,4 +694,26 @@
   <data name="HistoricalWorkOrdersUnavailable" xml:space="preserve"><value>Деякі історичні стани нарядів не вдалося відновити. Пакет не гарантує повного охоплення технічного обслуговування.</value></data>
   <data name="RestrictedWorkOrders" xml:space="preserve"><value>Докази нарядів обмежені поточним дозволеним обсягом доступу читача.</value></data>
   <data name="ProtectedDataRequired" xml:space="preserve"><value>Щоб продовжити, потрібно розблокувати захищені дані.</value></data>
+  <data name="ChecklistsIntro" xml:space="preserve"><value>Створюйте перевірки для ваших підрозділів, плануйте їх і дивіться, що виконано.</value></data>
+  <data name="Close" xml:space="preserve"><value>Закрити</value></data>
+  <data name="Continue" xml:space="preserve"><value>Продовжити</value></data>
+  <data name="Review" xml:space="preserve"><value>Перевірка</value></data>
+  <data name="ReviewHint" xml:space="preserve"><value>Перевірте відповіді нижче та збережіть.</value></data>
+  <data name="RequiredFieldsMissing" xml:space="preserve"><value>Заповніть підсвічені поля, перш ніж продовжити.</value></data>
+  <data name="NoRowsHelp" xml:space="preserve"><value>Тут ще нічого немає. Скористайтеся кнопками вище, щоб створити перший запис.</value></data>
+  <data name="HelpDefinitions" xml:space="preserve"><value>Чек-лист — це набір запитань, на які відповідає підрозділ. Опублікуйте його, перш ніж планувати чи виконувати.</value></data>
+  <data name="StartRunHint" xml:space="preserve"><value>Оберіть, щодо чого виконується ця перевірка.</value></data>
+  <data name="SkipHint" xml:space="preserve"><value>Виправдані перевірки залишаються в записі разом із зазначеною тут причиною.</value></data>
+  <data name="RetireHint" xml:space="preserve"><value>Списання зупиняє нові виконання та майбутні заплановані перевірки. Наявна історія зберігається.</value></data>
+  <data name="ReportRangeHint" xml:space="preserve"><value>Перевірки добираються за часом початку, а не завершення.</value></data>
+  <data name="HelpFieldCallId" xml:space="preserve"><value>Виклик, для якого формується пакет.</value></data>
+  <data name="StepScheduleBasics" xml:space="preserve"><value>Назвіть розклад</value></data>
+  <data name="StepScheduleBasicsHint" xml:space="preserve"><value>Як називається цей розклад і щодо чого він виконується.</value></data>
+  <data name="StepScheduleTiming" xml:space="preserve"><value>Коли він виконується</value></data>
+  <data name="StepScheduleTimingHint" xml:space="preserve"><value>Як часто відкривається перевірка і в якому часовому поясі читаються ці години.</value></data>
+  <data name="StepScheduleAssignment" xml:space="preserve"><value>Хто її виконує</value></data>
+  <data name="StepScheduleAssignmentHint" xml:space="preserve"><value>Хто відповідає за перевірку і скільки часу має після її відкриття.</value></data>
+  <data name="HelpFieldScheduleName" xml:space="preserve"><value>Показується у списку до виконання, тож зробіть її впізнаваною з першого погляду.</value></data>
+  <data name="HelpFieldWindowMinutes" xml:space="preserve"><value>Скільки часу має підрозділ, щоб завершити перевірку після її відкриття. Після цього вона вважається пропущеною.</value></data>
+  <data name="HelpFieldAssignment" xml:space="preserve"><value>Автоматична маршрутизація надсилає перевірку тому, хто відповідає за об'єкт. Оберіть особу, роль, групу чи техніку, щоб змінити це.</value></data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Inventory/Inventory.ar.resx
+++ b/Core/Resgrid.Localization/Areas/User/Inventory/Inventory.ar.resx
@@ -526,4 +526,137 @@
   <data name="WorkOrderPostingRequired" xml:space="preserve"><value>سجل هذه القطعة أو اعكسها من خلال أمر العمل المرتبط.</value></data>
   <data name="AssetSafetyHold" xml:space="preserve"><value>يمنع حظر سلامة الصيانة إعادة هذه المعدة إلى الخدمة.</value></data>
   <data name="ReadinessProRequired" xml:space="preserve"><value>يلزم Readiness Pro لأعمال الصيانة الجديدة.</value></data>
+  <data name="AdjustStock" xml:space="preserve"><value>تعديل المخزون</value></data>
+  <data name="Back" xml:space="preserve"><value>رجوع</value></data>
+  <data name="Category" xml:space="preserve"><value>الفئة</value></data>
+  <data name="Close" xml:space="preserve"><value>إغلاق</value></data>
+  <data name="Contents" xml:space="preserve"><value>المحتويات</value></data>
+  <data name="Continue" xml:space="preserve"><value>متابعة</value></data>
+  <data name="EditItem" xml:space="preserve"><value>تعديل الصنف</value></data>
+  <data name="Expires" xml:space="preserve"><value>تنتهي</value></data>
+  <data name="Filter" xml:space="preserve"><value>تصفية</value></data>
+  <data name="IssueEquipment" xml:space="preserve"><value>صرف معدات</value></data>
+  <data name="Item" xml:space="preserve"><value>الصنف</value></data>
+  <data name="NewCategory" xml:space="preserve"><value>فئة جديدة</value></data>
+  <data name="NewKit" xml:space="preserve"><value>طقم جديد</value></data>
+  <data name="NewLocation" xml:space="preserve"><value>موقع جديد</value></data>
+  <data name="NewLot" xml:space="preserve"><value>دفعة جديدة</value></data>
+  <data name="NewTransfer" xml:space="preserve"><value>نقل جديد</value></data>
+  <data name="NoRowsHelp" xml:space="preserve"><value>لا يوجد شيء هنا بعد. استخدم الأزرار أعلاه لإنشاء أول سجل.</value></data>
+  <data name="Outstanding" xml:space="preserve"><value>معلّق</value></data>
+  <data name="Quantity" xml:space="preserve"><value>الكمية</value></data>
+  <data name="RequiredFieldsMissing" xml:space="preserve"><value>املأ الحقول المميزة قبل المتابعة.</value></data>
+  <data name="Review" xml:space="preserve"><value>مراجعة</value></data>
+  <data name="ReviewHint" xml:space="preserve"><value>راجع الإجابات أدناه ثم احفظ.</value></data>
+  <data name="Transaction" xml:space="preserve"><value>حركة</value></data>
+  <data name="Type" xml:space="preserve"><value>النوع</value></data>
+  <data name="When" xml:space="preserve"><value>التاريخ</value></data>
+  <data name="WorkspaceIntro" xml:space="preserve"><value>تتبّع ما تملكه إدارتك وأين يُحفظ ومن يحمله.</value></data>
+  <data name="M4PurchasingIntro" xml:space="preserve"><value>إدارة المورّدين وإنشاء أوامر الشراء ومعرفة قيمة مخزونك.</value></data>
+  <data name="M5OperationsIntro" xml:space="preserve"><value>نفّذ الجرد الفعلي وعالج التنبيهات واطبع تقارير المخزون.</value></data>
+  <data name="HelpOnHand" xml:space="preserve"><value>ما لديك الآن حسب الصنف والموقع. صفِّ حسب صنف أو مكان، ثم عدّل المخزون عند تغيّر الجرد.</value></data>
+  <data name="HelpItems" xml:space="preserve"><value>الأصناف هي مدخلات الفهرس وليست أشياء مادية. حدّد طريقة التتبّع قبل إضافة المخزون.</value></data>
+  <data name="HelpCategories" xml:space="preserve"><value>تجمّع الفئات الأصناف لتبقى القوائم والتقارير مقروءة. يمكن أن تندرج الفئة تحت فئة أعلى.</value></data>
+  <data name="HelpLocations" xml:space="preserve"><value>المواقع هي حيث يوجد المخزون: المحطات والمركبات والأفراد والحاويات أو رف داخل موقع آخر.</value></data>
+  <data name="HelpLots" xml:space="preserve"><value>الدفعة هي مجموعة من صنف واحد تشترك في رقم الدفعة وتاريخ الانتهاء والتكلفة.</value></data>
+  <data name="HelpAssets" xml:space="preserve"><value>الأصول هي معدات ذات أرقام تسلسلية فردية. لكل منها رقمه وحالته وسجله.</value></data>
+  <data name="HelpIssuances" xml:space="preserve"><value>معدات مصروفة حاليًا لشخص أو مركبة. سجّل الإرجاع عند عودتها.</value></data>
+  <data name="HelpKits" xml:space="preserve"><value>الطقم قائمة ثابتة من الأصناف تُصرف معًا، مثل بدلة الإطفاء أو حقيبة الإسعاف.</value></data>
+  <data name="HelpTransfers" xml:space="preserve"><value>انقل المخزون بين موقعين. يُسجَّل طرفا الحركة في السجل.</value></data>
+  <data name="HelpHistory" xml:space="preserve"><value>تُكتب كل حركة في سجل للإضافة فقط. صفِّ حسب الصنف أو الموقع لتدقيق تغيير.</value></data>
+  <data name="HelpAssetDetail" xml:space="preserve"><value>السجل الكامل لأصل واحد مع قوائم التحقق وأوامر العمل الخاصة به.</value></data>
+  <data name="HelpTransaction" xml:space="preserve"><value>قيد واحد في السجل معروض كما كُتب تمامًا.</value></data>
+  <data name="HelpUnitEquipment" xml:space="preserve"><value>كل ما هو مخصص حاليًا للمركبة المحددة.</value></data>
+  <data name="HelpPersonnelGear" xml:space="preserve"><value>كل ما هو مصروف حاليًا للشخص المحدد.</value></data>
+  <data name="HelpHolderLookup" xml:space="preserve"><value>ابحث عن كل ما بحوزة مركبة أو شخص.</value></data>
+  <data name="HelpLocationRename" xml:space="preserve"><value>يمكن تغيير الاسم فقط هنا. حُدِّد الموضع والنطاق عند الإنشاء.</value></data>
+  <data name="HelpAssetStatus" xml:space="preserve"><value>يؤدي تغيير الحالة إلى إنشاء قيد في السجل. استخدمه عند الإصلاح أو التلف أو الفقد أو الإحالة.</value></data>
+  <data name="HelpWitness" xml:space="preserve"><value>أدخل رقم الطلب الظاهر عند التسجيل ثم اشهد بما رأيت.</value></data>
+  <data name="M4HelpVendors" xml:space="preserve"><value>المورّدون الذين تشتري منهم. يرتبط كل منهم بجهة اتصال شركة وقد يحمل رقم حساب.</value></data>
+  <data name="M4HelpPurchaseOrders" xml:space="preserve"><value>أنشئ أمر شراء لدى مورّد ثم استلم عليه. يسجّل الاستلام المخزون ويثبّت التكلفة.</value></data>
+  <data name="M4HelpValuation" xml:space="preserve"><value>قيمة المخزون لديك بحسب التكلفة المسجّلة عند الاستلام.</value></data>
+  <data name="M5NoAlertsHelp" xml:space="preserve"><value>لا توجد تنبيهات مفتوحة. حدّث لإعادة فحص المستويات وتواريخ الانتهاء والإرجاعات المتأخرة.</value></data>
+  <data name="M5CountEnterHelp" xml:space="preserve"><value>أدخل ما جردته فعليًا لكل سطر. يتحدّث عمود الفرق بعد الحفظ.</value></data>
+  <data name="M5CountNameHelp" xml:space="preserve"><value>اسم يسهل التعرّف عليه لاحقًا، مثل «الجرد السنوي للمحطة 2».</value></data>
+  <data name="StepItemBasics" xml:space="preserve"><value>وصف الصنف</value></data>
+  <data name="StepItemTracking" xml:space="preserve"><value>طريقة التتبّع</value></data>
+  <data name="StepItemStock" xml:space="preserve"><value>مستويات المخزون والتكلفة</value></data>
+  <data name="StepLocationBasics" xml:space="preserve"><value>سمِّ الموقع</value></data>
+  <data name="StepLocationScope" xml:space="preserve"><value>أين يقع</value></data>
+  <data name="StepMovementWhat" xml:space="preserve"><value>ما الذي يتحرك</value></data>
+  <data name="StepMovementWhere" xml:space="preserve"><value>من وإلى</value></data>
+  <data name="StepMovementAmount" xml:space="preserve"><value>الكمية</value></data>
+  <data name="StepIssueWhat" xml:space="preserve"><value>ما الذي يُصرف</value></data>
+  <data name="StepIssueWho" xml:space="preserve"><value>من يستلمه</value></data>
+  <data name="StepIssueWhen" xml:space="preserve"><value>الإرجاع والملاحظات</value></data>
+  <data name="StepAssetItem" xml:space="preserve"><value>أي صنف</value></data>
+  <data name="StepAssetIdentity" xml:space="preserve"><value>الرقم التسلسلي والوسوم</value></data>
+  <data name="StepLotItem" xml:space="preserve"><value>أي صنف</value></data>
+  <data name="StepLotDetails" xml:space="preserve"><value>تفاصيل الدفعة</value></data>
+  <data name="StepKitBasics" xml:space="preserve"><value>سمِّ الطقم</value></data>
+  <data name="StepKitContents" xml:space="preserve"><value>محتويات الطقم</value></data>
+  <data name="M4StepOrderHeader" xml:space="preserve"><value>تفاصيل الطلب</value></data>
+  <data name="M4StepOrderLines" xml:space="preserve"><value>بنود الطلب</value></data>
+  <data name="M5StepCountBasics" xml:space="preserve"><value>سمِّ عملية الجرد</value></data>
+  <data name="M5StepCountScope" xml:space="preserve"><value>النطاق</value></data>
+  <data name="M5StepReportKind" xml:space="preserve"><value>اختر تقريرًا</value></data>
+  <data name="M5StepReportFilters" xml:space="preserve"><value>ضيّق النطاق</value></data>
+  <data name="HelpFieldAmount" xml:space="preserve"><value>كم وحدة، بوحدة قياس الصنف.</value></data>
+  <data name="HelpFieldAsset" xml:space="preserve"><value>للأصناف ذات الأرقام التسلسلية، اختر الوحدة المحدّدة.</value></data>
+  <data name="HelpFieldCategory" xml:space="preserve"><value>تجميع اختياري تستخدمه القوائم والتقارير.</value></data>
+  <data name="HelpFieldCode" xml:space="preserve"><value>رقم الصنف أو القطعة الخاص بك، إن وُجد.</value></data>
+  <data name="HelpFieldCountLocation" xml:space="preserve"><value>اتركه فارغًا لجرد كل شيء.</value></data>
+  <data name="HelpFieldCurrency" xml:space="preserve"><value>رمز عملة من ثلاثة أحرف، مثل USD أو EUR.</value></data>
+  <data name="HelpFieldDefaultLocation" xml:space="preserve"><value>يصل المخزون الجديد إلى هنا عند عدم اختيار موقع.</value></data>
+  <data name="HelpFieldExpectedReturn" xml:space="preserve"><value>تُعلَّم الإرجاعات المتأخرة في شاشة التنبيهات.</value></data>
+  <data name="HelpFieldExpiration" xml:space="preserve"><value>التاريخ الذي يصبح فيه المخزون غير صالح.</value></data>
+  <data name="HelpFieldFromLocation" xml:space="preserve"><value>من أين يخرج المخزون. اتركه فارغًا عند إدخال مخزون جديد.</value></data>
+  <data name="HelpFieldHolder" xml:space="preserve"><value>اختر شخصًا أو مركبة، وليس كليهما.</value></data>
+  <data name="HelpFieldIsActive" xml:space="preserve"><value>تبقى الأصناف غير النشطة في السجل لكن لا يمكن اختيارها لحركات جديدة.</value></data>
+  <data name="HelpFieldIsControlledSubstance" xml:space="preserve"><value>تتطلب الحركات شاهدًا ثانيًا وتُحفظ للتدقيق.</value></data>
+  <data name="HelpFieldIsKit" xml:space="preserve"><value>حدّده كحاوية طقم بدلاً من صنف يُخزّن بمفرده.</value></data>
+  <data name="HelpFieldLocationType" xml:space="preserve"><value>محطة أو مركبة أو شخص أو حاوية أو موقع فرعي داخل موقع آخر.</value></data>
+  <data name="HelpFieldLot" xml:space="preserve"><value>اختر الدفعة التي جاء منها المخزون إذا كان الصنف يُتتبَّع بالدفعات.</value></data>
+  <data name="HelpFieldMinimum" xml:space="preserve"><value>أطلق تنبيهًا عند انخفاض الرصيد عن هذا الحد.</value></data>
+  <data name="HelpFieldNote" xml:space="preserve"><value>سبب حدوث ذلك. تظهر الملاحظات في السجل والتقارير.</value></data>
+  <data name="HelpFieldParent" xml:space="preserve"><value>اختياري. أدرج هذا السجل ضمن سجل آخر.</value></data>
+  <data name="HelpFieldReorderPoint" xml:space="preserve"><value>اقترح إعادة الطلب عند بلوغ الرصيد هذا الحد.</value></data>
+  <data name="HelpFieldReportRange" xml:space="preserve"><value>تتجاهل تقارير اللقطة نطاق التاريخ.</value></data>
+  <data name="HelpFieldRequiresExpiration" xml:space="preserve"><value>اشترط تاريخ انتهاء ليظهر الصنف في تنبيهات الانتهاء.</value></data>
+  <data name="HelpFieldRequiresLotTracking" xml:space="preserve"><value>اشترط رقم دفعة عند كل استلام لهذا الصنف.</value></data>
+  <data name="HelpFieldReturnCondition" xml:space="preserve"><value>الحالة التي عادت بها المعدات.</value></data>
+  <data name="HelpFieldSerialNumber" xml:space="preserve"><value>الرقم التسلسلي للمصنّع. يجب أن يكون فريدًا لهذا الصنف.</value></data>
+  <data name="HelpFieldToLocation" xml:space="preserve"><value>إلى أين يذهب المخزون. اتركه فارغًا عند الاستهلاك أو الشطب.</value></data>
+  <data name="HelpFieldTrackingMode" xml:space="preserve"><value>السائب يحصي كمية. أما التسلسلي فيتتبّع كل وحدة على حدة برقمها وسجلها.</value></data>
+  <data name="HelpFieldUnitCost" xml:space="preserve"><value>تكلفة الوحدة الواحدة، تُستخدم للتقييم.</value></data>
+  <data name="HelpFieldUnitOfMeasure" xml:space="preserve"><value>كيف تُحصيه: قطعة، صندوق، لتر، متر.</value></data>
+  <data name="M4AccountNumberHelp" xml:space="preserve"><value>رقم الحساب الذي يعرفك به هذا المورّد.</value></data>
+  <data name="M4CompanyContactHelp" xml:space="preserve"><value>اختر جهة اتصال الشركة التي ينتمي إليها هذا المورّد.</value></data>
+  <data name="M4NewVendorHint" xml:space="preserve"><value>المورّد هو جهة اتصال شركة تشتري منها. أضف جهة الاتصال أولًا إن لم تكن موجودة.</value></data>
+  <data name="M4PurchaseOrderNumberHelp" xml:space="preserve"><value>مرجعك لهذا الطلب. يظهر في السجل عند استلام المخزون.</value></data>
+  <data name="M4StepOrderHeaderHint" xml:space="preserve"><value>ممّن تشتري، وبأي مرجع، وبأي عملة.</value></data>
+  <data name="M4StepOrderLinesHint" xml:space="preserve"><value>سطر لكل صنف. الكميات والتكاليف هنا هي أساس الاستلام.</value></data>
+  <data name="M5StepCountBasicsHint" xml:space="preserve"><value>يثبّت الجرد لقطة من مخزونك لمقارنتها بما على الرف.</value></data>
+  <data name="M5StepCountScopeHint" xml:space="preserve"><value>اجرد موقعًا واحدًا، أو اتركه فارغًا لجرد الإدارة كلها.</value></data>
+  <data name="M5StepReportKindHint" xml:space="preserve"><value>يحدّد التقرير أي المرشّحات في الخطوة التالية تنطبق.</value></data>
+  <data name="M5StepReportFiltersHint" xml:space="preserve"><value>اترك المرشّح فارغًا لتضمين كل شيء. المرشّحات غير المتاحة تظهر معطّلة.</value></data>
+  <data name="StepAssetItemHint" xml:space="preserve"><value>الأصل هو وحدة مادية من صنف. حدّد الصنف ومكان وجوده.</value></data>
+  <data name="StepAssetIdentityHint" xml:space="preserve"><value>كيف تُعرَّف هذه الوحدة عند أخذها أو مسحها ضوئيًا.</value></data>
+  <data name="StepIssueWhatHint" xml:space="preserve"><value>اختر الصنف والمكان الذي يخرج منه.</value></data>
+  <data name="StepIssueWhenHint" xml:space="preserve"><value>متى تتوقع إعادته، وما يستحق التسجيل عن التسليم.</value></data>
+  <data name="StepItemBasicsHint" xml:space="preserve"><value>ما سيراه الناس عند البحث عنه في قائمة.</value></data>
+  <data name="StepItemTrackingHint" xml:space="preserve"><value>تحدّد هذه الإجابات ما سيطلبه النظام لاحقًا، ويصعب تغييرها بعد وجود مخزون.</value></data>
+  <data name="StepItemStockHint" xml:space="preserve"><value>حدود اختيارية تُطلق تنبيهات نقص المخزون، إضافةً إلى التكلفة المستخدمة في التقييم.</value></data>
+  <data name="StepKitBasicsHint" xml:space="preserve"><value>تُصرف الأطقم كوحدة واحدة، فامنحه اسمًا يعرفه أفرادك.</value></data>
+  <data name="StepKitContentsHint" xml:space="preserve"><value>اذكر كل صنف يحتويه الطقم وكميته.</value></data>
+  <data name="StepKitIssueHint" xml:space="preserve"><value>أكّد أي وحدة مادية ومن أي رف يأتي كل جزء من الطقم.</value></data>
+  <data name="StepLocationBasicsHint" xml:space="preserve"><value>يظهر الاسم في كل قائمة تسأل عن مكان الشيء.</value></data>
+  <data name="StepLocationScopeHint" xml:space="preserve"><value>املأ الحقل المطابق للنوع الذي اخترته فقط، واترك البقية فارغة.</value></data>
+  <data name="StepLotDetailsHint" xml:space="preserve"><value>رقم الدفعة كما هو مطبوع على العبوة، مع تكلفتها وتاريخ انتهائها.</value></data>
+  <data name="StepLotItemHint" xml:space="preserve"><value>تنتمي الدفعات دائمًا إلى صنف واحد، فاختره أولًا.</value></data>
+  <data name="StepMovementWhatHint" xml:space="preserve"><value>يحدّد نوع الحركة أي الحقول أدناه سيستخدمها النظام.</value></data>
+  <data name="StepMovementWhereHint" xml:space="preserve"><value>الاستلام يحتاج وجهة فقط؛ والاستهلاك أو الشطب يحتاج مصدرًا فقط.</value></data>
+  <data name="StepMovementAmountHint" xml:space="preserve"><value>الكمية والسبب. كلاهما يُدرج في القيد الذي يُنشأ.</value></data>
+  <data name="StepReturnHint" xml:space="preserve"><value>حدّد الكمية المُعادة، وإلى أين ذهبت، وحالتها.</value></data>
+  <data name="Inactive" xml:space="preserve"><value>غير نشط</value></data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Inventory/Inventory.de.resx
+++ b/Core/Resgrid.Localization/Areas/User/Inventory/Inventory.de.resx
@@ -650,4 +650,137 @@
   <data name="WorkOrderPostingRequired" xml:space="preserve"><value>Dieses Teil über seinen Arbeitsauftrag buchen oder stornieren.</value></data>
   <data name="AssetSafetyHold" xml:space="preserve"><value>Eine Wartungssicherheitssperre verhindert die Wiederinbetriebnahme dieses Geräts.</value></data>
   <data name="ReadinessProRequired" xml:space="preserve"><value>Für neue Wartungsarbeiten ist Readiness Pro erforderlich.</value></data>
+  <data name="AdjustStock" xml:space="preserve"><value>Bestand anpassen</value></data>
+  <data name="Back" xml:space="preserve"><value>Zurück</value></data>
+  <data name="Category" xml:space="preserve"><value>Kategorie</value></data>
+  <data name="Close" xml:space="preserve"><value>Schließen</value></data>
+  <data name="Contents" xml:space="preserve"><value>Inhalt</value></data>
+  <data name="Continue" xml:space="preserve"><value>Weiter</value></data>
+  <data name="EditItem" xml:space="preserve"><value>Artikel bearbeiten</value></data>
+  <data name="Expires" xml:space="preserve"><value>Läuft ab</value></data>
+  <data name="Filter" xml:space="preserve"><value>Filtern</value></data>
+  <data name="IssueEquipment" xml:space="preserve"><value>Ausrüstung ausgeben</value></data>
+  <data name="Item" xml:space="preserve"><value>Artikel</value></data>
+  <data name="NewCategory" xml:space="preserve"><value>Neue Kategorie</value></data>
+  <data name="NewKit" xml:space="preserve"><value>Neues Set</value></data>
+  <data name="NewLocation" xml:space="preserve"><value>Neuer Lagerort</value></data>
+  <data name="NewLot" xml:space="preserve"><value>Neue Charge</value></data>
+  <data name="NewTransfer" xml:space="preserve"><value>Neue Umlagerung</value></data>
+  <data name="NoRowsHelp" xml:space="preserve"><value>Hier ist noch nichts. Legen Sie über die Schaltflächen oben den ersten Eintrag an.</value></data>
+  <data name="Outstanding" xml:space="preserve"><value>Offen</value></data>
+  <data name="Quantity" xml:space="preserve"><value>Menge</value></data>
+  <data name="RequiredFieldsMissing" xml:space="preserve"><value>Füllen Sie die hervorgehobenen Felder aus, bevor Sie fortfahren.</value></data>
+  <data name="Review" xml:space="preserve"><value>Prüfen</value></data>
+  <data name="ReviewHint" xml:space="preserve"><value>Prüfen Sie die Angaben unten und speichern Sie dann.</value></data>
+  <data name="Transaction" xml:space="preserve"><value>Buchung</value></data>
+  <data name="Type" xml:space="preserve"><value>Typ</value></data>
+  <data name="When" xml:space="preserve"><value>Zeitpunkt</value></data>
+  <data name="WorkspaceIntro" xml:space="preserve"><value>Verfolgen Sie, was Ihre Abteilung besitzt, wo es lagert und wer es mitführt.</value></data>
+  <data name="M4PurchasingIntro" xml:space="preserve"><value>Lieferanten verwalten, Bestellungen anlegen und den Wert Ihres Bestands sehen.</value></data>
+  <data name="M5OperationsIntro" xml:space="preserve"><value>Inventuren durchführen, Warnungen abarbeiten und Bestandsberichte drucken.</value></data>
+  <data name="HelpOnHand" xml:space="preserve"><value>Ihr aktueller Bestand nach Artikel und Lagerort. Filtern Sie nach Artikel oder Ort und passen Sie den Bestand an, wenn sich eine Zählung ändert.</value></data>
+  <data name="HelpItems" xml:space="preserve"><value>Artikel sind das, was Sie führen: der Katalogeintrag, nicht das physische Objekt. Legen Sie die Nachverfolgung fest, bevor Sie Bestand erfassen.</value></data>
+  <data name="HelpCategories" xml:space="preserve"><value>Kategorien gruppieren Artikel, damit Listen und Berichte lesbar bleiben. Eine Kategorie kann einer übergeordneten Kategorie untergeordnet sein.</value></data>
+  <data name="HelpLocations" xml:space="preserve"><value>Lagerorte sind, wo Bestand liegt: Wachen, Fahrzeuge, Personen, Behälter oder ein Fach innerhalb eines anderen Ortes.</value></data>
+  <data name="HelpLots" xml:space="preserve"><value>Eine Charge ist eine Menge eines Artikels mit gleicher Chargennummer, gleichem Ablaufdatum und gleichen Kosten.</value></data>
+  <data name="HelpAssets" xml:space="preserve"><value>Assets sind einzeln seriennummerierte Ausrüstungsteile. Jedes hat eigene Seriennummer, Status und Historie.</value></data>
+  <data name="HelpIssuances" xml:space="preserve"><value>Ausrüstung, die derzeit an eine Person oder ein Fahrzeug ausgegeben ist. Erfassen Sie die Rückgabe, wenn sie zurückkommt.</value></data>
+  <data name="HelpKits" xml:space="preserve"><value>Ein Set ist eine feste Liste von Artikeln, die zusammen ausgegeben werden, etwa eine Einsatzkleidung oder ein Notfallrucksack.</value></data>
+  <data name="HelpTransfers" xml:space="preserve"><value>Bestand zwischen zwei Lagerorten umlagern. Beide Seiten der Bewegung werden im Journal erfasst.</value></data>
+  <data name="HelpHistory" xml:space="preserve"><value>Jede Bewegung wird in ein reines Anfüge-Journal geschrieben. Filtern Sie nach Artikel oder Ort, um eine Änderung zu prüfen.</value></data>
+  <data name="HelpAssetDetail" xml:space="preserve"><value>Die vollständige Historie eines einzelnen Assets samt Checklisten und Arbeitsaufträgen.</value></data>
+  <data name="HelpTransaction" xml:space="preserve"><value>Ein einzelner Journaleintrag, genau so dargestellt, wie er erfasst wurde.</value></data>
+  <data name="HelpUnitEquipment" xml:space="preserve"><value>Alles, was dem ausgewählten Fahrzeug derzeit zugeordnet ist.</value></data>
+  <data name="HelpPersonnelGear" xml:space="preserve"><value>Alles, was derzeit an die ausgewählte Person ausgegeben ist.</value></data>
+  <data name="HelpHolderLookup" xml:space="preserve"><value>Zeigen Sie alles an, was ein Fahrzeug oder eine Person führt.</value></data>
+  <data name="HelpLocationRename" xml:space="preserve"><value>Hier lässt sich nur der Name ändern. Zuordnung und Geltungsbereich wurden bei der Anlage festgelegt.</value></data>
+  <data name="HelpAssetStatus" xml:space="preserve"><value>Eine Statusänderung erzeugt einen Journaleintrag. Nutzen Sie sie bei Reparatur, Beschädigung, Verlust oder Ausmusterung.</value></data>
+  <data name="HelpWitness" xml:space="preserve"><value>Geben Sie die beim Buchen angezeigte Anforderungsnummer ein und bestätigen Sie, was Sie beobachtet haben.</value></data>
+  <data name="M4HelpVendors" xml:space="preserve"><value>Lieferanten, bei denen Sie einkaufen. Jeder ist mit einem Firmenkontakt verknüpft und kann eine Kundennummer führen.</value></data>
+  <data name="M4HelpPurchaseOrders" xml:space="preserve"><value>Legen Sie eine Bestellung bei einem Lieferanten an und buchen Sie den Wareneingang. Der Eingang bucht den Bestand und erfasst die Kosten.</value></data>
+  <data name="M4HelpValuation" xml:space="preserve"><value>Der Wert Ihres Bestands auf Basis der beim Wareneingang erfassten Kosten.</value></data>
+  <data name="M5NoAlertsHelp" xml:space="preserve"><value>Keine offenen Warnungen. Aktualisieren Sie, um Bestände, Ablaufdaten und überfällige Rückgaben erneut zu prüfen.</value></data>
+  <data name="M5CountEnterHelp" xml:space="preserve"><value>Tragen Sie für jede Zeile die tatsächlich gezählte Menge ein. Die Abweichungsspalte aktualisiert sich nach dem Speichern.</value></data>
+  <data name="M5CountNameHelp" xml:space="preserve"><value>Etwas, das Sie später wiedererkennen, etwa "Wache 2 Jahresinventur".</value></data>
+  <data name="StepItemBasics" xml:space="preserve"><value>Artikel beschreiben</value></data>
+  <data name="StepItemTracking" xml:space="preserve"><value>Art der Nachverfolgung</value></data>
+  <data name="StepItemStock" xml:space="preserve"><value>Bestandsgrenzen und Kosten</value></data>
+  <data name="StepLocationBasics" xml:space="preserve"><value>Lagerort benennen</value></data>
+  <data name="StepLocationScope" xml:space="preserve"><value>Zuordnung</value></data>
+  <data name="StepMovementWhat" xml:space="preserve"><value>Was bewegt wird</value></data>
+  <data name="StepMovementWhere" xml:space="preserve"><value>Von und nach</value></data>
+  <data name="StepMovementAmount" xml:space="preserve"><value>Menge</value></data>
+  <data name="StepIssueWhat" xml:space="preserve"><value>Was ausgegeben wird</value></data>
+  <data name="StepIssueWho" xml:space="preserve"><value>Wer es übernimmt</value></data>
+  <data name="StepIssueWhen" xml:space="preserve"><value>Rückgabe und Notizen</value></data>
+  <data name="StepAssetItem" xml:space="preserve"><value>Welcher Artikel</value></data>
+  <data name="StepAssetIdentity" xml:space="preserve"><value>Seriennummer und Kennzeichnung</value></data>
+  <data name="StepLotItem" xml:space="preserve"><value>Welcher Artikel</value></data>
+  <data name="StepLotDetails" xml:space="preserve"><value>Chargendaten</value></data>
+  <data name="StepKitBasics" xml:space="preserve"><value>Set benennen</value></data>
+  <data name="StepKitContents" xml:space="preserve"><value>Set-Inhalt</value></data>
+  <data name="M4StepOrderHeader" xml:space="preserve"><value>Bestelldaten</value></data>
+  <data name="M4StepOrderLines" xml:space="preserve"><value>Bestellpositionen</value></data>
+  <data name="M5StepCountBasics" xml:space="preserve"><value>Inventur benennen</value></data>
+  <data name="M5StepCountScope" xml:space="preserve"><value>Umfang</value></data>
+  <data name="M5StepReportKind" xml:space="preserve"><value>Bericht wählen</value></data>
+  <data name="M5StepReportFilters" xml:space="preserve"><value>Eingrenzen</value></data>
+  <data name="HelpFieldAmount" xml:space="preserve"><value>Wie viele Einheiten, in der Mengeneinheit des Artikels.</value></data>
+  <data name="HelpFieldAsset" xml:space="preserve"><value>Bei seriennummerierten Artikeln die genaue Einheit auswählen.</value></data>
+  <data name="HelpFieldCategory" xml:space="preserve"><value>Optionale Gruppierung für Listen und Berichte.</value></data>
+  <data name="HelpFieldCode" xml:space="preserve"><value>Ihre eigene Artikel- oder Teilenummer, falls vorhanden.</value></data>
+  <data name="HelpFieldCountLocation" xml:space="preserve"><value>Leer lassen, um alles zu zählen.</value></data>
+  <data name="HelpFieldCurrency" xml:space="preserve"><value>Dreistelliger Währungscode, etwa USD oder EUR.</value></data>
+  <data name="HelpFieldDefaultLocation" xml:space="preserve"><value>Neuer Bestand landet hier, wenn kein Lagerort gewählt wird.</value></data>
+  <data name="HelpFieldExpectedReturn" xml:space="preserve"><value>Überfällige Rückgaben erscheinen im Warnungsbereich.</value></data>
+  <data name="HelpFieldExpiration" xml:space="preserve"><value>Das Datum, ab dem dieser Bestand nicht mehr verwendbar ist.</value></data>
+  <data name="HelpFieldFromLocation" xml:space="preserve"><value>Von wo der Bestand abgeht. Leer lassen, wenn neuer Bestand zugeht.</value></data>
+  <data name="HelpFieldHolder" xml:space="preserve"><value>Wählen Sie entweder eine Person oder ein Fahrzeug, nicht beides.</value></data>
+  <data name="HelpFieldIsActive" xml:space="preserve"><value>Inaktive Artikel bleiben in der Historie, sind aber für neue Bewegungen nicht wählbar.</value></data>
+  <data name="HelpFieldIsControlledSubstance" xml:space="preserve"><value>Bewegungen müssen von einer zweiten Person bezeugt werden und werden revisionssicher aufbewahrt.</value></data>
+  <data name="HelpFieldIsKit" xml:space="preserve"><value>Als Set-Behälter kennzeichnen statt als eigenständig geführten Artikel.</value></data>
+  <data name="HelpFieldLocationType" xml:space="preserve"><value>Wache, Fahrzeug, Person, Behälter oder Unterort eines anderen Ortes.</value></data>
+  <data name="HelpFieldLot" xml:space="preserve"><value>Wählen Sie die Charge, aus der dieser Bestand stammt, sofern chargenpflichtig.</value></data>
+  <data name="HelpFieldMinimum" xml:space="preserve"><value>Warnung auslösen, wenn der Bestand darunter fällt.</value></data>
+  <data name="HelpFieldNote" xml:space="preserve"><value>Warum dies geschah. Notizen erscheinen im Journal und in Berichten.</value></data>
+  <data name="HelpFieldParent" xml:space="preserve"><value>Optional. Diesem Eintrag einen übergeordneten Eintrag zuweisen.</value></data>
+  <data name="HelpFieldReorderPoint" xml:space="preserve"><value>Nachbestellung vorschlagen, sobald der Bestand diesen Wert erreicht.</value></data>
+  <data name="HelpFieldReportRange" xml:space="preserve"><value>Stichtagsberichte ignorieren den Zeitraum.</value></data>
+  <data name="HelpFieldRequiresExpiration" xml:space="preserve"><value>Ablaufdatum verlangen, damit der Artikel in Ablaufwarnungen erscheint.</value></data>
+  <data name="HelpFieldRequiresLotTracking" xml:space="preserve"><value>Bei jedem Wareneingang dieses Artikels eine Chargennummer verlangen.</value></data>
+  <data name="HelpFieldReturnCondition" xml:space="preserve"><value>Der Zustand, in dem die Ausrüstung zurückkam.</value></data>
+  <data name="HelpFieldSerialNumber" xml:space="preserve"><value>Herstellerseriennummer. Sie muss für diesen Artikel eindeutig sein.</value></data>
+  <data name="HelpFieldToLocation" xml:space="preserve"><value>Wohin der Bestand geht. Leer lassen bei Verbrauch oder Ausbuchung.</value></data>
+  <data name="HelpFieldTrackingMode" xml:space="preserve"><value>Schüttgut zählt eine Menge. Seriennummeriert verfolgt jede Einheit einzeln mit eigener Nummer und Historie.</value></data>
+  <data name="HelpFieldUnitCost" xml:space="preserve"><value>Kosten je Einheit, für die Bewertung verwendet.</value></data>
+  <data name="HelpFieldUnitOfMeasure" xml:space="preserve"><value>Wie Sie zählen: Stück, Karton, Liter, Meter.</value></data>
+  <data name="M4AccountNumberHelp" xml:space="preserve"><value>Die Kundennummer, unter der dieser Lieferant Sie führt.</value></data>
+  <data name="M4CompanyContactHelp" xml:space="preserve"><value>Wählen Sie den Firmenkontakt, zu dem dieser Lieferant gehört.</value></data>
+  <data name="M4NewVendorHint" xml:space="preserve"><value>Ein Lieferant ist ein Firmenkontakt, bei dem Sie einkaufen. Legen Sie den Kontakt zuerst an, falls er fehlt.</value></data>
+  <data name="M4PurchaseOrderNumberHelp" xml:space="preserve"><value>Ihre Referenz für diese Bestellung. Sie erscheint beim Wareneingang im Journal.</value></data>
+  <data name="M4StepOrderHeaderHint" xml:space="preserve"><value>Bei wem Sie kaufen, unter welcher Referenz und in welcher Währung.</value></data>
+  <data name="M4StepOrderLinesHint" xml:space="preserve"><value>Eine Zeile je Artikel. Mengen und Kosten hier sind die Grundlage des Wareneingangs.</value></data>
+  <data name="M5StepCountBasicsHint" xml:space="preserve"><value>Eine Inventur friert eine Momentaufnahme Ihres Bestands ein, um sie mit dem Regal zu vergleichen.</value></data>
+  <data name="M5StepCountScopeHint" xml:space="preserve"><value>Einen Lagerort zählen oder leer lassen, um die gesamte Abteilung zu zählen.</value></data>
+  <data name="M5StepReportKindHint" xml:space="preserve"><value>Der Bericht bestimmt, welche Filter im nächsten Schritt gelten.</value></data>
+  <data name="M5StepReportFiltersHint" xml:space="preserve"><value>Leere Filter schließen alles ein. Nicht verfügbare Filter sind ausgegraut.</value></data>
+  <data name="StepAssetItemHint" xml:space="preserve"><value>Ein Asset ist eine physische Einheit eines Artikels. Geben Sie Artikel und Lagerort an.</value></data>
+  <data name="StepAssetIdentityHint" xml:space="preserve"><value>Wie diese Einheit identifiziert wird, wenn sie jemand aufnimmt oder scannt.</value></data>
+  <data name="StepIssueWhatHint" xml:space="preserve"><value>Wählen Sie den Artikel und den Ort, aus dem er entnommen wird.</value></data>
+  <data name="StepIssueWhenHint" xml:space="preserve"><value>Wann Sie es zurückerwarten und was zur Übergabe festzuhalten ist.</value></data>
+  <data name="StepItemBasicsHint" xml:space="preserve"><value>Was Nutzer sehen, wenn sie in einer Liste danach suchen.</value></data>
+  <data name="StepItemTrackingHint" xml:space="preserve"><value>Diese Angaben bestimmen spätere Abfragen und lassen sich mit vorhandenem Bestand kaum ändern.</value></data>
+  <data name="StepItemStockHint" xml:space="preserve"><value>Optionale Schwellen für Bestandswarnungen sowie die Kosten für die Bewertung.</value></data>
+  <data name="StepKitBasicsHint" xml:space="preserve"><value>Sets werden als Ganzes ausgegeben; wählen Sie einen Namen, den Ihre Einsatzkräfte kennen.</value></data>
+  <data name="StepKitContentsHint" xml:space="preserve"><value>Listen Sie jeden enthaltenen Artikel und die jeweilige Menge auf.</value></data>
+  <data name="StepKitIssueHint" xml:space="preserve"><value>Bestätigen Sie für jeden Teil des Sets die physische Einheit und den Lagerort.</value></data>
+  <data name="StepLocationBasicsHint" xml:space="preserve"><value>Der Name erscheint in jeder Auswahl, die nach dem Ort fragt.</value></data>
+  <data name="StepLocationScopeHint" xml:space="preserve"><value>Füllen Sie nur das Feld aus, das zum gewählten Typ passt; den Rest leer lassen.</value></data>
+  <data name="StepLotDetailsHint" xml:space="preserve"><value>Die Chargennummer wie auf der Verpackung, dazu Kosten und Ablaufdatum der Charge.</value></data>
+  <data name="StepLotItemHint" xml:space="preserve"><value>Chargen gehören immer zu einem Artikel; wählen Sie ihn zuerst.</value></data>
+  <data name="StepMovementWhatHint" xml:space="preserve"><value>Die Bewegungsart bestimmt, welche der Felder unten verwendet werden.</value></data>
+  <data name="StepMovementWhereHint" xml:space="preserve"><value>Ein Zugang braucht nur ein Ziel; Verbrauch oder Ausbuchung nur eine Quelle.</value></data>
+  <data name="StepMovementAmountHint" xml:space="preserve"><value>Menge und Grund. Beides landet im erzeugten Journaleintrag.</value></data>
+  <data name="StepReturnHint" xml:space="preserve"><value>Geben Sie an, wie viel zurückkam, wohin es ging und in welchem Zustand es ist.</value></data>
+  <data name="Inactive" xml:space="preserve"><value>Inaktiv</value></data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Inventory/Inventory.el.resx
+++ b/Core/Resgrid.Localization/Areas/User/Inventory/Inventory.el.resx
@@ -709,4 +709,137 @@
   <data name="WorkOrderPostingRequired" xml:space="preserve"><value>Καταχωρίστε ή αντιλογίστε το ανταλλακτικό μέσω της εντολής εργασίας του.</value></data>
   <data name="AssetSafetyHold" xml:space="preserve"><value>Δέσμευση ασφαλείας συντήρησης εμποδίζει την επαναφορά του εξοπλισμού.</value></data>
   <data name="ReadinessProRequired" xml:space="preserve"><value>Απαιτείται Readiness Pro για νέες εργασίες συντήρησης.</value></data>
+  <data name="AdjustStock" xml:space="preserve"><value>Προσαρμογή αποθέματος</value></data>
+  <data name="Back" xml:space="preserve"><value>Πίσω</value></data>
+  <data name="Category" xml:space="preserve"><value>Κατηγορία</value></data>
+  <data name="Close" xml:space="preserve"><value>Κλείσιμο</value></data>
+  <data name="Contents" xml:space="preserve"><value>Περιεχόμενα</value></data>
+  <data name="Continue" xml:space="preserve"><value>Συνέχεια</value></data>
+  <data name="EditItem" xml:space="preserve"><value>Επεξεργασία είδους</value></data>
+  <data name="Expires" xml:space="preserve"><value>Λήγει</value></data>
+  <data name="Filter" xml:space="preserve"><value>Φίλτρο</value></data>
+  <data name="IssueEquipment" xml:space="preserve"><value>Χρέωση εξοπλισμού</value></data>
+  <data name="Item" xml:space="preserve"><value>Είδος</value></data>
+  <data name="NewCategory" xml:space="preserve"><value>Νέα κατηγορία</value></data>
+  <data name="NewKit" xml:space="preserve"><value>Νέο κιτ</value></data>
+  <data name="NewLocation" xml:space="preserve"><value>Νέα τοποθεσία</value></data>
+  <data name="NewLot" xml:space="preserve"><value>Νέα παρτίδα</value></data>
+  <data name="NewTransfer" xml:space="preserve"><value>Νέα μεταφορά</value></data>
+  <data name="NoRowsHelp" xml:space="preserve"><value>Δεν υπάρχει τίποτα ακόμη. Χρησιμοποιήστε τα κουμπιά παραπάνω για να δημιουργήσετε την πρώτη εγγραφή.</value></data>
+  <data name="Outstanding" xml:space="preserve"><value>Σε εκκρεμότητα</value></data>
+  <data name="Quantity" xml:space="preserve"><value>Ποσότητα</value></data>
+  <data name="RequiredFieldsMissing" xml:space="preserve"><value>Συμπληρώστε τα επισημασμένα πεδία πριν συνεχίσετε.</value></data>
+  <data name="Review" xml:space="preserve"><value>Έλεγχος</value></data>
+  <data name="ReviewHint" xml:space="preserve"><value>Ελέγξτε τις απαντήσεις παρακάτω και αποθηκεύστε.</value></data>
+  <data name="Transaction" xml:space="preserve"><value>Εγγραφή κίνησης</value></data>
+  <data name="Type" xml:space="preserve"><value>Τύπος</value></data>
+  <data name="When" xml:space="preserve"><value>Πότε</value></data>
+  <data name="WorkspaceIntro" xml:space="preserve"><value>Παρακολουθήστε τι κατέχει η υπηρεσία σας, πού φυλάσσεται και ποιος το έχει χρεωθεί.</value></data>
+  <data name="M4PurchasingIntro" xml:space="preserve"><value>Διαχειριστείτε προμηθευτές, δημιουργήστε παραγγελίες και δείτε την αξία του αποθέματος.</value></data>
+  <data name="M5OperationsIntro" xml:space="preserve"><value>Εκτελέστε φυσικές απογραφές, διαχειριστείτε ειδοποιήσεις και εκτυπώστε αναφορές.</value></data>
+  <data name="HelpOnHand" xml:space="preserve"><value>Τι έχετε αυτή τη στιγμή, ανά είδος και τοποθεσία. Φιλτράρετε ανά είδος ή χώρο και προσαρμόστε το απόθεμα όταν αλλάζει μια καταμέτρηση.</value></data>
+  <data name="HelpItems" xml:space="preserve"><value>Τα είδη είναι οι καταχωρίσεις καταλόγου, όχι φυσικά αντικείμενα. Αποφασίστε πώς παρακολουθείται καθένα πριν προσθέσετε απόθεμα.</value></data>
+  <data name="HelpCategories" xml:space="preserve"><value>Οι κατηγορίες ομαδοποιούν είδη ώστε λίστες και αναφορές να παραμένουν ευανάγνωστες. Μια κατηγορία μπορεί να ανήκει σε γονική κατηγορία.</value></data>
+  <data name="HelpLocations" xml:space="preserve"><value>Οι τοποθεσίες είναι όπου βρίσκεται το απόθεμα: σταθμοί, οχήματα, άτομα, περιέκτες ή ένα ράφι μέσα σε άλλη τοποθεσία.</value></data>
+  <data name="HelpLots" xml:space="preserve"><value>Μια παρτίδα είναι ένα σύνολο ενός είδους με κοινό αριθμό παρτίδας, ημερομηνία λήξης και κόστος.</value></data>
+  <data name="HelpAssets" xml:space="preserve"><value>Τα πάγια είναι εξοπλισμός με ατομικό σειριακό αριθμό. Το καθένα έχει δικό του αριθμό, κατάσταση και ιστορικό.</value></data>
+  <data name="HelpIssuances" xml:space="preserve"><value>Εξοπλισμός χρεωμένος αυτή τη στιγμή σε άτομο ή όχημα. Καταγράψτε την επιστροφή όταν γυρίσει.</value></data>
+  <data name="HelpKits" xml:space="preserve"><value>Ένα κιτ είναι μια σταθερή λίστα ειδών που χρεώνονται μαζί, όπως στολή επέμβασης ή σάκος διάσωσης.</value></data>
+  <data name="HelpTransfers" xml:space="preserve"><value>Μετακινήστε απόθεμα μεταξύ δύο τοποθεσιών. Και οι δύο πλευρές της κίνησης καταγράφονται.</value></data>
+  <data name="HelpHistory" xml:space="preserve"><value>Κάθε κίνηση καταγράφεται σε ημερολόγιο μόνο προσθήκης. Φιλτράρετε ανά είδος ή τοποθεσία για έλεγχο.</value></data>
+  <data name="HelpAssetDetail" xml:space="preserve"><value>Το πλήρες ιστορικό ενός παγίου, μαζί με τις λίστες ελέγχου και τις εντολές εργασίας.</value></data>
+  <data name="HelpTransaction" xml:space="preserve"><value>Μία εγγραφή ημερολογίου, όπως ακριβώς καταγράφηκε.</value></data>
+  <data name="HelpUnitEquipment" xml:space="preserve"><value>Ό,τι είναι αυτή τη στιγμή χρεωμένο στο επιλεγμένο όχημα.</value></data>
+  <data name="HelpPersonnelGear" xml:space="preserve"><value>Ό,τι είναι αυτή τη στιγμή χρεωμένο στο επιλεγμένο άτομο.</value></data>
+  <data name="HelpHolderLookup" xml:space="preserve"><value>Αναζητήστε ό,τι κατέχει ένα όχημα ή ένα άτομο.</value></data>
+  <data name="HelpLocationRename" xml:space="preserve"><value>Εδώ αλλάζει μόνο το όνομα. Η τοποθέτηση και το εύρος ορίστηκαν κατά τη δημιουργία.</value></data>
+  <data name="HelpAssetStatus" xml:space="preserve"><value>Η αλλαγή κατάστασης δημιουργεί εγγραφή. Χρησιμοποιήστε την σε επισκευή, ζημιά, απώλεια ή απόσυρση.</value></data>
+  <data name="HelpWitness" xml:space="preserve"><value>Εισαγάγετε τον αριθμό αιτήματος που εμφανίστηκε κατά την καταχώριση και βεβαιώστε τι είδατε.</value></data>
+  <data name="M4HelpVendors" xml:space="preserve"><value>Προμηθευτές από τους οποίους αγοράζετε. Καθένας συνδέεται με εταιρική επαφή και μπορεί να έχει αριθμό λογαριασμού.</value></data>
+  <data name="M4HelpPurchaseOrders" xml:space="preserve"><value>Δημιουργήστε παραγγελία σε προμηθευτή και μετά παραλάβετε. Η παραλαβή καταχωρεί το απόθεμα και το κόστος.</value></data>
+  <data name="M4HelpValuation" xml:space="preserve"><value>Η αξία του αποθέματος που έχετε, με βάση το κόστος που καταγράφηκε στην παραλαβή.</value></data>
+  <data name="M5NoAlertsHelp" xml:space="preserve"><value>Δεν υπάρχουν ανοιχτές ειδοποιήσεις. Ανανεώστε για νέο έλεγχο αποθεμάτων, λήξεων και εκπρόθεσμων επιστροφών.</value></data>
+  <data name="M5CountEnterHelp" xml:space="preserve"><value>Καταχωρίστε την πραγματική καταμέτρηση για κάθε γραμμή. Η στήλη απόκλισης ενημερώνεται μετά την αποθήκευση.</value></data>
+  <data name="M5CountNameHelp" xml:space="preserve"><value>Κάτι που θα αναγνωρίσετε αργότερα, π.χ. «Ετήσια απογραφή Σταθμού 2».</value></data>
+  <data name="StepItemBasics" xml:space="preserve"><value>Περιγράψτε το είδος</value></data>
+  <data name="StepItemTracking" xml:space="preserve"><value>Τρόπος παρακολούθησης</value></data>
+  <data name="StepItemStock" xml:space="preserve"><value>Επίπεδα αποθέματος και κόστος</value></data>
+  <data name="StepLocationBasics" xml:space="preserve"><value>Ονομάστε την τοποθεσία</value></data>
+  <data name="StepLocationScope" xml:space="preserve"><value>Πού ανήκει</value></data>
+  <data name="StepMovementWhat" xml:space="preserve"><value>Τι μετακινείται</value></data>
+  <data name="StepMovementWhere" xml:space="preserve"><value>Από και προς</value></data>
+  <data name="StepMovementAmount" xml:space="preserve"><value>Πόσο</value></data>
+  <data name="StepIssueWhat" xml:space="preserve"><value>Τι χρεώνεται</value></data>
+  <data name="StepIssueWho" xml:space="preserve"><value>Ποιος το παραλαμβάνει</value></data>
+  <data name="StepIssueWhen" xml:space="preserve"><value>Επιστροφή και σημειώσεις</value></data>
+  <data name="StepAssetItem" xml:space="preserve"><value>Ποιο είδος</value></data>
+  <data name="StepAssetIdentity" xml:space="preserve"><value>Σειριακός αριθμός και ετικέτες</value></data>
+  <data name="StepLotItem" xml:space="preserve"><value>Ποιο είδος</value></data>
+  <data name="StepLotDetails" xml:space="preserve"><value>Στοιχεία παρτίδας</value></data>
+  <data name="StepKitBasics" xml:space="preserve"><value>Ονομάστε το κιτ</value></data>
+  <data name="StepKitContents" xml:space="preserve"><value>Περιεχόμενο κιτ</value></data>
+  <data name="M4StepOrderHeader" xml:space="preserve"><value>Στοιχεία παραγγελίας</value></data>
+  <data name="M4StepOrderLines" xml:space="preserve"><value>Γραμμές παραγγελίας</value></data>
+  <data name="M5StepCountBasics" xml:space="preserve"><value>Ονομάστε την απογραφή</value></data>
+  <data name="M5StepCountScope" xml:space="preserve"><value>Εύρος</value></data>
+  <data name="M5StepReportKind" xml:space="preserve"><value>Επιλέξτε αναφορά</value></data>
+  <data name="M5StepReportFilters" xml:space="preserve"><value>Περιορίστε το</value></data>
+  <data name="HelpFieldAmount" xml:space="preserve"><value>Πόσες μονάδες, στη μονάδα μέτρησης του είδους.</value></data>
+  <data name="HelpFieldAsset" xml:space="preserve"><value>Για είδη με σειριακό αριθμό, επιλέξτε τη συγκεκριμένη μονάδα.</value></data>
+  <data name="HelpFieldCategory" xml:space="preserve"><value>Προαιρετική ομαδοποίηση για λίστες και αναφορές.</value></data>
+  <data name="HelpFieldCode" xml:space="preserve"><value>Ο δικός σας κωδικός είδους ή ανταλλακτικού, αν υπάρχει.</value></data>
+  <data name="HelpFieldCountLocation" xml:space="preserve"><value>Αφήστε το κενό για καταμέτρηση όλων.</value></data>
+  <data name="HelpFieldCurrency" xml:space="preserve"><value>Τριγράμματος κωδικός νομίσματος, π.χ. USD ή EUR.</value></data>
+  <data name="HelpFieldDefaultLocation" xml:space="preserve"><value>Το νέο απόθεμα καταλήγει εδώ όταν δεν επιλεγεί τοποθεσία.</value></data>
+  <data name="HelpFieldExpectedReturn" xml:space="preserve"><value>Οι εκπρόθεσμες επιστροφές επισημαίνονται στις ειδοποιήσεις.</value></data>
+  <data name="HelpFieldExpiration" xml:space="preserve"><value>Η ημερομηνία μετά την οποία το απόθεμα δεν είναι χρησιμοποιήσιμο.</value></data>
+  <data name="HelpFieldFromLocation" xml:space="preserve"><value>Από πού φεύγει το απόθεμα. Αφήστε κενό για εισαγωγή νέου αποθέματος.</value></data>
+  <data name="HelpFieldHolder" xml:space="preserve"><value>Επιλέξτε άτομο ή όχημα, όχι και τα δύο.</value></data>
+  <data name="HelpFieldIsActive" xml:space="preserve"><value>Τα ανενεργά είδη παραμένουν στο ιστορικό αλλά δεν επιλέγονται για νέες κινήσεις.</value></data>
+  <data name="HelpFieldIsControlledSubstance" xml:space="preserve"><value>Οι κινήσεις απαιτούν δεύτερο μάρτυρα και τηρούνται για έλεγχο.</value></data>
+  <data name="HelpFieldIsKit" xml:space="preserve"><value>Σημειώστε το ως περιέκτη κιτ αντί για είδος που αποθηκεύεται μόνο του.</value></data>
+  <data name="HelpFieldLocationType" xml:space="preserve"><value>Σταθμός, όχημα, άτομο, περιέκτης ή υπο-τοποθεσία άλλου χώρου.</value></data>
+  <data name="HelpFieldLot" xml:space="preserve"><value>Επιλέξτε την παρτίδα προέλευσης, αν το είδος παρακολουθείται ανά παρτίδα.</value></data>
+  <data name="HelpFieldMinimum" xml:space="preserve"><value>Δημιουργία ειδοποίησης όταν το απόθεμα πέσει κάτω από αυτό.</value></data>
+  <data name="HelpFieldNote" xml:space="preserve"><value>Γιατί συνέβη. Οι σημειώσεις εμφανίζονται στο ημερολόγιο και τις αναφορές.</value></data>
+  <data name="HelpFieldParent" xml:space="preserve"><value>Προαιρετικό. Ένθεση αυτής της εγγραφής κάτω από άλλη.</value></data>
+  <data name="HelpFieldReorderPoint" xml:space="preserve"><value>Πρόταση επαναπαραγγελίας όταν το απόθεμα φτάσει σε αυτό.</value></data>
+  <data name="HelpFieldReportRange" xml:space="preserve"><value>Οι αναφορές στιγμιότυπου αγνοούν το εύρος ημερομηνιών.</value></data>
+  <data name="HelpFieldRequiresExpiration" xml:space="preserve"><value>Απαίτηση ημερομηνίας λήξης ώστε το είδος να εμφανίζεται στις ειδοποιήσεις.</value></data>
+  <data name="HelpFieldRequiresLotTracking" xml:space="preserve"><value>Απαίτηση αριθμού παρτίδας σε κάθε παραλαβή του είδους.</value></data>
+  <data name="HelpFieldReturnCondition" xml:space="preserve"><value>Η κατάσταση στην οποία επέστρεψε ο εξοπλισμός.</value></data>
+  <data name="HelpFieldSerialNumber" xml:space="preserve"><value>Σειριακός αριθμός κατασκευαστή. Πρέπει να είναι μοναδικός για το είδος.</value></data>
+  <data name="HelpFieldToLocation" xml:space="preserve"><value>Πού πηγαίνει το απόθεμα. Αφήστε κενό σε ανάλωση ή διαγραφή.</value></data>
+  <data name="HelpFieldTrackingMode" xml:space="preserve"><value>Χύμα μετρά ποσότητα. Σειριακό παρακολουθεί κάθε μονάδα ξεχωριστά, με δικό της αριθμό και ιστορικό.</value></data>
+  <data name="HelpFieldUnitCost" xml:space="preserve"><value>Κόστος μίας μονάδας, για την αποτίμηση.</value></data>
+  <data name="HelpFieldUnitOfMeasure" xml:space="preserve"><value>Πώς το μετράτε: τεμάχιο, κιβώτιο, λίτρο, μέτρο.</value></data>
+  <data name="M4AccountNumberHelp" xml:space="preserve"><value>Ο λογαριασμός με τον οποίο σας γνωρίζει ο προμηθευτής.</value></data>
+  <data name="M4CompanyContactHelp" xml:space="preserve"><value>Επιλέξτε την εταιρική επαφή στην οποία ανήκει ο προμηθευτής.</value></data>
+  <data name="M4NewVendorHint" xml:space="preserve"><value>Ο προμηθευτής είναι εταιρική επαφή από την οποία αγοράζετε. Προσθέστε πρώτα την επαφή αν λείπει.</value></data>
+  <data name="M4PurchaseOrderNumberHelp" xml:space="preserve"><value>Η αναφορά σας για την παραγγελία. Εμφανίζεται στο ημερολόγιο κατά την παραλαβή.</value></data>
+  <data name="M4StepOrderHeaderHint" xml:space="preserve"><value>Από ποιον αγοράζετε, με ποια αναφορά και σε ποιο νόμισμα.</value></data>
+  <data name="M4StepOrderLinesHint" xml:space="preserve"><value>Μία γραμμή ανά είδος. Ποσότητες και κόστη εδώ αποτελούν τη βάση της παραλαβής.</value></data>
+  <data name="M5StepCountBasicsHint" xml:space="preserve"><value>Η απογραφή παγώνει ένα στιγμιότυπο του αποθέματος για σύγκριση με το ράφι.</value></data>
+  <data name="M5StepCountScopeHint" xml:space="preserve"><value>Καταμετρήστε μία τοποθεσία ή αφήστε κενό για όλη την υπηρεσία.</value></data>
+  <data name="M5StepReportKindHint" xml:space="preserve"><value>Η αναφορά καθορίζει ποια φίλτρα του επόμενου βήματος ισχύουν.</value></data>
+  <data name="M5StepReportFiltersHint" xml:space="preserve"><value>Αφήστε ένα φίλτρο κενό για να συμπεριληφθούν όλα. Τα μη διαθέσιμα φίλτρα είναι ανενεργά.</value></data>
+  <data name="StepAssetItemHint" xml:space="preserve"><value>Ένα πάγιο είναι μία φυσική μονάδα ενός είδους. Δηλώστε το είδος και πού θα βρίσκεται.</value></data>
+  <data name="StepAssetIdentityHint" xml:space="preserve"><value>Πώς αναγνωρίζεται αυτή η μονάδα όταν κάποιος την πάρει ή τη σαρώσει.</value></data>
+  <data name="StepIssueWhatHint" xml:space="preserve"><value>Επιλέξτε το είδος και τον χώρο από τον οποίο βγαίνει.</value></data>
+  <data name="StepIssueWhenHint" xml:space="preserve"><value>Πότε το περιμένετε πίσω και ό,τι αξίζει να καταγραφεί για την παράδοση.</value></data>
+  <data name="StepItemBasicsHint" xml:space="preserve"><value>Τι θα βλέπουν οι χρήστες όταν το αναζητούν σε μια λίστα.</value></data>
+  <data name="StepItemTrackingHint" xml:space="preserve"><value>Αυτές οι απαντήσεις καθορίζουν τι θα ζητήσει το σύστημα αργότερα και δύσκολα αλλάζουν όταν υπάρχει απόθεμα.</value></data>
+  <data name="StepItemStockHint" xml:space="preserve"><value>Προαιρετικά όρια που ενεργοποιούν ειδοποιήσεις χαμηλού αποθέματος και το κόστος αποτίμησης.</value></data>
+  <data name="StepKitBasicsHint" xml:space="preserve"><value>Τα κιτ χρεώνονται ολόκληρα, οπότε δώστε όνομα που θα αναγνωρίζουν τα πληρώματα.</value></data>
+  <data name="StepKitContentsHint" xml:space="preserve"><value>Απαριθμήστε κάθε είδος του κιτ και την ποσότητά του.</value></data>
+  <data name="StepKitIssueHint" xml:space="preserve"><value>Επιβεβαιώστε ποια φυσική μονάδα και από ποιο ράφι προέρχεται κάθε μέρος του κιτ.</value></data>
+  <data name="StepLocationBasicsHint" xml:space="preserve"><value>Το όνομα εμφανίζεται σε κάθε λίστα που ρωτά πού βρίσκεται κάτι.</value></data>
+  <data name="StepLocationScopeHint" xml:space="preserve"><value>Συμπληρώστε μόνο το πεδίο που ταιριάζει στον τύπο που επιλέξατε· αφήστε τα υπόλοιπα κενά.</value></data>
+  <data name="StepLotDetailsHint" xml:space="preserve"><value>Ο αριθμός παρτίδας όπως αναγράφεται στη συσκευασία, μαζί με κόστος και λήξη.</value></data>
+  <data name="StepLotItemHint" xml:space="preserve"><value>Οι παρτίδες ανήκουν πάντα σε ένα είδος, οπότε επιλέξτε το πρώτα.</value></data>
+  <data name="StepMovementWhatHint" xml:space="preserve"><value>Το είδος της κίνησης καθορίζει ποια από τα παρακάτω πεδία θα χρησιμοποιηθούν.</value></data>
+  <data name="StepMovementWhereHint" xml:space="preserve"><value>Η παραλαβή χρειάζεται μόνο προορισμό· η ανάλωση ή διαγραφή μόνο προέλευση.</value></data>
+  <data name="StepMovementAmountHint" xml:space="preserve"><value>Η ποσότητα και ο λόγος. Και τα δύο καταγράφονται στην εγγραφή που δημιουργείται.</value></data>
+  <data name="StepReturnHint" xml:space="preserve"><value>Δηλώστε πόσα επέστρεψαν, πού πήγαν και σε τι κατάσταση είναι.</value></data>
+  <data name="Inactive" xml:space="preserve"><value>Ανενεργό</value></data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Inventory/Inventory.en.resx
+++ b/Core/Resgrid.Localization/Areas/User/Inventory/Inventory.en.resx
@@ -709,4 +709,137 @@
   <data name="WorkOrderPostingRequired" xml:space="preserve"><value>Post or reverse this part through its work order.</value></data>
   <data name="AssetSafetyHold" xml:space="preserve"><value>A maintenance safety hold prevents returning this equipment to service.</value></data>
   <data name="ReadinessProRequired" xml:space="preserve"><value>Readiness Pro is required for new maintenance work.</value></data>
+  <data name="AdjustStock" xml:space="preserve"><value>Adjust stock</value></data>
+  <data name="Back" xml:space="preserve"><value>Back</value></data>
+  <data name="Category" xml:space="preserve"><value>Category</value></data>
+  <data name="Close" xml:space="preserve"><value>Close</value></data>
+  <data name="Contents" xml:space="preserve"><value>Contents</value></data>
+  <data name="Continue" xml:space="preserve"><value>Continue</value></data>
+  <data name="EditItem" xml:space="preserve"><value>Edit item</value></data>
+  <data name="Expires" xml:space="preserve"><value>Expires</value></data>
+  <data name="Filter" xml:space="preserve"><value>Filter</value></data>
+  <data name="IssueEquipment" xml:space="preserve"><value>Issue equipment</value></data>
+  <data name="Item" xml:space="preserve"><value>Item</value></data>
+  <data name="NewCategory" xml:space="preserve"><value>New category</value></data>
+  <data name="NewKit" xml:space="preserve"><value>New kit</value></data>
+  <data name="NewLocation" xml:space="preserve"><value>New location</value></data>
+  <data name="NewLot" xml:space="preserve"><value>New lot</value></data>
+  <data name="NewTransfer" xml:space="preserve"><value>New transfer</value></data>
+  <data name="NoRowsHelp" xml:space="preserve"><value>Nothing here yet. Use the buttons above to create the first record.</value></data>
+  <data name="Outstanding" xml:space="preserve"><value>Outstanding</value></data>
+  <data name="Quantity" xml:space="preserve"><value>Quantity</value></data>
+  <data name="RequiredFieldsMissing" xml:space="preserve"><value>Fill in the highlighted fields before continuing.</value></data>
+  <data name="Review" xml:space="preserve"><value>Review</value></data>
+  <data name="ReviewHint" xml:space="preserve"><value>Check the answers below, then save.</value></data>
+  <data name="Transaction" xml:space="preserve"><value>Ledger entry</value></data>
+  <data name="Type" xml:space="preserve"><value>Type</value></data>
+  <data name="When" xml:space="preserve"><value>When</value></data>
+  <data name="WorkspaceIntro" xml:space="preserve"><value>Track what your department owns, where it is kept and who is carrying it.</value></data>
+  <data name="M4PurchasingIntro" xml:space="preserve"><value>Manage suppliers, raise purchase orders and see what your stock is worth.</value></data>
+  <data name="M5OperationsIntro" xml:space="preserve"><value>Run physical counts, work through alerts and print inventory reports.</value></data>
+  <data name="HelpOnHand" xml:space="preserve"><value>What you hold right now, by item and location. Filter to one item or place, then adjust the stock when a count changes.</value></data>
+  <data name="HelpItems" xml:space="preserve"><value>Items are the things you stock: the catalogue entry, not a physical object. Decide how each one is tracked before you add stock for it.</value></data>
+  <data name="HelpCategories" xml:space="preserve"><value>Categories group items so lists and reports stay readable. A category can sit under a parent category.</value></data>
+  <data name="HelpLocations" xml:space="preserve"><value>Locations are where stock lives: stations, apparatus, people, containers, or a shelf inside another location.</value></data>
+  <data name="HelpLots" xml:space="preserve"><value>A lot is a batch of one item sharing a lot number, an expiry date and a cost.</value></data>
+  <data name="HelpAssets" xml:space="preserve"><value>Assets are individually serialised pieces of equipment. Each one has its own serial number, status and history.</value></data>
+  <data name="HelpIssuances" xml:space="preserve"><value>Equipment currently signed out to a person or an apparatus. Record a return when it comes back.</value></data>
+  <data name="HelpKits" xml:space="preserve"><value>A kit is a fixed list of items issued together, such as a turnout gear set or a medic bag.</value></data>
+  <data name="HelpTransfers" xml:space="preserve"><value>Move stock between two locations. Both sides of the move are written to the ledger.</value></data>
+  <data name="HelpHistory" xml:space="preserve"><value>Every movement is written to an append-only ledger. Filter it by item or location to audit a change.</value></data>
+  <data name="HelpAssetDetail" xml:space="preserve"><value>The full history of a single asset, together with its checklists and work orders.</value></data>
+  <data name="HelpTransaction" xml:space="preserve"><value>A single ledger entry, shown exactly as it was written.</value></data>
+  <data name="HelpUnitEquipment" xml:space="preserve"><value>Everything currently assigned to the selected apparatus.</value></data>
+  <data name="HelpPersonnelGear" xml:space="preserve"><value>Everything currently signed out to the selected person.</value></data>
+  <data name="HelpHolderLookup" xml:space="preserve"><value>Look up everything held by one apparatus or one person.</value></data>
+  <data name="HelpLocationRename" xml:space="preserve"><value>Only the name can change here. Placement and scope were fixed when the location was created.</value></data>
+  <data name="HelpAssetStatus" xml:space="preserve"><value>Changing the status writes a ledger entry. Use it when equipment goes for repair, is damaged, lost or retired.</value></data>
+  <data name="HelpWitness" xml:space="preserve"><value>Enter the request number shown when the movement was posted, then attest to what you saw.</value></data>
+  <data name="M4HelpVendors" xml:space="preserve"><value>Suppliers you buy from. Each one is linked to a company contact and can carry an account number.</value></data>
+  <data name="M4HelpPurchaseOrders" xml:space="preserve"><value>Raise an order with a supplier, then receive against it. Receiving posts the stock and records what it cost.</value></data>
+  <data name="M4HelpValuation" xml:space="preserve"><value>What the stock you hold is worth, using the cost recorded when it was received.</value></data>
+  <data name="M5NoAlertsHelp" xml:space="preserve"><value>No alerts are open. Refresh to check stock levels, expiry dates and overdue returns again.</value></data>
+  <data name="M5CountEnterHelp" xml:space="preserve"><value>Enter what you actually counted for every line. The variance column updates once the count is saved.</value></data>
+  <data name="M5CountNameHelp" xml:space="preserve"><value>Something you will recognise later, such as "Station 2 annual count".</value></data>
+  <data name="StepItemBasics" xml:space="preserve"><value>Describe the item</value></data>
+  <data name="StepItemTracking" xml:space="preserve"><value>How it is tracked</value></data>
+  <data name="StepItemStock" xml:space="preserve"><value>Stock levels and cost</value></data>
+  <data name="StepLocationBasics" xml:space="preserve"><value>Name the location</value></data>
+  <data name="StepLocationScope" xml:space="preserve"><value>Where it sits</value></data>
+  <data name="StepMovementWhat" xml:space="preserve"><value>What is moving</value></data>
+  <data name="StepMovementWhere" xml:space="preserve"><value>From and to</value></data>
+  <data name="StepMovementAmount" xml:space="preserve"><value>How much</value></data>
+  <data name="StepIssueWhat" xml:space="preserve"><value>What is being issued</value></data>
+  <data name="StepIssueWho" xml:space="preserve"><value>Who is taking it</value></data>
+  <data name="StepIssueWhen" xml:space="preserve"><value>Return and notes</value></data>
+  <data name="StepAssetItem" xml:space="preserve"><value>Which item</value></data>
+  <data name="StepAssetIdentity" xml:space="preserve"><value>Serial and tags</value></data>
+  <data name="StepLotItem" xml:space="preserve"><value>Which item</value></data>
+  <data name="StepLotDetails" xml:space="preserve"><value>Lot details</value></data>
+  <data name="StepKitBasics" xml:space="preserve"><value>Name the kit</value></data>
+  <data name="StepKitContents" xml:space="preserve"><value>Kit contents</value></data>
+  <data name="M4StepOrderHeader" xml:space="preserve"><value>Order details</value></data>
+  <data name="M4StepOrderLines" xml:space="preserve"><value>Order lines</value></data>
+  <data name="M5StepCountBasics" xml:space="preserve"><value>Name the count</value></data>
+  <data name="M5StepCountScope" xml:space="preserve"><value>Scope</value></data>
+  <data name="M5StepReportKind" xml:space="preserve"><value>Choose a report</value></data>
+  <data name="M5StepReportFilters" xml:space="preserve"><value>Narrow it down</value></data>
+  <data name="HelpFieldAmount" xml:space="preserve"><value>How many units, in the item's unit of measure.</value></data>
+  <data name="HelpFieldAsset" xml:space="preserve"><value>For serialised items, pick the exact unit being moved.</value></data>
+  <data name="HelpFieldCategory" xml:space="preserve"><value>Optional grouping used by lists and reports.</value></data>
+  <data name="HelpFieldCode" xml:space="preserve"><value>Your own stock or part number, if you use one.</value></data>
+  <data name="HelpFieldCountLocation" xml:space="preserve"><value>Leave blank to count everything.</value></data>
+  <data name="HelpFieldCurrency" xml:space="preserve"><value>Three letter currency code, such as USD or EUR.</value></data>
+  <data name="HelpFieldDefaultLocation" xml:space="preserve"><value>New stock lands here when no location is chosen.</value></data>
+  <data name="HelpFieldExpectedReturn" xml:space="preserve"><value>Overdue returns are flagged on the alerts screen.</value></data>
+  <data name="HelpFieldExpiration" xml:space="preserve"><value>The date this stock stops being usable.</value></data>
+  <data name="HelpFieldFromLocation" xml:space="preserve"><value>Where the stock is leaving. Leave blank when bringing new stock in.</value></data>
+  <data name="HelpFieldHolder" xml:space="preserve"><value>Choose a person or an apparatus, not both.</value></data>
+  <data name="HelpFieldIsActive" xml:space="preserve"><value>Inactive items stay in history but cannot be chosen for new movements.</value></data>
+  <data name="HelpFieldIsControlledSubstance" xml:space="preserve"><value>Movements need a second person to witness them and are kept for audit.</value></data>
+  <data name="HelpFieldIsKit" xml:space="preserve"><value>Mark this as a kit container rather than something you stock on its own.</value></data>
+  <data name="HelpFieldLocationType" xml:space="preserve"><value>Station, apparatus, person, container, or a sub-location of another place.</value></data>
+  <data name="HelpFieldLot" xml:space="preserve"><value>Pick the batch this stock came from, if the item is lot tracked.</value></data>
+  <data name="HelpFieldMinimum" xml:space="preserve"><value>Raise an alert when the amount on hand falls below this.</value></data>
+  <data name="HelpFieldNote" xml:space="preserve"><value>Why this happened. Notes appear on the ledger and on reports.</value></data>
+  <data name="HelpFieldParent" xml:space="preserve"><value>Optional. Nest this under another record.</value></data>
+  <data name="HelpFieldReorderPoint" xml:space="preserve"><value>Suggest reordering once the amount on hand reaches this.</value></data>
+  <data name="HelpFieldReportRange" xml:space="preserve"><value>Snapshot reports ignore the date range.</value></data>
+  <data name="HelpFieldRequiresExpiration" xml:space="preserve"><value>Require an expiry date so this item appears on expiry alerts.</value></data>
+  <data name="HelpFieldRequiresLotTracking" xml:space="preserve"><value>Require a lot number whenever stock of this item is received.</value></data>
+  <data name="HelpFieldReturnCondition" xml:space="preserve"><value>The state the equipment came back in.</value></data>
+  <data name="HelpFieldSerialNumber" xml:space="preserve"><value>Manufacturer serial. It must be unique for this item.</value></data>
+  <data name="HelpFieldToLocation" xml:space="preserve"><value>Where the stock is going. Leave blank when consuming or writing stock off.</value></data>
+  <data name="HelpFieldTrackingMode" xml:space="preserve"><value>Bulk counts a quantity. Serialised tracks every unit separately, with its own serial number and history.</value></data>
+  <data name="HelpFieldUnitCost" xml:space="preserve"><value>Cost of one unit, used for valuation.</value></data>
+  <data name="HelpFieldUnitOfMeasure" xml:space="preserve"><value>How you count it: each, box, litre, metre.</value></data>
+  <data name="M4AccountNumberHelp" xml:space="preserve"><value>The account this supplier knows you by.</value></data>
+  <data name="M4CompanyContactHelp" xml:space="preserve"><value>Pick the company contact this supplier record belongs to.</value></data>
+  <data name="M4NewVendorHint" xml:space="preserve"><value>A supplier is a company contact you buy from. Add the contact first if it is not in the list.</value></data>
+  <data name="M4PurchaseOrderNumberHelp" xml:space="preserve"><value>Your reference for this order. It appears on the ledger when the stock is received.</value></data>
+  <data name="M4StepOrderHeaderHint" xml:space="preserve"><value>Who you are buying from, under what reference, and in which currency.</value></data>
+  <data name="M4StepOrderLinesHint" xml:space="preserve"><value>One line per item. Quantities and costs here are what you will receive against.</value></data>
+  <data name="M5StepCountBasicsHint" xml:space="preserve"><value>A count freezes a snapshot of your stock so you can compare it with what is on the shelf.</value></data>
+  <data name="M5StepCountScopeHint" xml:space="preserve"><value>Count one location, or leave it blank to count the whole department.</value></data>
+  <data name="M5StepReportKindHint" xml:space="preserve"><value>The report decides which of the filters on the next step apply.</value></data>
+  <data name="M5StepReportFiltersHint" xml:space="preserve"><value>Leave a filter blank to include everything. Unavailable filters are greyed out.</value></data>
+  <data name="StepAssetItemHint" xml:space="preserve"><value>An asset is one physical unit of an item. Say which item it is and where it will live.</value></data>
+  <data name="StepAssetIdentityHint" xml:space="preserve"><value>How this unit is identified when someone picks it up or scans it.</value></data>
+  <data name="StepIssueWhatHint" xml:space="preserve"><value>Choose the item and the place it is coming out of.</value></data>
+  <data name="StepIssueWhenHint" xml:space="preserve"><value>When you expect it back, and anything worth recording about the hand-over.</value></data>
+  <data name="StepItemBasicsHint" xml:space="preserve"><value>What people will see when they search for this in a list.</value></data>
+  <data name="StepItemTrackingHint" xml:space="preserve"><value>These answers decide what the system asks for later, so they are hard to change once stock exists.</value></data>
+  <data name="StepItemStockHint" xml:space="preserve"><value>Optional thresholds that drive low stock alerts, plus the cost used for valuation.</value></data>
+  <data name="StepKitBasicsHint" xml:space="preserve"><value>Kits are issued as a whole, so give this one a name your crews will recognise.</value></data>
+  <data name="StepKitContentsHint" xml:space="preserve"><value>List every item the kit contains and how many of each.</value></data>
+  <data name="StepKitIssueHint" xml:space="preserve"><value>Confirm which physical unit and which shelf each part of the kit is coming from.</value></data>
+  <data name="StepLocationBasicsHint" xml:space="preserve"><value>The name shows up in every drop-down that asks where something is.</value></data>
+  <data name="StepLocationScopeHint" xml:space="preserve"><value>Fill in only the field that matches the type you chose; leave the rest blank.</value></data>
+  <data name="StepLotDetailsHint" xml:space="preserve"><value>The lot number as printed on the packaging, plus what the batch cost and when it expires.</value></data>
+  <data name="StepLotItemHint" xml:space="preserve"><value>Lots always belong to one item, so pick it first.</value></data>
+  <data name="StepMovementWhatHint" xml:space="preserve"><value>The kind of movement decides which of the fields below the system will use.</value></data>
+  <data name="StepMovementWhereHint" xml:space="preserve"><value>Receiving needs only a destination; consuming or writing off needs only a source.</value></data>
+  <data name="StepMovementAmountHint" xml:space="preserve"><value>The quantity and the reason. Both end up on the ledger entry this creates.</value></data>
+  <data name="StepReturnHint" xml:space="preserve"><value>Say how much came back, where it went, and what condition it is in.</value></data>
+  <data name="Inactive" xml:space="preserve"><value>Inactive</value></data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Inventory/Inventory.es.resx
+++ b/Core/Resgrid.Localization/Areas/User/Inventory/Inventory.es.resx
@@ -650,4 +650,137 @@
   <data name="WorkOrderPostingRequired" xml:space="preserve"><value>Registre o revierta esta pieza mediante su orden de trabajo.</value></data>
   <data name="AssetSafetyHold" xml:space="preserve"><value>Un bloqueo de seguridad de mantenimiento impide devolver este equipo al servicio.</value></data>
   <data name="ReadinessProRequired" xml:space="preserve"><value>Readiness Pro es necesario para nuevos trabajos de mantenimiento.</value></data>
+  <data name="AdjustStock" xml:space="preserve"><value>Ajustar existencias</value></data>
+  <data name="Back" xml:space="preserve"><value>Atrás</value></data>
+  <data name="Category" xml:space="preserve"><value>Categoría</value></data>
+  <data name="Close" xml:space="preserve"><value>Cerrar</value></data>
+  <data name="Contents" xml:space="preserve"><value>Contenido</value></data>
+  <data name="Continue" xml:space="preserve"><value>Continuar</value></data>
+  <data name="EditItem" xml:space="preserve"><value>Editar artículo</value></data>
+  <data name="Expires" xml:space="preserve"><value>Caduca</value></data>
+  <data name="Filter" xml:space="preserve"><value>Filtrar</value></data>
+  <data name="IssueEquipment" xml:space="preserve"><value>Entregar equipo</value></data>
+  <data name="Item" xml:space="preserve"><value>Artículo</value></data>
+  <data name="NewCategory" xml:space="preserve"><value>Nueva categoría</value></data>
+  <data name="NewKit" xml:space="preserve"><value>Nuevo kit</value></data>
+  <data name="NewLocation" xml:space="preserve"><value>Nueva ubicación</value></data>
+  <data name="NewLot" xml:space="preserve"><value>Nuevo lote</value></data>
+  <data name="NewTransfer" xml:space="preserve"><value>Nuevo traslado</value></data>
+  <data name="NoRowsHelp" xml:space="preserve"><value>Aquí todavía no hay nada. Use los botones de arriba para crear el primer registro.</value></data>
+  <data name="Outstanding" xml:space="preserve"><value>Pendiente</value></data>
+  <data name="Quantity" xml:space="preserve"><value>Cantidad</value></data>
+  <data name="RequiredFieldsMissing" xml:space="preserve"><value>Complete los campos resaltados antes de continuar.</value></data>
+  <data name="Review" xml:space="preserve"><value>Revisar</value></data>
+  <data name="ReviewHint" xml:space="preserve"><value>Revise las respuestas de abajo y guarde.</value></data>
+  <data name="Transaction" xml:space="preserve"><value>Movimiento</value></data>
+  <data name="Type" xml:space="preserve"><value>Tipo</value></data>
+  <data name="When" xml:space="preserve"><value>Cuándo</value></data>
+  <data name="WorkspaceIntro" xml:space="preserve"><value>Controle lo que posee su departamento, dónde se guarda y quién lo lleva.</value></data>
+  <data name="M4PurchasingIntro" xml:space="preserve"><value>Gestione proveedores, cree órdenes de compra y vea el valor de sus existencias.</value></data>
+  <data name="M5OperationsIntro" xml:space="preserve"><value>Realice recuentos físicos, resuelva alertas e imprima informes de inventario.</value></data>
+  <data name="HelpOnHand" xml:space="preserve"><value>Lo que tiene ahora mismo, por artículo y ubicación. Filtre por artículo o lugar y ajuste las existencias cuando cambie un recuento.</value></data>
+  <data name="HelpItems" xml:space="preserve"><value>Los artículos son lo que almacena: la ficha de catálogo, no un objeto físico. Defina cómo se rastrea cada uno antes de añadir existencias.</value></data>
+  <data name="HelpCategories" xml:space="preserve"><value>Las categorías agrupan artículos para que las listas e informes sean legibles. Una categoría puede depender de otra superior.</value></data>
+  <data name="HelpLocations" xml:space="preserve"><value>Las ubicaciones son donde está el material: parques, vehículos, personas, contenedores o un estante dentro de otra ubicación.</value></data>
+  <data name="HelpLots" xml:space="preserve"><value>Un lote es un conjunto de un artículo con el mismo número de lote, caducidad y coste.</value></data>
+  <data name="HelpAssets" xml:space="preserve"><value>Los activos son equipos con número de serie individual. Cada uno tiene su propio número, estado e historial.</value></data>
+  <data name="HelpIssuances" xml:space="preserve"><value>Equipo actualmente entregado a una persona o vehículo. Registre la devolución cuando regrese.</value></data>
+  <data name="HelpKits" xml:space="preserve"><value>Un kit es una lista fija de artículos que se entregan juntos, como un equipo de intervención o una mochila sanitaria.</value></data>
+  <data name="HelpTransfers" xml:space="preserve"><value>Mueva existencias entre dos ubicaciones. Ambos lados del movimiento quedan en el registro.</value></data>
+  <data name="HelpHistory" xml:space="preserve"><value>Cada movimiento se escribe en un registro solo de adición. Filtre por artículo o ubicación para auditar un cambio.</value></data>
+  <data name="HelpAssetDetail" xml:space="preserve"><value>El historial completo de un activo, junto con sus listas de comprobación y órdenes de trabajo.</value></data>
+  <data name="HelpTransaction" xml:space="preserve"><value>Un único asiento del registro, mostrado tal como se escribió.</value></data>
+  <data name="HelpUnitEquipment" xml:space="preserve"><value>Todo lo asignado actualmente al vehículo seleccionado.</value></data>
+  <data name="HelpPersonnelGear" xml:space="preserve"><value>Todo lo entregado actualmente a la persona seleccionada.</value></data>
+  <data name="HelpHolderLookup" xml:space="preserve"><value>Consulte todo lo que tiene un vehículo o una persona.</value></data>
+  <data name="HelpLocationRename" xml:space="preserve"><value>Aquí solo se puede cambiar el nombre. La ubicación y el alcance se fijaron al crearla.</value></data>
+  <data name="HelpAssetStatus" xml:space="preserve"><value>Cambiar el estado genera un asiento en el registro. Úselo cuando el equipo va a reparación, se daña, se pierde o se retira.</value></data>
+  <data name="HelpWitness" xml:space="preserve"><value>Introduzca el número de solicitud mostrado al registrar el movimiento y atestigüe lo que presenció.</value></data>
+  <data name="M4HelpVendors" xml:space="preserve"><value>Proveedores a los que compra. Cada uno se vincula a un contacto de empresa y puede tener un número de cuenta.</value></data>
+  <data name="M4HelpPurchaseOrders" xml:space="preserve"><value>Cree una orden con un proveedor y luego recepcione contra ella. La recepción registra las existencias y su coste.</value></data>
+  <data name="M4HelpValuation" xml:space="preserve"><value>El valor de las existencias que tiene, según el coste registrado en la recepción.</value></data>
+  <data name="M5NoAlertsHelp" xml:space="preserve"><value>No hay alertas abiertas. Actualice para volver a comprobar existencias, caducidades y devoluciones vencidas.</value></data>
+  <data name="M5CountEnterHelp" xml:space="preserve"><value>Introduzca lo realmente contado en cada línea. La columna de diferencia se actualiza al guardar.</value></data>
+  <data name="M5CountNameHelp" xml:space="preserve"><value>Algo que reconozca después, por ejemplo "Recuento anual del parque 2".</value></data>
+  <data name="StepItemBasics" xml:space="preserve"><value>Describa el artículo</value></data>
+  <data name="StepItemTracking" xml:space="preserve"><value>Cómo se rastrea</value></data>
+  <data name="StepItemStock" xml:space="preserve"><value>Niveles de existencias y coste</value></data>
+  <data name="StepLocationBasics" xml:space="preserve"><value>Nombre la ubicación</value></data>
+  <data name="StepLocationScope" xml:space="preserve"><value>Dónde se sitúa</value></data>
+  <data name="StepMovementWhat" xml:space="preserve"><value>Qué se mueve</value></data>
+  <data name="StepMovementWhere" xml:space="preserve"><value>Desde y hacia</value></data>
+  <data name="StepMovementAmount" xml:space="preserve"><value>Cuánto</value></data>
+  <data name="StepIssueWhat" xml:space="preserve"><value>Qué se entrega</value></data>
+  <data name="StepIssueWho" xml:space="preserve"><value>Quién lo recibe</value></data>
+  <data name="StepIssueWhen" xml:space="preserve"><value>Devolución y notas</value></data>
+  <data name="StepAssetItem" xml:space="preserve"><value>Qué artículo</value></data>
+  <data name="StepAssetIdentity" xml:space="preserve"><value>Número de serie y etiquetas</value></data>
+  <data name="StepLotItem" xml:space="preserve"><value>Qué artículo</value></data>
+  <data name="StepLotDetails" xml:space="preserve"><value>Datos del lote</value></data>
+  <data name="StepKitBasics" xml:space="preserve"><value>Nombre el kit</value></data>
+  <data name="StepKitContents" xml:space="preserve"><value>Contenido del kit</value></data>
+  <data name="M4StepOrderHeader" xml:space="preserve"><value>Datos del pedido</value></data>
+  <data name="M4StepOrderLines" xml:space="preserve"><value>Líneas del pedido</value></data>
+  <data name="M5StepCountBasics" xml:space="preserve"><value>Nombre el recuento</value></data>
+  <data name="M5StepCountScope" xml:space="preserve"><value>Alcance</value></data>
+  <data name="M5StepReportKind" xml:space="preserve"><value>Elija un informe</value></data>
+  <data name="M5StepReportFilters" xml:space="preserve"><value>Acote el resultado</value></data>
+  <data name="HelpFieldAmount" xml:space="preserve"><value>Cuántas unidades, en la unidad de medida del artículo.</value></data>
+  <data name="HelpFieldAsset" xml:space="preserve"><value>Para artículos con número de serie, elija la unidad exacta.</value></data>
+  <data name="HelpFieldCategory" xml:space="preserve"><value>Agrupación opcional usada en listas e informes.</value></data>
+  <data name="HelpFieldCode" xml:space="preserve"><value>Su propio código de artículo o pieza, si lo usa.</value></data>
+  <data name="HelpFieldCountLocation" xml:space="preserve"><value>Déjelo en blanco para contar todo.</value></data>
+  <data name="HelpFieldCurrency" xml:space="preserve"><value>Código de moneda de tres letras, como USD o EUR.</value></data>
+  <data name="HelpFieldDefaultLocation" xml:space="preserve"><value>Las nuevas existencias van aquí si no se elige ubicación.</value></data>
+  <data name="HelpFieldExpectedReturn" xml:space="preserve"><value>Las devoluciones vencidas se marcan en la pantalla de alertas.</value></data>
+  <data name="HelpFieldExpiration" xml:space="preserve"><value>La fecha en que estas existencias dejan de ser utilizables.</value></data>
+  <data name="HelpFieldFromLocation" xml:space="preserve"><value>De dónde sale el material. Déjelo vacío al dar entrada a material nuevo.</value></data>
+  <data name="HelpFieldHolder" xml:space="preserve"><value>Elija una persona o un vehículo, no ambos.</value></data>
+  <data name="HelpFieldIsActive" xml:space="preserve"><value>Los artículos inactivos permanecen en el historial pero no pueden usarse en nuevos movimientos.</value></data>
+  <data name="HelpFieldIsControlledSubstance" xml:space="preserve"><value>Los movimientos requieren un segundo testigo y se conservan para auditoría.</value></data>
+  <data name="HelpFieldIsKit" xml:space="preserve"><value>Márquelo como contenedor de kit en lugar de un artículo que se almacena por sí solo.</value></data>
+  <data name="HelpFieldLocationType" xml:space="preserve"><value>Parque, vehículo, persona, contenedor o sububicación de otro lugar.</value></data>
+  <data name="HelpFieldLot" xml:space="preserve"><value>Elija el lote del que procede el material, si el artículo se rastrea por lotes.</value></data>
+  <data name="HelpFieldMinimum" xml:space="preserve"><value>Generar una alerta cuando las existencias bajen de este valor.</value></data>
+  <data name="HelpFieldNote" xml:space="preserve"><value>Por qué ocurrió. Las notas aparecen en el registro y en los informes.</value></data>
+  <data name="HelpFieldParent" xml:space="preserve"><value>Opcional. Anide este registro bajo otro.</value></data>
+  <data name="HelpFieldReorderPoint" xml:space="preserve"><value>Sugerir reposición cuando las existencias lleguen a este valor.</value></data>
+  <data name="HelpFieldReportRange" xml:space="preserve"><value>Los informes de instantánea ignoran el rango de fechas.</value></data>
+  <data name="HelpFieldRequiresExpiration" xml:space="preserve"><value>Exigir fecha de caducidad para que el artículo aparezca en las alertas.</value></data>
+  <data name="HelpFieldRequiresLotTracking" xml:space="preserve"><value>Exigir número de lote cada vez que se reciba este artículo.</value></data>
+  <data name="HelpFieldReturnCondition" xml:space="preserve"><value>El estado en que volvió el equipo.</value></data>
+  <data name="HelpFieldSerialNumber" xml:space="preserve"><value>Número de serie del fabricante. Debe ser único para este artículo.</value></data>
+  <data name="HelpFieldToLocation" xml:space="preserve"><value>A dónde va el material. Déjelo vacío al consumir o dar de baja.</value></data>
+  <data name="HelpFieldTrackingMode" xml:space="preserve"><value>A granel cuenta una cantidad. Serializado rastrea cada unidad por separado, con su número e historial.</value></data>
+  <data name="HelpFieldUnitCost" xml:space="preserve"><value>Coste de una unidad, usado para la valoración.</value></data>
+  <data name="HelpFieldUnitOfMeasure" xml:space="preserve"><value>Cómo lo cuenta: unidad, caja, litro, metro.</value></data>
+  <data name="M4AccountNumberHelp" xml:space="preserve"><value>La cuenta con la que este proveedor le identifica.</value></data>
+  <data name="M4CompanyContactHelp" xml:space="preserve"><value>Elija el contacto de empresa al que pertenece este proveedor.</value></data>
+  <data name="M4NewVendorHint" xml:space="preserve"><value>Un proveedor es un contacto de empresa al que compra. Cree primero el contacto si no está en la lista.</value></data>
+  <data name="M4PurchaseOrderNumberHelp" xml:space="preserve"><value>Su referencia para este pedido. Aparece en el registro al recibir el material.</value></data>
+  <data name="M4StepOrderHeaderHint" xml:space="preserve"><value>A quién compra, con qué referencia y en qué moneda.</value></data>
+  <data name="M4StepOrderLinesHint" xml:space="preserve"><value>Una línea por artículo. Las cantidades y costes aquí son la base de la recepción.</value></data>
+  <data name="M5StepCountBasicsHint" xml:space="preserve"><value>Un recuento congela una instantánea de sus existencias para compararla con lo que hay en el estante.</value></data>
+  <data name="M5StepCountScopeHint" xml:space="preserve"><value>Cuente una ubicación o déjelo vacío para contar todo el departamento.</value></data>
+  <data name="M5StepReportKindHint" xml:space="preserve"><value>El informe determina qué filtros del siguiente paso se aplican.</value></data>
+  <data name="M5StepReportFiltersHint" xml:space="preserve"><value>Deje un filtro vacío para incluir todo. Los filtros no disponibles aparecen atenuados.</value></data>
+  <data name="StepAssetItemHint" xml:space="preserve"><value>Un activo es una unidad física de un artículo. Indique de qué artículo se trata y dónde estará.</value></data>
+  <data name="StepAssetIdentityHint" xml:space="preserve"><value>Cómo se identifica esta unidad cuando alguien la toma o la escanea.</value></data>
+  <data name="StepIssueWhatHint" xml:space="preserve"><value>Elija el artículo y el lugar del que sale.</value></data>
+  <data name="StepIssueWhenHint" xml:space="preserve"><value>Cuándo espera su devolución y lo que merezca anotarse sobre la entrega.</value></data>
+  <data name="StepItemBasicsHint" xml:space="preserve"><value>Lo que verán las personas al buscarlo en una lista.</value></data>
+  <data name="StepItemTrackingHint" xml:space="preserve"><value>Estas respuestas deciden lo que el sistema pedirá después, y cuesta cambiarlas si ya hay existencias.</value></data>
+  <data name="StepItemStockHint" xml:space="preserve"><value>Umbrales opcionales que generan alertas de stock bajo, más el coste para la valoración.</value></data>
+  <data name="StepKitBasicsHint" xml:space="preserve"><value>Los kits se entregan completos, así que use un nombre que su personal reconozca.</value></data>
+  <data name="StepKitContentsHint" xml:space="preserve"><value>Enumere cada artículo del kit y cuántos de cada uno.</value></data>
+  <data name="StepKitIssueHint" xml:space="preserve"><value>Confirme qué unidad física y de qué estante sale cada parte del kit.</value></data>
+  <data name="StepLocationBasicsHint" xml:space="preserve"><value>El nombre aparece en cada desplegable que pregunta dónde está algo.</value></data>
+  <data name="StepLocationScopeHint" xml:space="preserve"><value>Rellene solo el campo que corresponda al tipo elegido; deje el resto vacío.</value></data>
+  <data name="StepLotDetailsHint" xml:space="preserve"><value>El número de lote impreso en el envase, más el coste y la caducidad del lote.</value></data>
+  <data name="StepLotItemHint" xml:space="preserve"><value>Los lotes siempre pertenecen a un artículo; elíjalo primero.</value></data>
+  <data name="StepMovementWhatHint" xml:space="preserve"><value>El tipo de movimiento determina cuáles de los campos siguientes se usan.</value></data>
+  <data name="StepMovementWhereHint" xml:space="preserve"><value>Una entrada solo necesita destino; un consumo o baja solo necesita origen.</value></data>
+  <data name="StepMovementAmountHint" xml:space="preserve"><value>La cantidad y el motivo. Ambos quedan en el asiento que se genera.</value></data>
+  <data name="StepReturnHint" xml:space="preserve"><value>Indique cuánto se devolvió, a dónde fue y en qué estado está.</value></data>
+  <data name="Inactive" xml:space="preserve"><value>Inactivo</value></data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Inventory/Inventory.fr.resx
+++ b/Core/Resgrid.Localization/Areas/User/Inventory/Inventory.fr.resx
@@ -650,4 +650,137 @@
   <data name="WorkOrderPostingRequired" xml:space="preserve"><value>Comptabilisez ou annulez cette pièce depuis son ordre de travail.</value></data>
   <data name="AssetSafetyHold" xml:space="preserve"><value>Un blocage de sécurité de maintenance empêche la remise en service de ce matériel.</value></data>
   <data name="ReadinessProRequired" xml:space="preserve"><value>Readiness Pro est requis pour les nouveaux travaux de maintenance.</value></data>
+  <data name="AdjustStock" xml:space="preserve"><value>Ajuster le stock</value></data>
+  <data name="Back" xml:space="preserve"><value>Retour</value></data>
+  <data name="Category" xml:space="preserve"><value>Catégorie</value></data>
+  <data name="Close" xml:space="preserve"><value>Fermer</value></data>
+  <data name="Contents" xml:space="preserve"><value>Contenu</value></data>
+  <data name="Continue" xml:space="preserve"><value>Continuer</value></data>
+  <data name="EditItem" xml:space="preserve"><value>Modifier l'article</value></data>
+  <data name="Expires" xml:space="preserve"><value>Expire le</value></data>
+  <data name="Filter" xml:space="preserve"><value>Filtrer</value></data>
+  <data name="IssueEquipment" xml:space="preserve"><value>Attribuer un équipement</value></data>
+  <data name="Item" xml:space="preserve"><value>Article</value></data>
+  <data name="NewCategory" xml:space="preserve"><value>Nouvelle catégorie</value></data>
+  <data name="NewKit" xml:space="preserve"><value>Nouveau kit</value></data>
+  <data name="NewLocation" xml:space="preserve"><value>Nouvel emplacement</value></data>
+  <data name="NewLot" xml:space="preserve"><value>Nouveau lot</value></data>
+  <data name="NewTransfer" xml:space="preserve"><value>Nouveau transfert</value></data>
+  <data name="NoRowsHelp" xml:space="preserve"><value>Rien pour l'instant. Utilisez les boutons ci-dessus pour créer le premier enregistrement.</value></data>
+  <data name="Outstanding" xml:space="preserve"><value>En cours</value></data>
+  <data name="Quantity" xml:space="preserve"><value>Quantité</value></data>
+  <data name="RequiredFieldsMissing" xml:space="preserve"><value>Renseignez les champs en surbrillance avant de continuer.</value></data>
+  <data name="Review" xml:space="preserve"><value>Vérifier</value></data>
+  <data name="ReviewHint" xml:space="preserve"><value>Vérifiez les réponses ci-dessous, puis enregistrez.</value></data>
+  <data name="Transaction" xml:space="preserve"><value>Écriture</value></data>
+  <data name="Type" xml:space="preserve"><value>Type</value></data>
+  <data name="When" xml:space="preserve"><value>Date</value></data>
+  <data name="WorkspaceIntro" xml:space="preserve"><value>Suivez ce que possède votre service, où c'est stocké et qui l'emporte.</value></data>
+  <data name="M4PurchasingIntro" xml:space="preserve"><value>Gérez les fournisseurs, créez des bons de commande et consultez la valeur du stock.</value></data>
+  <data name="M5OperationsIntro" xml:space="preserve"><value>Réalisez des inventaires physiques, traitez les alertes et imprimez des rapports.</value></data>
+  <data name="HelpOnHand" xml:space="preserve"><value>Ce que vous détenez actuellement, par article et emplacement. Filtrez sur un article ou un lieu, puis ajustez le stock si un comptage change.</value></data>
+  <data name="HelpItems" xml:space="preserve"><value>Les articles sont ce que vous stockez : la fiche catalogue, pas l'objet physique. Choisissez le suivi avant d'ajouter du stock.</value></data>
+  <data name="HelpCategories" xml:space="preserve"><value>Les catégories regroupent les articles pour garder les listes et rapports lisibles. Une catégorie peut dépendre d'une catégorie parente.</value></data>
+  <data name="HelpLocations" xml:space="preserve"><value>Les emplacements sont l'endroit où se trouve le stock : casernes, engins, personnes, conteneurs ou une étagère dans un autre emplacement.</value></data>
+  <data name="HelpLots" xml:space="preserve"><value>Un lot regroupe un article partageant un numéro de lot, une date de péremption et un coût.</value></data>
+  <data name="HelpAssets" xml:space="preserve"><value>Les actifs sont des équipements identifiés par numéro de série. Chacun a son numéro, son état et son historique.</value></data>
+  <data name="HelpIssuances" xml:space="preserve"><value>Équipement actuellement attribué à une personne ou un engin. Enregistrez le retour quand il revient.</value></data>
+  <data name="HelpKits" xml:space="preserve"><value>Un kit est une liste fixe d'articles remis ensemble, par exemple une tenue de feu ou un sac de secours.</value></data>
+  <data name="HelpTransfers" xml:space="preserve"><value>Déplacez du stock entre deux emplacements. Les deux côtés du mouvement sont inscrits au journal.</value></data>
+  <data name="HelpHistory" xml:space="preserve"><value>Chaque mouvement est inscrit dans un journal en ajout seul. Filtrez par article ou emplacement pour auditer un changement.</value></data>
+  <data name="HelpAssetDetail" xml:space="preserve"><value>L'historique complet d'un actif, avec ses listes de contrôle et ordres de travail.</value></data>
+  <data name="HelpTransaction" xml:space="preserve"><value>Une seule écriture du journal, affichée telle qu'elle a été inscrite.</value></data>
+  <data name="HelpUnitEquipment" xml:space="preserve"><value>Tout ce qui est actuellement affecté à l'engin sélectionné.</value></data>
+  <data name="HelpPersonnelGear" xml:space="preserve"><value>Tout ce qui est actuellement attribué à la personne sélectionnée.</value></data>
+  <data name="HelpHolderLookup" xml:space="preserve"><value>Consultez tout ce que détient un engin ou une personne.</value></data>
+  <data name="HelpLocationRename" xml:space="preserve"><value>Seul le nom peut être modifié ici. Le rattachement et la portée ont été fixés à la création.</value></data>
+  <data name="HelpAssetStatus" xml:space="preserve"><value>Changer l'état crée une écriture au journal. À utiliser en cas de réparation, dommage, perte ou réforme.</value></data>
+  <data name="HelpWitness" xml:space="preserve"><value>Saisissez le numéro de demande affiché lors de l'écriture, puis attestez de ce que vous avez constaté.</value></data>
+  <data name="M4HelpVendors" xml:space="preserve"><value>Les fournisseurs auprès desquels vous achetez. Chacun est lié à un contact société et peut porter un numéro de compte.</value></data>
+  <data name="M4HelpPurchaseOrders" xml:space="preserve"><value>Créez une commande auprès d'un fournisseur, puis réceptionnez. La réception enregistre le stock et son coût.</value></data>
+  <data name="M4HelpValuation" xml:space="preserve"><value>La valeur du stock détenu, calculée avec le coût enregistré à la réception.</value></data>
+  <data name="M5NoAlertsHelp" xml:space="preserve"><value>Aucune alerte ouverte. Actualisez pour revérifier les niveaux de stock, les péremptions et les retours en retard.</value></data>
+  <data name="M5CountEnterHelp" xml:space="preserve"><value>Saisissez ce que vous avez réellement compté pour chaque ligne. L'écart se met à jour après enregistrement.</value></data>
+  <data name="M5CountNameHelp" xml:space="preserve"><value>Un intitulé reconnaissable plus tard, par exemple « Inventaire annuel caserne 2 ».</value></data>
+  <data name="StepItemBasics" xml:space="preserve"><value>Décrire l'article</value></data>
+  <data name="StepItemTracking" xml:space="preserve"><value>Mode de suivi</value></data>
+  <data name="StepItemStock" xml:space="preserve"><value>Niveaux de stock et coût</value></data>
+  <data name="StepLocationBasics" xml:space="preserve"><value>Nommer l'emplacement</value></data>
+  <data name="StepLocationScope" xml:space="preserve"><value>Rattachement</value></data>
+  <data name="StepMovementWhat" xml:space="preserve"><value>Ce qui bouge</value></data>
+  <data name="StepMovementWhere" xml:space="preserve"><value>De et vers</value></data>
+  <data name="StepMovementAmount" xml:space="preserve"><value>Quelle quantité</value></data>
+  <data name="StepIssueWhat" xml:space="preserve"><value>Ce qui est attribué</value></data>
+  <data name="StepIssueWho" xml:space="preserve"><value>Qui le prend</value></data>
+  <data name="StepIssueWhen" xml:space="preserve"><value>Retour et notes</value></data>
+  <data name="StepAssetItem" xml:space="preserve"><value>Quel article</value></data>
+  <data name="StepAssetIdentity" xml:space="preserve"><value>Numéro de série et étiquettes</value></data>
+  <data name="StepLotItem" xml:space="preserve"><value>Quel article</value></data>
+  <data name="StepLotDetails" xml:space="preserve"><value>Détails du lot</value></data>
+  <data name="StepKitBasics" xml:space="preserve"><value>Nommer le kit</value></data>
+  <data name="StepKitContents" xml:space="preserve"><value>Contenu du kit</value></data>
+  <data name="M4StepOrderHeader" xml:space="preserve"><value>Détails de la commande</value></data>
+  <data name="M4StepOrderLines" xml:space="preserve"><value>Lignes de commande</value></data>
+  <data name="M5StepCountBasics" xml:space="preserve"><value>Nommer l'inventaire</value></data>
+  <data name="M5StepCountScope" xml:space="preserve"><value>Périmètre</value></data>
+  <data name="M5StepReportKind" xml:space="preserve"><value>Choisir un rapport</value></data>
+  <data name="M5StepReportFilters" xml:space="preserve"><value>Affiner</value></data>
+  <data name="HelpFieldAmount" xml:space="preserve"><value>Combien d'unités, dans l'unité de mesure de l'article.</value></data>
+  <data name="HelpFieldAsset" xml:space="preserve"><value>Pour les articles sérialisés, choisissez l'unité exacte.</value></data>
+  <data name="HelpFieldCategory" xml:space="preserve"><value>Regroupement facultatif utilisé par les listes et rapports.</value></data>
+  <data name="HelpFieldCode" xml:space="preserve"><value>Votre propre référence article ou pièce, le cas échéant.</value></data>
+  <data name="HelpFieldCountLocation" xml:space="preserve"><value>Laissez vide pour tout compter.</value></data>
+  <data name="HelpFieldCurrency" xml:space="preserve"><value>Code devise à trois lettres, par exemple USD ou EUR.</value></data>
+  <data name="HelpFieldDefaultLocation" xml:space="preserve"><value>Le nouveau stock arrive ici si aucun emplacement n'est choisi.</value></data>
+  <data name="HelpFieldExpectedReturn" xml:space="preserve"><value>Les retours en retard sont signalés dans les alertes.</value></data>
+  <data name="HelpFieldExpiration" xml:space="preserve"><value>La date à laquelle ce stock n'est plus utilisable.</value></data>
+  <data name="HelpFieldFromLocation" xml:space="preserve"><value>D'où part le stock. Laissez vide pour une entrée de stock neuf.</value></data>
+  <data name="HelpFieldHolder" xml:space="preserve"><value>Choisissez une personne ou un engin, pas les deux.</value></data>
+  <data name="HelpFieldIsActive" xml:space="preserve"><value>Les articles inactifs restent dans l'historique mais ne peuvent plus être utilisés.</value></data>
+  <data name="HelpFieldIsControlledSubstance" xml:space="preserve"><value>Les mouvements doivent être attestés par un témoin et sont conservés pour audit.</value></data>
+  <data name="HelpFieldIsKit" xml:space="preserve"><value>Marquez-le comme contenant de kit plutôt que comme article stocké seul.</value></data>
+  <data name="HelpFieldLocationType" xml:space="preserve"><value>Caserne, engin, personne, conteneur ou sous-emplacement d'un autre lieu.</value></data>
+  <data name="HelpFieldLot" xml:space="preserve"><value>Choisissez le lot d'origine si l'article est suivi par lot.</value></data>
+  <data name="HelpFieldMinimum" xml:space="preserve"><value>Déclencher une alerte quand le stock passe sous ce seuil.</value></data>
+  <data name="HelpFieldNote" xml:space="preserve"><value>Pourquoi cela s'est produit. Les notes figurent au journal et dans les rapports.</value></data>
+  <data name="HelpFieldParent" xml:space="preserve"><value>Facultatif. Rattachez cet enregistrement à un autre.</value></data>
+  <data name="HelpFieldReorderPoint" xml:space="preserve"><value>Proposer un réapprovisionnement quand le stock atteint ce seuil.</value></data>
+  <data name="HelpFieldReportRange" xml:space="preserve"><value>Les rapports instantanés ignorent la plage de dates.</value></data>
+  <data name="HelpFieldRequiresExpiration" xml:space="preserve"><value>Exiger une date de péremption pour que l'article apparaisse dans les alertes.</value></data>
+  <data name="HelpFieldRequiresLotTracking" xml:space="preserve"><value>Exiger un numéro de lot à chaque réception de cet article.</value></data>
+  <data name="HelpFieldReturnCondition" xml:space="preserve"><value>L'état dans lequel l'équipement est revenu.</value></data>
+  <data name="HelpFieldSerialNumber" xml:space="preserve"><value>Numéro de série constructeur. Il doit être unique pour cet article.</value></data>
+  <data name="HelpFieldToLocation" xml:space="preserve"><value>Où va le stock. Laissez vide en cas de consommation ou de sortie définitive.</value></data>
+  <data name="HelpFieldTrackingMode" xml:space="preserve"><value>En vrac compte une quantité. Sérialisé suit chaque unité séparément, avec son numéro et son historique.</value></data>
+  <data name="HelpFieldUnitCost" xml:space="preserve"><value>Coût d'une unité, utilisé pour la valorisation.</value></data>
+  <data name="HelpFieldUnitOfMeasure" xml:space="preserve"><value>Comment vous le comptez : pièce, boîte, litre, mètre.</value></data>
+  <data name="M4AccountNumberHelp" xml:space="preserve"><value>Le compte sous lequel ce fournisseur vous identifie.</value></data>
+  <data name="M4CompanyContactHelp" xml:space="preserve"><value>Choisissez le contact société auquel ce fournisseur est rattaché.</value></data>
+  <data name="M4NewVendorHint" xml:space="preserve"><value>Un fournisseur est un contact société auprès duquel vous achetez. Créez d'abord le contact s'il manque.</value></data>
+  <data name="M4PurchaseOrderNumberHelp" xml:space="preserve"><value>Votre référence pour cette commande. Elle figure au journal lors de la réception.</value></data>
+  <data name="M4StepOrderHeaderHint" xml:space="preserve"><value>Auprès de qui vous achetez, sous quelle référence et dans quelle devise.</value></data>
+  <data name="M4StepOrderLinesHint" xml:space="preserve"><value>Une ligne par article. Les quantités et coûts serviront de base à la réception.</value></data>
+  <data name="M5StepCountBasicsHint" xml:space="preserve"><value>Un inventaire fige un instantané du stock pour le comparer à ce qui est en rayon.</value></data>
+  <data name="M5StepCountScopeHint" xml:space="preserve"><value>Comptez un emplacement, ou laissez vide pour tout le service.</value></data>
+  <data name="M5StepReportKindHint" xml:space="preserve"><value>Le rapport détermine quels filtres de l'étape suivante s'appliquent.</value></data>
+  <data name="M5StepReportFiltersHint" xml:space="preserve"><value>Laissez un filtre vide pour tout inclure. Les filtres indisponibles sont grisés.</value></data>
+  <data name="StepAssetItemHint" xml:space="preserve"><value>Un actif est une unité physique d'un article. Indiquez l'article et son emplacement.</value></data>
+  <data name="StepAssetIdentityHint" xml:space="preserve"><value>Comment cette unité est identifiée lorsqu'on la prend ou la scanne.</value></data>
+  <data name="StepIssueWhatHint" xml:space="preserve"><value>Choisissez l'article et l'emplacement d'où il sort.</value></data>
+  <data name="StepIssueWhenHint" xml:space="preserve"><value>Quand vous l'attendez en retour, et ce qu'il faut noter sur la remise.</value></data>
+  <data name="StepItemBasicsHint" xml:space="preserve"><value>Ce que les utilisateurs verront en le cherchant dans une liste.</value></data>
+  <data name="StepItemTrackingHint" xml:space="preserve"><value>Ces réponses déterminent ce que le système demandera ensuite ; elles sont difficiles à modifier une fois du stock présent.</value></data>
+  <data name="StepItemStockHint" xml:space="preserve"><value>Seuils facultatifs déclenchant les alertes de stock bas, et coût utilisé pour la valorisation.</value></data>
+  <data name="StepKitBasicsHint" xml:space="preserve"><value>Les kits sont remis en bloc ; donnez-lui un nom que vos équipes reconnaîtront.</value></data>
+  <data name="StepKitContentsHint" xml:space="preserve"><value>Listez chaque article du kit et sa quantité.</value></data>
+  <data name="StepKitIssueHint" xml:space="preserve"><value>Confirmez pour chaque élément du kit l'unité physique et l'emplacement d'origine.</value></data>
+  <data name="StepLocationBasicsHint" xml:space="preserve"><value>Le nom apparaît dans chaque liste demandant où se trouve un élément.</value></data>
+  <data name="StepLocationScopeHint" xml:space="preserve"><value>Ne renseignez que le champ correspondant au type choisi ; laissez le reste vide.</value></data>
+  <data name="StepLotDetailsHint" xml:space="preserve"><value>Le numéro de lot imprimé sur l'emballage, avec son coût et sa péremption.</value></data>
+  <data name="StepLotItemHint" xml:space="preserve"><value>Un lot appartient toujours à un article ; choisissez-le d'abord.</value></data>
+  <data name="StepMovementWhatHint" xml:space="preserve"><value>Le type de mouvement détermine les champs ci-dessous qui seront utilisés.</value></data>
+  <data name="StepMovementWhereHint" xml:space="preserve"><value>Une entrée n'exige qu'une destination ; une consommation ou sortie qu'une origine.</value></data>
+  <data name="StepMovementAmountHint" xml:space="preserve"><value>La quantité et le motif. Les deux figurent dans l'écriture générée.</value></data>
+  <data name="StepReturnHint" xml:space="preserve"><value>Indiquez la quantité rendue, sa destination et son état.</value></data>
+  <data name="Inactive" xml:space="preserve"><value>Inactif</value></data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Inventory/Inventory.it.resx
+++ b/Core/Resgrid.Localization/Areas/User/Inventory/Inventory.it.resx
@@ -650,4 +650,137 @@
   <data name="WorkOrderPostingRequired" xml:space="preserve"><value>Registra o storna questo ricambio tramite il relativo ordine di lavoro.</value></data>
   <data name="AssetSafetyHold" xml:space="preserve"><value>Un blocco di sicurezza di manutenzione impedisce il ritorno in servizio dell'attrezzatura.</value></data>
   <data name="ReadinessProRequired" xml:space="preserve"><value>Readiness Pro è necessario per nuovi lavori di manutenzione.</value></data>
+  <data name="AdjustStock" xml:space="preserve"><value>Rettifica scorte</value></data>
+  <data name="Back" xml:space="preserve"><value>Indietro</value></data>
+  <data name="Category" xml:space="preserve"><value>Categoria</value></data>
+  <data name="Close" xml:space="preserve"><value>Chiudi</value></data>
+  <data name="Contents" xml:space="preserve"><value>Contenuto</value></data>
+  <data name="Continue" xml:space="preserve"><value>Continua</value></data>
+  <data name="EditItem" xml:space="preserve"><value>Modifica articolo</value></data>
+  <data name="Expires" xml:space="preserve"><value>Scade</value></data>
+  <data name="Filter" xml:space="preserve"><value>Filtra</value></data>
+  <data name="IssueEquipment" xml:space="preserve"><value>Assegna attrezzatura</value></data>
+  <data name="Item" xml:space="preserve"><value>Articolo</value></data>
+  <data name="NewCategory" xml:space="preserve"><value>Nuova categoria</value></data>
+  <data name="NewKit" xml:space="preserve"><value>Nuovo kit</value></data>
+  <data name="NewLocation" xml:space="preserve"><value>Nuova ubicazione</value></data>
+  <data name="NewLot" xml:space="preserve"><value>Nuovo lotto</value></data>
+  <data name="NewTransfer" xml:space="preserve"><value>Nuovo trasferimento</value></data>
+  <data name="NoRowsHelp" xml:space="preserve"><value>Non c'è ancora nulla. Usa i pulsanti sopra per creare il primo record.</value></data>
+  <data name="Outstanding" xml:space="preserve"><value>In sospeso</value></data>
+  <data name="Quantity" xml:space="preserve"><value>Quantità</value></data>
+  <data name="RequiredFieldsMissing" xml:space="preserve"><value>Compila i campi evidenziati prima di continuare.</value></data>
+  <data name="Review" xml:space="preserve"><value>Verifica</value></data>
+  <data name="ReviewHint" xml:space="preserve"><value>Controlla le risposte qui sotto, poi salva.</value></data>
+  <data name="Transaction" xml:space="preserve"><value>Movimento</value></data>
+  <data name="Type" xml:space="preserve"><value>Tipo</value></data>
+  <data name="When" xml:space="preserve"><value>Data</value></data>
+  <data name="WorkspaceIntro" xml:space="preserve"><value>Tieni traccia di ciò che possiede il tuo reparto, dove si trova e chi lo porta.</value></data>
+  <data name="M4PurchasingIntro" xml:space="preserve"><value>Gestisci i fornitori, crea ordini di acquisto e verifica il valore delle scorte.</value></data>
+  <data name="M5OperationsIntro" xml:space="preserve"><value>Esegui inventari fisici, gestisci gli avvisi e stampa i report di magazzino.</value></data>
+  <data name="HelpOnHand" xml:space="preserve"><value>Ciò che hai ora, per articolo e ubicazione. Filtra per articolo o luogo e rettifica le scorte quando un conteggio cambia.</value></data>
+  <data name="HelpItems" xml:space="preserve"><value>Gli articoli sono ciò che tieni a magazzino: la voce di catalogo, non l'oggetto fisico. Decidi come tracciarli prima di aggiungere scorte.</value></data>
+  <data name="HelpCategories" xml:space="preserve"><value>Le categorie raggruppano gli articoli per mantenere leggibili elenchi e report. Una categoria può stare sotto una categoria superiore.</value></data>
+  <data name="HelpLocations" xml:space="preserve"><value>Le ubicazioni sono dove si trova la merce: sedi, mezzi, persone, contenitori o uno scaffale dentro un'altra ubicazione.</value></data>
+  <data name="HelpLots" xml:space="preserve"><value>Un lotto è un gruppo di un articolo con stesso numero di lotto, scadenza e costo.</value></data>
+  <data name="HelpAssets" xml:space="preserve"><value>I cespiti sono attrezzature con numero di serie individuale. Ognuno ha numero, stato e cronologia propri.</value></data>
+  <data name="HelpIssuances" xml:space="preserve"><value>Attrezzatura attualmente assegnata a una persona o a un mezzo. Registra il reso quando rientra.</value></data>
+  <data name="HelpKits" xml:space="preserve"><value>Un kit è un elenco fisso di articoli consegnati insieme, come una dotazione di intervento o uno zaino sanitario.</value></data>
+  <data name="HelpTransfers" xml:space="preserve"><value>Sposta scorte tra due ubicazioni. Entrambi i lati del movimento vengono registrati nel giornale.</value></data>
+  <data name="HelpHistory" xml:space="preserve"><value>Ogni movimento viene scritto in un giornale a sola aggiunta. Filtra per articolo o ubicazione per verificare una modifica.</value></data>
+  <data name="HelpAssetDetail" xml:space="preserve"><value>La cronologia completa di un cespite, con le sue checklist e gli ordini di lavoro.</value></data>
+  <data name="HelpTransaction" xml:space="preserve"><value>Una singola registrazione del giornale, mostrata come è stata scritta.</value></data>
+  <data name="HelpUnitEquipment" xml:space="preserve"><value>Tutto ciò che è attualmente assegnato al mezzo selezionato.</value></data>
+  <data name="HelpPersonnelGear" xml:space="preserve"><value>Tutto ciò che è attualmente assegnato alla persona selezionata.</value></data>
+  <data name="HelpHolderLookup" xml:space="preserve"><value>Cerca tutto ciò che è in carico a un mezzo o a una persona.</value></data>
+  <data name="HelpLocationRename" xml:space="preserve"><value>Qui puoi cambiare solo il nome. Collocazione e ambito sono stati fissati alla creazione.</value></data>
+  <data name="HelpAssetStatus" xml:space="preserve"><value>Cambiare lo stato genera una registrazione. Usalo quando l'attrezzatura va in riparazione, si danneggia, si perde o viene dismessa.</value></data>
+  <data name="HelpWitness" xml:space="preserve"><value>Inserisci il numero di richiesta mostrato alla registrazione, poi attesta quanto hai osservato.</value></data>
+  <data name="M4HelpVendors" xml:space="preserve"><value>Fornitori da cui acquisti. Ognuno è collegato a un contatto aziendale e può avere un numero di conto.</value></data>
+  <data name="M4HelpPurchaseOrders" xml:space="preserve"><value>Crea un ordine con un fornitore, poi registra il ricevimento. Il ricevimento carica le scorte e registra il costo.</value></data>
+  <data name="M4HelpValuation" xml:space="preserve"><value>Il valore delle scorte che detieni, usando il costo registrato al ricevimento.</value></data>
+  <data name="M5NoAlertsHelp" xml:space="preserve"><value>Nessun avviso aperto. Aggiorna per ricontrollare scorte, scadenze e resi in ritardo.</value></data>
+  <data name="M5CountEnterHelp" xml:space="preserve"><value>Inserisci ciò che hai davvero contato per ogni riga. La colonna scostamento si aggiorna dopo il salvataggio.</value></data>
+  <data name="M5CountNameHelp" xml:space="preserve"><value>Un nome che riconoscerai in seguito, ad esempio "Inventario annuale sede 2".</value></data>
+  <data name="StepItemBasics" xml:space="preserve"><value>Descrivi l'articolo</value></data>
+  <data name="StepItemTracking" xml:space="preserve"><value>Come viene tracciato</value></data>
+  <data name="StepItemStock" xml:space="preserve"><value>Livelli di scorta e costo</value></data>
+  <data name="StepLocationBasics" xml:space="preserve"><value>Assegna un nome all'ubicazione</value></data>
+  <data name="StepLocationScope" xml:space="preserve"><value>Dove si colloca</value></data>
+  <data name="StepMovementWhat" xml:space="preserve"><value>Cosa si muove</value></data>
+  <data name="StepMovementWhere" xml:space="preserve"><value>Da e a</value></data>
+  <data name="StepMovementAmount" xml:space="preserve"><value>Quanto</value></data>
+  <data name="StepIssueWhat" xml:space="preserve"><value>Cosa viene assegnato</value></data>
+  <data name="StepIssueWho" xml:space="preserve"><value>Chi lo prende in carico</value></data>
+  <data name="StepIssueWhen" xml:space="preserve"><value>Reso e note</value></data>
+  <data name="StepAssetItem" xml:space="preserve"><value>Quale articolo</value></data>
+  <data name="StepAssetIdentity" xml:space="preserve"><value>Numero di serie ed etichette</value></data>
+  <data name="StepLotItem" xml:space="preserve"><value>Quale articolo</value></data>
+  <data name="StepLotDetails" xml:space="preserve"><value>Dettagli del lotto</value></data>
+  <data name="StepKitBasics" xml:space="preserve"><value>Assegna un nome al kit</value></data>
+  <data name="StepKitContents" xml:space="preserve"><value>Contenuto del kit</value></data>
+  <data name="M4StepOrderHeader" xml:space="preserve"><value>Dati dell'ordine</value></data>
+  <data name="M4StepOrderLines" xml:space="preserve"><value>Righe dell'ordine</value></data>
+  <data name="M5StepCountBasics" xml:space="preserve"><value>Assegna un nome all'inventario</value></data>
+  <data name="M5StepCountScope" xml:space="preserve"><value>Ambito</value></data>
+  <data name="M5StepReportKind" xml:space="preserve"><value>Scegli un report</value></data>
+  <data name="M5StepReportFilters" xml:space="preserve"><value>Restringi il campo</value></data>
+  <data name="HelpFieldAmount" xml:space="preserve"><value>Quante unità, nell'unità di misura dell'articolo.</value></data>
+  <data name="HelpFieldAsset" xml:space="preserve"><value>Per gli articoli serializzati, scegli l'unità esatta.</value></data>
+  <data name="HelpFieldCategory" xml:space="preserve"><value>Raggruppamento facoltativo usato da elenchi e report.</value></data>
+  <data name="HelpFieldCode" xml:space="preserve"><value>Il tuo codice articolo o ricambio, se lo usi.</value></data>
+  <data name="HelpFieldCountLocation" xml:space="preserve"><value>Lascia vuoto per contare tutto.</value></data>
+  <data name="HelpFieldCurrency" xml:space="preserve"><value>Codice valuta di tre lettere, ad esempio USD o EUR.</value></data>
+  <data name="HelpFieldDefaultLocation" xml:space="preserve"><value>Le nuove scorte finiscono qui se non si sceglie un'ubicazione.</value></data>
+  <data name="HelpFieldExpectedReturn" xml:space="preserve"><value>I resi in ritardo vengono segnalati nella schermata avvisi.</value></data>
+  <data name="HelpFieldExpiration" xml:space="preserve"><value>La data in cui queste scorte non sono più utilizzabili.</value></data>
+  <data name="HelpFieldFromLocation" xml:space="preserve"><value>Da dove esce la merce. Lascia vuoto per un carico di nuova merce.</value></data>
+  <data name="HelpFieldHolder" xml:space="preserve"><value>Scegli una persona o un mezzo, non entrambi.</value></data>
+  <data name="HelpFieldIsActive" xml:space="preserve"><value>Gli articoli inattivi restano nello storico ma non sono selezionabili per nuovi movimenti.</value></data>
+  <data name="HelpFieldIsControlledSubstance" xml:space="preserve"><value>I movimenti richiedono un secondo testimone e vengono conservati per l'audit.</value></data>
+  <data name="HelpFieldIsKit" xml:space="preserve"><value>Segna come contenitore di kit invece di un articolo stoccato da solo.</value></data>
+  <data name="HelpFieldLocationType" xml:space="preserve"><value>Sede, mezzo, persona, contenitore o sotto-ubicazione di un altro luogo.</value></data>
+  <data name="HelpFieldLot" xml:space="preserve"><value>Scegli il lotto di provenienza, se l'articolo è tracciato a lotti.</value></data>
+  <data name="HelpFieldMinimum" xml:space="preserve"><value>Genera un avviso quando la giacenza scende sotto questo valore.</value></data>
+  <data name="HelpFieldNote" xml:space="preserve"><value>Perché è successo. Le note compaiono nel giornale e nei report.</value></data>
+  <data name="HelpFieldParent" xml:space="preserve"><value>Facoltativo. Annida questo record sotto un altro.</value></data>
+  <data name="HelpFieldReorderPoint" xml:space="preserve"><value>Suggerisci il riordino quando la giacenza raggiunge questo valore.</value></data>
+  <data name="HelpFieldReportRange" xml:space="preserve"><value>I report istantanei ignorano l'intervallo di date.</value></data>
+  <data name="HelpFieldRequiresExpiration" xml:space="preserve"><value>Richiedi una data di scadenza così l'articolo compare negli avvisi.</value></data>
+  <data name="HelpFieldRequiresLotTracking" xml:space="preserve"><value>Richiedi un numero di lotto a ogni ricevimento di questo articolo.</value></data>
+  <data name="HelpFieldReturnCondition" xml:space="preserve"><value>Le condizioni in cui è rientrata l'attrezzatura.</value></data>
+  <data name="HelpFieldSerialNumber" xml:space="preserve"><value>Numero di serie del produttore. Deve essere univoco per questo articolo.</value></data>
+  <data name="HelpFieldToLocation" xml:space="preserve"><value>Dove va la merce. Lascia vuoto in caso di consumo o scarico.</value></data>
+  <data name="HelpFieldTrackingMode" xml:space="preserve"><value>Sfuso conta una quantità. Serializzato traccia ogni unità separatamente, con numero e cronologia propri.</value></data>
+  <data name="HelpFieldUnitCost" xml:space="preserve"><value>Costo di una unità, usato per la valorizzazione.</value></data>
+  <data name="HelpFieldUnitOfMeasure" xml:space="preserve"><value>Come lo conti: pezzo, scatola, litro, metro.</value></data>
+  <data name="M4AccountNumberHelp" xml:space="preserve"><value>Il conto con cui questo fornitore ti identifica.</value></data>
+  <data name="M4CompanyContactHelp" xml:space="preserve"><value>Scegli il contatto aziendale a cui appartiene questo fornitore.</value></data>
+  <data name="M4NewVendorHint" xml:space="preserve"><value>Un fornitore è un contatto aziendale da cui acquisti. Crea prima il contatto se non è in elenco.</value></data>
+  <data name="M4PurchaseOrderNumberHelp" xml:space="preserve"><value>Il tuo riferimento per questo ordine. Compare nel giornale al ricevimento.</value></data>
+  <data name="M4StepOrderHeaderHint" xml:space="preserve"><value>Da chi acquisti, con quale riferimento e in quale valuta.</value></data>
+  <data name="M4StepOrderLinesHint" xml:space="preserve"><value>Una riga per articolo. Quantità e costi qui sono la base del ricevimento.</value></data>
+  <data name="M5StepCountBasicsHint" xml:space="preserve"><value>Un inventario congela un'istantanea delle scorte per confrontarla con lo scaffale.</value></data>
+  <data name="M5StepCountScopeHint" xml:space="preserve"><value>Conta una singola ubicazione o lascia vuoto per tutto il reparto.</value></data>
+  <data name="M5StepReportKindHint" xml:space="preserve"><value>Il report determina quali filtri del passo successivo si applicano.</value></data>
+  <data name="M5StepReportFiltersHint" xml:space="preserve"><value>Lascia vuoto un filtro per includere tutto. I filtri non disponibili sono disattivati.</value></data>
+  <data name="StepAssetItemHint" xml:space="preserve"><value>Un cespite è un'unità fisica di un articolo. Indica quale articolo è e dove starà.</value></data>
+  <data name="StepAssetIdentityHint" xml:space="preserve"><value>Come viene identificata questa unità quando qualcuno la prende o la scansiona.</value></data>
+  <data name="StepIssueWhatHint" xml:space="preserve"><value>Scegli l'articolo e il luogo da cui esce.</value></data>
+  <data name="StepIssueWhenHint" xml:space="preserve"><value>Quando lo attendi indietro e quanto vale la pena annotare sulla consegna.</value></data>
+  <data name="StepItemBasicsHint" xml:space="preserve"><value>Ciò che le persone vedranno cercandolo in un elenco.</value></data>
+  <data name="StepItemTrackingHint" xml:space="preserve"><value>Queste risposte decidono cosa chiederà il sistema in seguito e sono difficili da cambiare con scorte esistenti.</value></data>
+  <data name="StepItemStockHint" xml:space="preserve"><value>Soglie facoltative che generano avvisi di scorta bassa e il costo usato per la valorizzazione.</value></data>
+  <data name="StepKitBasicsHint" xml:space="preserve"><value>I kit si consegnano interi, quindi dagli un nome che le squadre riconoscano.</value></data>
+  <data name="StepKitContentsHint" xml:space="preserve"><value>Elenca ogni articolo del kit e la relativa quantità.</value></data>
+  <data name="StepKitIssueHint" xml:space="preserve"><value>Conferma per ogni parte del kit quale unità fisica e da quale scaffale proviene.</value></data>
+  <data name="StepLocationBasicsHint" xml:space="preserve"><value>Il nome compare in ogni elenco che chiede dove si trova qualcosa.</value></data>
+  <data name="StepLocationScopeHint" xml:space="preserve"><value>Compila solo il campo corrispondente al tipo scelto; lascia vuoti gli altri.</value></data>
+  <data name="StepLotDetailsHint" xml:space="preserve"><value>Il numero di lotto stampato sulla confezione, con costo e scadenza.</value></data>
+  <data name="StepLotItemHint" xml:space="preserve"><value>I lotti appartengono sempre a un articolo, quindi scegli prima quello.</value></data>
+  <data name="StepMovementWhatHint" xml:space="preserve"><value>Il tipo di movimento determina quali dei campi sotto verranno usati.</value></data>
+  <data name="StepMovementWhereHint" xml:space="preserve"><value>Un carico richiede solo la destinazione; un consumo o scarico solo l'origine.</value></data>
+  <data name="StepMovementAmountHint" xml:space="preserve"><value>La quantità e il motivo. Entrambi finiscono nella registrazione creata.</value></data>
+  <data name="StepReturnHint" xml:space="preserve"><value>Indica quanto è rientrato, dove è andato e in che condizioni è.</value></data>
+  <data name="Inactive" xml:space="preserve"><value>Non attivo</value></data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Inventory/Inventory.pl.resx
+++ b/Core/Resgrid.Localization/Areas/User/Inventory/Inventory.pl.resx
@@ -650,4 +650,137 @@
   <data name="WorkOrderPostingRequired" xml:space="preserve"><value>Zaksięguj lub odwróć tę część przez jej zlecenie.</value></data>
   <data name="AssetSafetyHold" xml:space="preserve"><value>Blokada bezpieczeństwa konserwacji uniemożliwia przywrócenie sprzętu do użytku.</value></data>
   <data name="ReadinessProRequired" xml:space="preserve"><value>Readiness Pro jest wymagany do nowych prac konserwacyjnych.</value></data>
+  <data name="AdjustStock" xml:space="preserve"><value>Koryguj stan</value></data>
+  <data name="Back" xml:space="preserve"><value>Wstecz</value></data>
+  <data name="Category" xml:space="preserve"><value>Kategoria</value></data>
+  <data name="Close" xml:space="preserve"><value>Zamknij</value></data>
+  <data name="Contents" xml:space="preserve"><value>Zawartość</value></data>
+  <data name="Continue" xml:space="preserve"><value>Dalej</value></data>
+  <data name="EditItem" xml:space="preserve"><value>Edytuj pozycję</value></data>
+  <data name="Expires" xml:space="preserve"><value>Wygasa</value></data>
+  <data name="Filter" xml:space="preserve"><value>Filtruj</value></data>
+  <data name="IssueEquipment" xml:space="preserve"><value>Wydaj sprzęt</value></data>
+  <data name="Item" xml:space="preserve"><value>Pozycja</value></data>
+  <data name="NewCategory" xml:space="preserve"><value>Nowa kategoria</value></data>
+  <data name="NewKit" xml:space="preserve"><value>Nowy zestaw</value></data>
+  <data name="NewLocation" xml:space="preserve"><value>Nowa lokalizacja</value></data>
+  <data name="NewLot" xml:space="preserve"><value>Nowa partia</value></data>
+  <data name="NewTransfer" xml:space="preserve"><value>Nowe przesunięcie</value></data>
+  <data name="NoRowsHelp" xml:space="preserve"><value>Jeszcze nic tu nie ma. Użyj przycisków powyżej, aby utworzyć pierwszy wpis.</value></data>
+  <data name="Outstanding" xml:space="preserve"><value>Zaległe</value></data>
+  <data name="Quantity" xml:space="preserve"><value>Ilość</value></data>
+  <data name="RequiredFieldsMissing" xml:space="preserve"><value>Wypełnij podświetlone pola przed przejściem dalej.</value></data>
+  <data name="Review" xml:space="preserve"><value>Podsumowanie</value></data>
+  <data name="ReviewHint" xml:space="preserve"><value>Sprawdź poniższe odpowiedzi, a następnie zapisz.</value></data>
+  <data name="Transaction" xml:space="preserve"><value>Zapis księgi</value></data>
+  <data name="Type" xml:space="preserve"><value>Typ</value></data>
+  <data name="When" xml:space="preserve"><value>Kiedy</value></data>
+  <data name="WorkspaceIntro" xml:space="preserve"><value>Śledź, co posiada Twoja jednostka, gdzie to jest przechowywane i kto to nosi.</value></data>
+  <data name="M4PurchasingIntro" xml:space="preserve"><value>Zarządzaj dostawcami, twórz zamówienia i sprawdzaj wartość zapasów.</value></data>
+  <data name="M5OperationsIntro" xml:space="preserve"><value>Przeprowadzaj inwentaryzacje, obsługuj alerty i drukuj raporty magazynowe.</value></data>
+  <data name="HelpOnHand" xml:space="preserve"><value>Aktualny stan według pozycji i lokalizacji. Filtruj po pozycji lub miejscu i koryguj stan po zmianie wyniku liczenia.</value></data>
+  <data name="HelpItems" xml:space="preserve"><value>Pozycje to wpisy katalogowe, a nie fizyczne przedmioty. Ustal sposób śledzenia, zanim dodasz stan magazynowy.</value></data>
+  <data name="HelpCategories" xml:space="preserve"><value>Kategorie grupują pozycje, aby listy i raporty pozostały czytelne. Kategoria może należeć do kategorii nadrzędnej.</value></data>
+  <data name="HelpLocations" xml:space="preserve"><value>Lokalizacje to miejsca przechowywania: remizy, pojazdy, osoby, pojemniki lub półka wewnątrz innej lokalizacji.</value></data>
+  <data name="HelpLots" xml:space="preserve"><value>Partia to grupa jednej pozycji o wspólnym numerze partii, dacie ważności i koszcie.</value></data>
+  <data name="HelpAssets" xml:space="preserve"><value>Zasoby to sprzęt z indywidualnym numerem seryjnym. Każdy ma własny numer, status i historię.</value></data>
+  <data name="HelpIssuances" xml:space="preserve"><value>Sprzęt aktualnie wydany osobie lub pojazdowi. Zarejestruj zwrot, gdy wróci.</value></data>
+  <data name="HelpKits" xml:space="preserve"><value>Zestaw to stała lista pozycji wydawanych razem, np. ubranie bojowe lub torba ratownicza.</value></data>
+  <data name="HelpTransfers" xml:space="preserve"><value>Przenoś zapas między dwiema lokalizacjami. Obie strony ruchu trafiają do księgi.</value></data>
+  <data name="HelpHistory" xml:space="preserve"><value>Każdy ruch trafia do księgi tylko do dopisywania. Filtruj po pozycji lub lokalizacji, aby zbadać zmianę.</value></data>
+  <data name="HelpAssetDetail" xml:space="preserve"><value>Pełna historia zasobu wraz z listami kontrolnymi i zleceniami pracy.</value></data>
+  <data name="HelpTransaction" xml:space="preserve"><value>Pojedynczy zapis księgi, pokazany dokładnie tak, jak został zapisany.</value></data>
+  <data name="HelpUnitEquipment" xml:space="preserve"><value>Wszystko, co jest obecnie przypisane do wybranego pojazdu.</value></data>
+  <data name="HelpPersonnelGear" xml:space="preserve"><value>Wszystko, co jest obecnie wydane wybranej osobie.</value></data>
+  <data name="HelpHolderLookup" xml:space="preserve"><value>Sprawdź wszystko, co posiada dany pojazd lub osoba.</value></data>
+  <data name="HelpLocationRename" xml:space="preserve"><value>Tutaj można zmienić tylko nazwę. Umiejscowienie i zakres ustalono przy tworzeniu.</value></data>
+  <data name="HelpAssetStatus" xml:space="preserve"><value>Zmiana statusu tworzy zapis w księdze. Użyj jej przy naprawie, uszkodzeniu, utracie lub wycofaniu.</value></data>
+  <data name="HelpWitness" xml:space="preserve"><value>Wpisz numer żądania pokazany przy księgowaniu i poświadcz to, co widziałeś.</value></data>
+  <data name="M4HelpVendors" xml:space="preserve"><value>Dostawcy, u których kupujesz. Każdy jest powiązany z kontaktem firmowym i może mieć numer konta.</value></data>
+  <data name="M4HelpPurchaseOrders" xml:space="preserve"><value>Utwórz zamówienie u dostawcy, a następnie przyjmij dostawę. Przyjęcie księguje zapas i zapisuje koszt.</value></data>
+  <data name="M4HelpValuation" xml:space="preserve"><value>Wartość posiadanego zapasu według kosztu zapisanego przy przyjęciu.</value></data>
+  <data name="M5NoAlertsHelp" xml:space="preserve"><value>Brak otwartych alertów. Odśwież, aby ponownie sprawdzić stany, terminy ważności i zaległe zwroty.</value></data>
+  <data name="M5CountEnterHelp" xml:space="preserve"><value>Wpisz faktycznie policzoną ilość dla każdej linii. Kolumna różnicy zaktualizuje się po zapisaniu.</value></data>
+  <data name="M5CountNameHelp" xml:space="preserve"><value>Nazwa, którą później rozpoznasz, np. „Inwentaryzacja roczna JRG 2”.</value></data>
+  <data name="StepItemBasics" xml:space="preserve"><value>Opisz pozycję</value></data>
+  <data name="StepItemTracking" xml:space="preserve"><value>Sposób śledzenia</value></data>
+  <data name="StepItemStock" xml:space="preserve"><value>Poziomy zapasu i koszt</value></data>
+  <data name="StepLocationBasics" xml:space="preserve"><value>Nazwij lokalizację</value></data>
+  <data name="StepLocationScope" xml:space="preserve"><value>Gdzie się znajduje</value></data>
+  <data name="StepMovementWhat" xml:space="preserve"><value>Co się przemieszcza</value></data>
+  <data name="StepMovementWhere" xml:space="preserve"><value>Skąd i dokąd</value></data>
+  <data name="StepMovementAmount" xml:space="preserve"><value>Ile</value></data>
+  <data name="StepIssueWhat" xml:space="preserve"><value>Co jest wydawane</value></data>
+  <data name="StepIssueWho" xml:space="preserve"><value>Kto to odbiera</value></data>
+  <data name="StepIssueWhen" xml:space="preserve"><value>Zwrot i uwagi</value></data>
+  <data name="StepAssetItem" xml:space="preserve"><value>Która pozycja</value></data>
+  <data name="StepAssetIdentity" xml:space="preserve"><value>Numer seryjny i oznaczenia</value></data>
+  <data name="StepLotItem" xml:space="preserve"><value>Która pozycja</value></data>
+  <data name="StepLotDetails" xml:space="preserve"><value>Dane partii</value></data>
+  <data name="StepKitBasics" xml:space="preserve"><value>Nazwij zestaw</value></data>
+  <data name="StepKitContents" xml:space="preserve"><value>Zawartość zestawu</value></data>
+  <data name="M4StepOrderHeader" xml:space="preserve"><value>Dane zamówienia</value></data>
+  <data name="M4StepOrderLines" xml:space="preserve"><value>Pozycje zamówienia</value></data>
+  <data name="M5StepCountBasics" xml:space="preserve"><value>Nazwij inwentaryzację</value></data>
+  <data name="M5StepCountScope" xml:space="preserve"><value>Zakres</value></data>
+  <data name="M5StepReportKind" xml:space="preserve"><value>Wybierz raport</value></data>
+  <data name="M5StepReportFilters" xml:space="preserve"><value>Zawęź wyniki</value></data>
+  <data name="HelpFieldAmount" xml:space="preserve"><value>Ile jednostek, w jednostce miary pozycji.</value></data>
+  <data name="HelpFieldAsset" xml:space="preserve"><value>Dla pozycji z numerem seryjnym wybierz konkretny egzemplarz.</value></data>
+  <data name="HelpFieldCategory" xml:space="preserve"><value>Opcjonalne grupowanie używane na listach i w raportach.</value></data>
+  <data name="HelpFieldCode" xml:space="preserve"><value>Własny numer katalogowy lub części, jeśli go stosujesz.</value></data>
+  <data name="HelpFieldCountLocation" xml:space="preserve"><value>Pozostaw puste, aby policzyć wszystko.</value></data>
+  <data name="HelpFieldCurrency" xml:space="preserve"><value>Trzyliterowy kod waluty, np. USD lub EUR.</value></data>
+  <data name="HelpFieldDefaultLocation" xml:space="preserve"><value>Nowy zapas trafia tutaj, gdy nie wybrano lokalizacji.</value></data>
+  <data name="HelpFieldExpectedReturn" xml:space="preserve"><value>Zaległe zwroty są oznaczane na ekranie alertów.</value></data>
+  <data name="HelpFieldExpiration" xml:space="preserve"><value>Data, od której zapas przestaje być zdatny do użycia.</value></data>
+  <data name="HelpFieldFromLocation" xml:space="preserve"><value>Skąd wychodzi zapas. Pozostaw puste przy przyjęciu nowego zapasu.</value></data>
+  <data name="HelpFieldHolder" xml:space="preserve"><value>Wybierz osobę albo pojazd, nie oba.</value></data>
+  <data name="HelpFieldIsActive" xml:space="preserve"><value>Nieaktywne pozycje pozostają w historii, ale nie można ich wybrać do nowych ruchów.</value></data>
+  <data name="HelpFieldIsControlledSubstance" xml:space="preserve"><value>Ruchy wymagają świadka i są przechowywane do celów audytu.</value></data>
+  <data name="HelpFieldIsKit" xml:space="preserve"><value>Oznacz jako pojemnik zestawu, a nie pozycję magazynowaną osobno.</value></data>
+  <data name="HelpFieldLocationType" xml:space="preserve"><value>Remiza, pojazd, osoba, pojemnik lub podlokalizacja innego miejsca.</value></data>
+  <data name="HelpFieldLot" xml:space="preserve"><value>Wybierz partię pochodzenia, jeśli pozycja jest śledzona partiami.</value></data>
+  <data name="HelpFieldMinimum" xml:space="preserve"><value>Zgłoś alert, gdy stan spadnie poniżej tej wartości.</value></data>
+  <data name="HelpFieldNote" xml:space="preserve"><value>Dlaczego tak się stało. Uwagi pojawiają się w księdze i raportach.</value></data>
+  <data name="HelpFieldParent" xml:space="preserve"><value>Opcjonalnie. Zagnieźdź ten wpis pod innym.</value></data>
+  <data name="HelpFieldReorderPoint" xml:space="preserve"><value>Zaproponuj zamówienie, gdy stan osiągnie tę wartość.</value></data>
+  <data name="HelpFieldReportRange" xml:space="preserve"><value>Raporty migawkowe ignorują zakres dat.</value></data>
+  <data name="HelpFieldRequiresExpiration" xml:space="preserve"><value>Wymagaj daty ważności, aby pozycja pojawiała się w alertach.</value></data>
+  <data name="HelpFieldRequiresLotTracking" xml:space="preserve"><value>Wymagaj numeru partii przy każdym przyjęciu tej pozycji.</value></data>
+  <data name="HelpFieldReturnCondition" xml:space="preserve"><value>Stan, w jakim sprzęt wrócił.</value></data>
+  <data name="HelpFieldSerialNumber" xml:space="preserve"><value>Numer seryjny producenta. Musi być unikalny dla tej pozycji.</value></data>
+  <data name="HelpFieldToLocation" xml:space="preserve"><value>Dokąd trafia zapas. Pozostaw puste przy zużyciu lub odpisie.</value></data>
+  <data name="HelpFieldTrackingMode" xml:space="preserve"><value>Luzem zlicza ilość. Numer seryjny śledzi każdy egzemplarz osobno, z własnym numerem i historią.</value></data>
+  <data name="HelpFieldUnitCost" xml:space="preserve"><value>Koszt jednej jednostki, używany do wyceny.</value></data>
+  <data name="HelpFieldUnitOfMeasure" xml:space="preserve"><value>Jak liczysz: sztuka, opakowanie, litr, metr.</value></data>
+  <data name="M4AccountNumberHelp" xml:space="preserve"><value>Numer konta, pod którym zna Cię ten dostawca.</value></data>
+  <data name="M4CompanyContactHelp" xml:space="preserve"><value>Wybierz kontakt firmowy, do którego należy ten dostawca.</value></data>
+  <data name="M4NewVendorHint" xml:space="preserve"><value>Dostawca to kontakt firmowy, u którego kupujesz. Najpierw dodaj kontakt, jeśli go nie ma.</value></data>
+  <data name="M4PurchaseOrderNumberHelp" xml:space="preserve"><value>Twój numer referencyjny zamówienia. Pojawi się w księdze przy przyjęciu.</value></data>
+  <data name="M4StepOrderHeaderHint" xml:space="preserve"><value>Od kogo kupujesz, pod jakim numerem i w jakiej walucie.</value></data>
+  <data name="M4StepOrderLinesHint" xml:space="preserve"><value>Jedna linia na pozycję. Ilości i koszty stanowią podstawę przyjęcia.</value></data>
+  <data name="M5StepCountBasicsHint" xml:space="preserve"><value>Inwentaryzacja zamraża migawkę zapasu, aby porównać ją z tym, co jest na półce.</value></data>
+  <data name="M5StepCountScopeHint" xml:space="preserve"><value>Policz jedną lokalizację lub pozostaw puste, aby objąć całą jednostkę.</value></data>
+  <data name="M5StepReportKindHint" xml:space="preserve"><value>Raport decyduje, które filtry z następnego kroku mają zastosowanie.</value></data>
+  <data name="M5StepReportFiltersHint" xml:space="preserve"><value>Pozostaw filtr pusty, aby uwzględnić wszystko. Niedostępne filtry są wyszarzone.</value></data>
+  <data name="StepAssetItemHint" xml:space="preserve"><value>Zasób to fizyczny egzemplarz pozycji. Wskaż pozycję i miejsce przechowywania.</value></data>
+  <data name="StepAssetIdentityHint" xml:space="preserve"><value>Jak identyfikowany jest ten egzemplarz przy pobraniu lub skanowaniu.</value></data>
+  <data name="StepIssueWhatHint" xml:space="preserve"><value>Wybierz pozycję i miejsce, z którego jest pobierana.</value></data>
+  <data name="StepIssueWhenHint" xml:space="preserve"><value>Kiedy spodziewasz się zwrotu i co warto odnotować o wydaniu.</value></data>
+  <data name="StepItemBasicsHint" xml:space="preserve"><value>To, co użytkownicy zobaczą, szukając tego na liście.</value></data>
+  <data name="StepItemTrackingHint" xml:space="preserve"><value>Te odpowiedzi decydują, o co system zapyta później, i trudno je zmienić, gdy istnieje zapas.</value></data>
+  <data name="StepItemStockHint" xml:space="preserve"><value>Opcjonalne progi generujące alerty niskiego stanu oraz koszt do wyceny.</value></data>
+  <data name="StepKitBasicsHint" xml:space="preserve"><value>Zestawy wydaje się w całości, więc nadaj nazwę rozpoznawalną dla załóg.</value></data>
+  <data name="StepKitContentsHint" xml:space="preserve"><value>Wymień każdą pozycję zestawu i jej ilość.</value></data>
+  <data name="StepKitIssueHint" xml:space="preserve"><value>Potwierdź, który egzemplarz i z której półki pochodzi każdy element zestawu.</value></data>
+  <data name="StepLocationBasicsHint" xml:space="preserve"><value>Nazwa pojawi się w każdej liście pytającej o miejsce.</value></data>
+  <data name="StepLocationScopeHint" xml:space="preserve"><value>Wypełnij tylko pole odpowiadające wybranemu typowi; resztę zostaw pustą.</value></data>
+  <data name="StepLotDetailsHint" xml:space="preserve"><value>Numer partii z opakowania oraz koszt i data ważności partii.</value></data>
+  <data name="StepLotItemHint" xml:space="preserve"><value>Partie zawsze należą do jednej pozycji, więc wybierz ją najpierw.</value></data>
+  <data name="StepMovementWhatHint" xml:space="preserve"><value>Rodzaj ruchu decyduje, które z poniższych pól zostaną użyte.</value></data>
+  <data name="StepMovementWhereHint" xml:space="preserve"><value>Przyjęcie wymaga tylko celu; zużycie lub odpis tylko źródła.</value></data>
+  <data name="StepMovementAmountHint" xml:space="preserve"><value>Ilość i powód. Oba trafiają do tworzonego zapisu księgi.</value></data>
+  <data name="StepReturnHint" xml:space="preserve"><value>Podaj, ile wróciło, gdzie trafiło i w jakim jest stanie.</value></data>
+  <data name="Inactive" xml:space="preserve"><value>Nieaktywny</value></data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Inventory/Inventory.sv.resx
+++ b/Core/Resgrid.Localization/Areas/User/Inventory/Inventory.sv.resx
@@ -650,4 +650,137 @@
   <data name="WorkOrderPostingRequired" xml:space="preserve"><value>Bokför eller återför delen via dess arbetsorder.</value></data>
   <data name="AssetSafetyHold" xml:space="preserve"><value>En säkerhetsspärr för underhåll hindrar att utrustningen återtas i drift.</value></data>
   <data name="ReadinessProRequired" xml:space="preserve"><value>Readiness Pro krävs för nya underhållsarbeten.</value></data>
+  <data name="AdjustStock" xml:space="preserve"><value>Justera lager</value></data>
+  <data name="Back" xml:space="preserve"><value>Tillbaka</value></data>
+  <data name="Category" xml:space="preserve"><value>Kategori</value></data>
+  <data name="Close" xml:space="preserve"><value>Stäng</value></data>
+  <data name="Contents" xml:space="preserve"><value>Innehåll</value></data>
+  <data name="Continue" xml:space="preserve"><value>Fortsätt</value></data>
+  <data name="EditItem" xml:space="preserve"><value>Redigera artikel</value></data>
+  <data name="Expires" xml:space="preserve"><value>Går ut</value></data>
+  <data name="Filter" xml:space="preserve"><value>Filtrera</value></data>
+  <data name="IssueEquipment" xml:space="preserve"><value>Lämna ut utrustning</value></data>
+  <data name="Item" xml:space="preserve"><value>Artikel</value></data>
+  <data name="NewCategory" xml:space="preserve"><value>Ny kategori</value></data>
+  <data name="NewKit" xml:space="preserve"><value>Ny sats</value></data>
+  <data name="NewLocation" xml:space="preserve"><value>Ny plats</value></data>
+  <data name="NewLot" xml:space="preserve"><value>Nytt parti</value></data>
+  <data name="NewTransfer" xml:space="preserve"><value>Ny överföring</value></data>
+  <data name="NoRowsHelp" xml:space="preserve"><value>Inget här ännu. Använd knapparna ovan för att skapa den första posten.</value></data>
+  <data name="Outstanding" xml:space="preserve"><value>Utestående</value></data>
+  <data name="Quantity" xml:space="preserve"><value>Antal</value></data>
+  <data name="RequiredFieldsMissing" xml:space="preserve"><value>Fyll i de markerade fälten innan du fortsätter.</value></data>
+  <data name="Review" xml:space="preserve"><value>Granska</value></data>
+  <data name="ReviewHint" xml:space="preserve"><value>Kontrollera uppgifterna nedan och spara sedan.</value></data>
+  <data name="Transaction" xml:space="preserve"><value>Transaktion</value></data>
+  <data name="Type" xml:space="preserve"><value>Typ</value></data>
+  <data name="When" xml:space="preserve"><value>När</value></data>
+  <data name="WorkspaceIntro" xml:space="preserve"><value>Håll reda på vad din organisation äger, var det förvaras och vem som bär det.</value></data>
+  <data name="M4PurchasingIntro" xml:space="preserve"><value>Hantera leverantörer, skapa inköpsorder och se vad lagret är värt.</value></data>
+  <data name="M5OperationsIntro" xml:space="preserve"><value>Genomför inventeringar, hantera varningar och skriv ut lagerrapporter.</value></data>
+  <data name="HelpOnHand" xml:space="preserve"><value>Vad du har just nu, per artikel och plats. Filtrera på en artikel eller plats och justera lagret när en räkning ändras.</value></data>
+  <data name="HelpItems" xml:space="preserve"><value>Artiklar är det du lagerför: katalogposten, inte ett fysiskt föremål. Bestäm hur varje artikel spåras innan du lägger till lager.</value></data>
+  <data name="HelpCategories" xml:space="preserve"><value>Kategorier grupperar artiklar så att listor och rapporter förblir läsbara. En kategori kan ligga under en överordnad kategori.</value></data>
+  <data name="HelpLocations" xml:space="preserve"><value>Platser är där lagret finns: stationer, fordon, personer, behållare eller en hylla inuti en annan plats.</value></data>
+  <data name="HelpLots" xml:space="preserve"><value>Ett parti är en sats av en artikel med samma partinummer, utgångsdatum och kostnad.</value></data>
+  <data name="HelpAssets" xml:space="preserve"><value>Tillgångar är utrustning med individuellt serienummer. Var och en har eget nummer, status och historik.</value></data>
+  <data name="HelpIssuances" xml:space="preserve"><value>Utrustning som just nu är utlämnad till en person eller ett fordon. Registrera återlämning när den kommer tillbaka.</value></data>
+  <data name="HelpKits" xml:space="preserve"><value>En sats är en fast lista med artiklar som lämnas ut tillsammans, till exempel larmställ eller en akutväska.</value></data>
+  <data name="HelpTransfers" xml:space="preserve"><value>Flytta lager mellan två platser. Båda sidor av flytten skrivs till journalen.</value></data>
+  <data name="HelpHistory" xml:space="preserve"><value>Varje rörelse skrivs till en journal som endast kan utökas. Filtrera på artikel eller plats för att granska en ändring.</value></data>
+  <data name="HelpAssetDetail" xml:space="preserve"><value>Hela historiken för en tillgång, tillsammans med dess checklistor och arbetsorder.</value></data>
+  <data name="HelpTransaction" xml:space="preserve"><value>En enskild journalpost, visad exakt som den skrevs.</value></data>
+  <data name="HelpUnitEquipment" xml:space="preserve"><value>Allt som just nu är tilldelat det valda fordonet.</value></data>
+  <data name="HelpPersonnelGear" xml:space="preserve"><value>Allt som just nu är utlämnat till den valda personen.</value></data>
+  <data name="HelpHolderLookup" xml:space="preserve"><value>Slå upp allt som ett fordon eller en person har.</value></data>
+  <data name="HelpLocationRename" xml:space="preserve"><value>Endast namnet kan ändras här. Placering och omfattning fastställdes när platsen skapades.</value></data>
+  <data name="HelpAssetStatus" xml:space="preserve"><value>En statusändring skapar en journalpost. Använd den vid reparation, skada, förlust eller utrangering.</value></data>
+  <data name="HelpWitness" xml:space="preserve"><value>Ange begärannumret som visades vid bokföringen och intyga vad du såg.</value></data>
+  <data name="M4HelpVendors" xml:space="preserve"><value>Leverantörer du köper från. Var och en är kopplad till en företagskontakt och kan ha ett kundnummer.</value></data>
+  <data name="M4HelpPurchaseOrders" xml:space="preserve"><value>Skapa en order hos en leverantör och ta sedan emot mot den. Mottagningen bokför lagret och registrerar kostnaden.</value></data>
+  <data name="M4HelpValuation" xml:space="preserve"><value>Vad lagret du har är värt, baserat på kostnaden som registrerades vid mottagning.</value></data>
+  <data name="M5NoAlertsHelp" xml:space="preserve"><value>Inga öppna varningar. Uppdatera för att kontrollera lagernivåer, utgångsdatum och försenade återlämningar igen.</value></data>
+  <data name="M5CountEnterHelp" xml:space="preserve"><value>Ange vad du faktiskt räknade för varje rad. Avvikelsekolumnen uppdateras när räkningen sparats.</value></data>
+  <data name="M5CountNameHelp" xml:space="preserve"><value>Något du känner igen senare, till exempel "Station 2 årsinventering".</value></data>
+  <data name="StepItemBasics" xml:space="preserve"><value>Beskriv artikeln</value></data>
+  <data name="StepItemTracking" xml:space="preserve"><value>Hur den spåras</value></data>
+  <data name="StepItemStock" xml:space="preserve"><value>Lagernivåer och kostnad</value></data>
+  <data name="StepLocationBasics" xml:space="preserve"><value>Namnge platsen</value></data>
+  <data name="StepLocationScope" xml:space="preserve"><value>Var den hör hemma</value></data>
+  <data name="StepMovementWhat" xml:space="preserve"><value>Vad som flyttas</value></data>
+  <data name="StepMovementWhere" xml:space="preserve"><value>Från och till</value></data>
+  <data name="StepMovementAmount" xml:space="preserve"><value>Hur mycket</value></data>
+  <data name="StepIssueWhat" xml:space="preserve"><value>Vad som lämnas ut</value></data>
+  <data name="StepIssueWho" xml:space="preserve"><value>Vem som tar den</value></data>
+  <data name="StepIssueWhen" xml:space="preserve"><value>Återlämning och anteckningar</value></data>
+  <data name="StepAssetItem" xml:space="preserve"><value>Vilken artikel</value></data>
+  <data name="StepAssetIdentity" xml:space="preserve"><value>Serienummer och märkning</value></data>
+  <data name="StepLotItem" xml:space="preserve"><value>Vilken artikel</value></data>
+  <data name="StepLotDetails" xml:space="preserve"><value>Partiuppgifter</value></data>
+  <data name="StepKitBasics" xml:space="preserve"><value>Namnge satsen</value></data>
+  <data name="StepKitContents" xml:space="preserve"><value>Satsens innehåll</value></data>
+  <data name="M4StepOrderHeader" xml:space="preserve"><value>Orderuppgifter</value></data>
+  <data name="M4StepOrderLines" xml:space="preserve"><value>Orderrader</value></data>
+  <data name="M5StepCountBasics" xml:space="preserve"><value>Namnge inventeringen</value></data>
+  <data name="M5StepCountScope" xml:space="preserve"><value>Omfattning</value></data>
+  <data name="M5StepReportKind" xml:space="preserve"><value>Välj en rapport</value></data>
+  <data name="M5StepReportFilters" xml:space="preserve"><value>Avgränsa</value></data>
+  <data name="HelpFieldAmount" xml:space="preserve"><value>Hur många enheter, i artikelns måttenhet.</value></data>
+  <data name="HelpFieldAsset" xml:space="preserve"><value>För serienummermärkta artiklar, välj exakt enhet.</value></data>
+  <data name="HelpFieldCategory" xml:space="preserve"><value>Valfri gruppering som används i listor och rapporter.</value></data>
+  <data name="HelpFieldCode" xml:space="preserve"><value>Ditt eget artikel- eller reservdelsnummer, om du använder ett.</value></data>
+  <data name="HelpFieldCountLocation" xml:space="preserve"><value>Lämna tomt för att räkna allt.</value></data>
+  <data name="HelpFieldCurrency" xml:space="preserve"><value>Valutakod med tre bokstäver, till exempel USD eller EUR.</value></data>
+  <data name="HelpFieldDefaultLocation" xml:space="preserve"><value>Nytt lager hamnar här när ingen plats väljs.</value></data>
+  <data name="HelpFieldExpectedReturn" xml:space="preserve"><value>Försenade återlämningar flaggas på varningsskärmen.</value></data>
+  <data name="HelpFieldExpiration" xml:space="preserve"><value>Det datum då lagret inte längre går att använda.</value></data>
+  <data name="HelpFieldFromLocation" xml:space="preserve"><value>Varifrån lagret lämnar. Lämna tomt vid inleverans av nytt lager.</value></data>
+  <data name="HelpFieldHolder" xml:space="preserve"><value>Välj en person eller ett fordon, inte båda.</value></data>
+  <data name="HelpFieldIsActive" xml:space="preserve"><value>Inaktiva artiklar finns kvar i historiken men kan inte väljas för nya rörelser.</value></data>
+  <data name="HelpFieldIsControlledSubstance" xml:space="preserve"><value>Rörelser kräver en andra person som vittne och sparas för revision.</value></data>
+  <data name="HelpFieldIsKit" xml:space="preserve"><value>Markera som satsbehållare i stället för något du lagerför separat.</value></data>
+  <data name="HelpFieldLocationType" xml:space="preserve"><value>Station, fordon, person, behållare eller underplats till en annan plats.</value></data>
+  <data name="HelpFieldLot" xml:space="preserve"><value>Välj partiet lagret kommer från om artikeln partispåras.</value></data>
+  <data name="HelpFieldMinimum" xml:space="preserve"><value>Utlös en varning när saldot understiger detta.</value></data>
+  <data name="HelpFieldNote" xml:space="preserve"><value>Varför detta hände. Anteckningar visas i journalen och i rapporter.</value></data>
+  <data name="HelpFieldParent" xml:space="preserve"><value>Valfritt. Placera denna post under en annan.</value></data>
+  <data name="HelpFieldReorderPoint" xml:space="preserve"><value>Föreslå ombeställning när saldot når detta.</value></data>
+  <data name="HelpFieldReportRange" xml:space="preserve"><value>Ögonblicksrapporter ignorerar datumintervallet.</value></data>
+  <data name="HelpFieldRequiresExpiration" xml:space="preserve"><value>Kräv utgångsdatum så att artikeln syns i utgångsvarningar.</value></data>
+  <data name="HelpFieldRequiresLotTracking" xml:space="preserve"><value>Kräv partinummer varje gång denna artikel tas emot.</value></data>
+  <data name="HelpFieldReturnCondition" xml:space="preserve"><value>Skicket utrustningen kom tillbaka i.</value></data>
+  <data name="HelpFieldSerialNumber" xml:space="preserve"><value>Tillverkarens serienummer. Det måste vara unikt för artikeln.</value></data>
+  <data name="HelpFieldToLocation" xml:space="preserve"><value>Vart lagret går. Lämna tomt vid förbrukning eller avskrivning.</value></data>
+  <data name="HelpFieldTrackingMode" xml:space="preserve"><value>Bulk räknar en kvantitet. Serienummer spårar varje enhet separat, med eget nummer och historik.</value></data>
+  <data name="HelpFieldUnitCost" xml:space="preserve"><value>Kostnad för en enhet, används för värdering.</value></data>
+  <data name="HelpFieldUnitOfMeasure" xml:space="preserve"><value>Hur du räknar den: styck, kartong, liter, meter.</value></data>
+  <data name="M4AccountNumberHelp" xml:space="preserve"><value>Kontot som leverantören känner dig som.</value></data>
+  <data name="M4CompanyContactHelp" xml:space="preserve"><value>Välj företagskontakten som denna leverantör hör till.</value></data>
+  <data name="M4NewVendorHint" xml:space="preserve"><value>En leverantör är en företagskontakt du köper från. Lägg till kontakten först om den saknas.</value></data>
+  <data name="M4PurchaseOrderNumberHelp" xml:space="preserve"><value>Din referens för ordern. Den visas i journalen vid mottagning.</value></data>
+  <data name="M4StepOrderHeaderHint" xml:space="preserve"><value>Vem du köper av, under vilken referens och i vilken valuta.</value></data>
+  <data name="M4StepOrderLinesHint" xml:space="preserve"><value>En rad per artikel. Kvantiteter och kostnader här är underlag för mottagningen.</value></data>
+  <data name="M5StepCountBasicsHint" xml:space="preserve"><value>En inventering fryser en ögonblicksbild av lagret så du kan jämföra med hyllan.</value></data>
+  <data name="M5StepCountScopeHint" xml:space="preserve"><value>Räkna en plats, eller lämna tomt för att räkna hela organisationen.</value></data>
+  <data name="M5StepReportKindHint" xml:space="preserve"><value>Rapporten avgör vilka filter i nästa steg som gäller.</value></data>
+  <data name="M5StepReportFiltersHint" xml:space="preserve"><value>Lämna ett filter tomt för att ta med allt. Otillgängliga filter är nedtonade.</value></data>
+  <data name="StepAssetItemHint" xml:space="preserve"><value>En tillgång är en fysisk enhet av en artikel. Ange vilken artikel och var den ska finnas.</value></data>
+  <data name="StepAssetIdentityHint" xml:space="preserve"><value>Hur enheten identifieras när någon tar upp eller skannar den.</value></data>
+  <data name="StepIssueWhatHint" xml:space="preserve"><value>Välj artikeln och platsen den tas från.</value></data>
+  <data name="StepIssueWhenHint" xml:space="preserve"><value>När du väntar tillbaka den, och vad som är värt att notera om överlämningen.</value></data>
+  <data name="StepItemBasicsHint" xml:space="preserve"><value>Vad människor ser när de söker efter detta i en lista.</value></data>
+  <data name="StepItemTrackingHint" xml:space="preserve"><value>Dessa svar avgör vad systemet frågar efter senare och är svåra att ändra när lager finns.</value></data>
+  <data name="StepItemStockHint" xml:space="preserve"><value>Valfria trösklar som styr varningar om lågt lager, samt kostnaden för värdering.</value></data>
+  <data name="StepKitBasicsHint" xml:space="preserve"><value>Satser lämnas ut som helhet, så ge den ett namn dina besättningar känner igen.</value></data>
+  <data name="StepKitContentsHint" xml:space="preserve"><value>Lista varje artikel satsen innehåller och hur många av varje.</value></data>
+  <data name="StepKitIssueHint" xml:space="preserve"><value>Bekräfta vilken fysisk enhet och vilken plats varje del av satsen tas från.</value></data>
+  <data name="StepLocationBasicsHint" xml:space="preserve"><value>Namnet visas i varje listruta som frågar var något finns.</value></data>
+  <data name="StepLocationScopeHint" xml:space="preserve"><value>Fyll bara i fältet som matchar den typ du valde; lämna resten tomt.</value></data>
+  <data name="StepLotDetailsHint" xml:space="preserve"><value>Partinumret som står på förpackningen, plus vad partiet kostade och när det går ut.</value></data>
+  <data name="StepLotItemHint" xml:space="preserve"><value>Ett parti hör alltid till en artikel, så välj den först.</value></data>
+  <data name="StepMovementWhatHint" xml:space="preserve"><value>Typen av rörelse avgör vilka av fälten nedan som används.</value></data>
+  <data name="StepMovementWhereHint" xml:space="preserve"><value>En inleverans behöver bara en destination; förbrukning eller avskrivning bara en källa.</value></data>
+  <data name="StepMovementAmountHint" xml:space="preserve"><value>Kvantiteten och orsaken. Båda hamnar i journalposten som skapas.</value></data>
+  <data name="StepReturnHint" xml:space="preserve"><value>Ange hur mycket som kom tillbaka, vart det gick och i vilket skick det är.</value></data>
+  <data name="Inactive" xml:space="preserve"><value>Inaktiv</value></data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Inventory/Inventory.uk.resx
+++ b/Core/Resgrid.Localization/Areas/User/Inventory/Inventory.uk.resx
@@ -650,4 +650,137 @@
   <data name="WorkOrderPostingRequired" xml:space="preserve"><value>Проведіть або сторнуйте цю деталь через її наряд.</value></data>
   <data name="AssetSafetyHold" xml:space="preserve"><value>Блокування безпеки обслуговування перешкоджає поверненню обладнання в експлуатацію.</value></data>
   <data name="ReadinessProRequired" xml:space="preserve"><value>Для нових робіт з обслуговування потрібен Readiness Pro.</value></data>
+  <data name="AdjustStock" xml:space="preserve"><value>Скоригувати запас</value></data>
+  <data name="Back" xml:space="preserve"><value>Назад</value></data>
+  <data name="Category" xml:space="preserve"><value>Категорія</value></data>
+  <data name="Close" xml:space="preserve"><value>Закрити</value></data>
+  <data name="Contents" xml:space="preserve"><value>Вміст</value></data>
+  <data name="Continue" xml:space="preserve"><value>Продовжити</value></data>
+  <data name="EditItem" xml:space="preserve"><value>Редагувати позицію</value></data>
+  <data name="Expires" xml:space="preserve"><value>Спливає</value></data>
+  <data name="Filter" xml:space="preserve"><value>Фільтр</value></data>
+  <data name="IssueEquipment" xml:space="preserve"><value>Видати спорядження</value></data>
+  <data name="Item" xml:space="preserve"><value>Позиція</value></data>
+  <data name="NewCategory" xml:space="preserve"><value>Нова категорія</value></data>
+  <data name="NewKit" xml:space="preserve"><value>Новий комплект</value></data>
+  <data name="NewLocation" xml:space="preserve"><value>Нове розташування</value></data>
+  <data name="NewLot" xml:space="preserve"><value>Нова партія</value></data>
+  <data name="NewTransfer" xml:space="preserve"><value>Нове переміщення</value></data>
+  <data name="NoRowsHelp" xml:space="preserve"><value>Тут ще нічого немає. Скористайтеся кнопками вище, щоб створити перший запис.</value></data>
+  <data name="Outstanding" xml:space="preserve"><value>Не повернено</value></data>
+  <data name="Quantity" xml:space="preserve"><value>Кількість</value></data>
+  <data name="RequiredFieldsMissing" xml:space="preserve"><value>Заповніть підсвічені поля, перш ніж продовжити.</value></data>
+  <data name="Review" xml:space="preserve"><value>Перевірка</value></data>
+  <data name="ReviewHint" xml:space="preserve"><value>Перевірте відповіді нижче та збережіть.</value></data>
+  <data name="Transaction" xml:space="preserve"><value>Запис журналу</value></data>
+  <data name="Type" xml:space="preserve"><value>Тип</value></data>
+  <data name="When" xml:space="preserve"><value>Коли</value></data>
+  <data name="WorkspaceIntro" xml:space="preserve"><value>Відстежуйте, що має ваш підрозділ, де це зберігається і хто це носить.</value></data>
+  <data name="M4PurchasingIntro" xml:space="preserve"><value>Керуйте постачальниками, створюйте замовлення та дивіться вартість запасів.</value></data>
+  <data name="M5OperationsIntro" xml:space="preserve"><value>Проводьте інвентаризації, опрацьовуйте сповіщення та друкуйте звіти.</value></data>
+  <data name="HelpOnHand" xml:space="preserve"><value>Що ви маєте зараз, за позицією та розташуванням. Відфільтруйте за позицією чи місцем і скоригуйте запас, якщо підрахунок змінився.</value></data>
+  <data name="HelpItems" xml:space="preserve"><value>Позиції — це записи каталогу, а не фізичні предмети. Визначте спосіб обліку, перш ніж додавати запас.</value></data>
+  <data name="HelpCategories" xml:space="preserve"><value>Категорії групують позиції, щоб списки та звіти залишалися зрозумілими. Категорія може належати до батьківської.</value></data>
+  <data name="HelpLocations" xml:space="preserve"><value>Розташування — це де зберігається запас: частини, техніка, люди, контейнери або полиця всередині іншого розташування.</value></data>
+  <data name="HelpLots" xml:space="preserve"><value>Партія — це набір однієї позиції зі спільним номером партії, терміном придатності та вартістю.</value></data>
+  <data name="HelpAssets" xml:space="preserve"><value>Активи — це обладнання з індивідуальним серійним номером. Кожен має власний номер, стан та історію.</value></data>
+  <data name="HelpIssuances" xml:space="preserve"><value>Спорядження, видане особі чи техніці. Зафіксуйте повернення, коли його здадуть.</value></data>
+  <data name="HelpKits" xml:space="preserve"><value>Комплект — це фіксований перелік позицій, які видають разом, як-от бойовий одяг або медична сумка.</value></data>
+  <data name="HelpTransfers" xml:space="preserve"><value>Переміщуйте запас між двома розташуваннями. Обидві сторони руху записуються до журналу.</value></data>
+  <data name="HelpHistory" xml:space="preserve"><value>Кожен рух записується до журналу лише з додаванням. Фільтруйте за позицією чи розташуванням для аудиту.</value></data>
+  <data name="HelpAssetDetail" xml:space="preserve"><value>Повна історія одного активу разом із чек-листами та нарядами.</value></data>
+  <data name="HelpTransaction" xml:space="preserve"><value>Один запис журналу, показаний точно так, як його зроблено.</value></data>
+  <data name="HelpUnitEquipment" xml:space="preserve"><value>Усе, що зараз закріплено за обраною технікою.</value></data>
+  <data name="HelpPersonnelGear" xml:space="preserve"><value>Усе, що зараз видано обраній особі.</value></data>
+  <data name="HelpHolderLookup" xml:space="preserve"><value>Перегляньте все, що закріплено за технікою чи особою.</value></data>
+  <data name="HelpLocationRename" xml:space="preserve"><value>Тут можна змінити лише назву. Розміщення та область визначено під час створення.</value></data>
+  <data name="HelpAssetStatus" xml:space="preserve"><value>Зміна стану створює запис у журналі. Використовуйте її при ремонті, пошкодженні, втраті чи списанні.</value></data>
+  <data name="HelpWitness" xml:space="preserve"><value>Введіть номер запиту, показаний під час проведення, і засвідчіть побачене.</value></data>
+  <data name="M4HelpVendors" xml:space="preserve"><value>Постачальники, у яких ви купуєте. Кожного пов'язано з контактом компанії та може мати номер рахунку.</value></data>
+  <data name="M4HelpPurchaseOrders" xml:space="preserve"><value>Створіть замовлення в постачальника, потім оприбуткуйте його. Оприбуткування проводить запас і фіксує вартість.</value></data>
+  <data name="M4HelpValuation" xml:space="preserve"><value>Вартість наявного запасу за собівартістю, зафіксованою під час оприбуткування.</value></data>
+  <data name="M5NoAlertsHelp" xml:space="preserve"><value>Немає відкритих сповіщень. Оновіть, щоб знову перевірити залишки, терміни придатності та прострочені повернення.</value></data>
+  <data name="M5CountEnterHelp" xml:space="preserve"><value>Введіть фактично підраховану кількість для кожного рядка. Стовпець розбіжності оновиться після збереження.</value></data>
+  <data name="M5CountNameHelp" xml:space="preserve"><value>Те, що ви впізнаєте згодом, наприклад «Річна інвентаризація частини 2».</value></data>
+  <data name="StepItemBasics" xml:space="preserve"><value>Опишіть позицію</value></data>
+  <data name="StepItemTracking" xml:space="preserve"><value>Спосіб обліку</value></data>
+  <data name="StepItemStock" xml:space="preserve"><value>Рівні запасу та вартість</value></data>
+  <data name="StepLocationBasics" xml:space="preserve"><value>Назвіть розташування</value></data>
+  <data name="StepLocationScope" xml:space="preserve"><value>Де воно розташоване</value></data>
+  <data name="StepMovementWhat" xml:space="preserve"><value>Що переміщується</value></data>
+  <data name="StepMovementWhere" xml:space="preserve"><value>Звідки й куди</value></data>
+  <data name="StepMovementAmount" xml:space="preserve"><value>Скільки</value></data>
+  <data name="StepIssueWhat" xml:space="preserve"><value>Що видається</value></data>
+  <data name="StepIssueWho" xml:space="preserve"><value>Хто його отримує</value></data>
+  <data name="StepIssueWhen" xml:space="preserve"><value>Повернення та примітки</value></data>
+  <data name="StepAssetItem" xml:space="preserve"><value>Яка позиція</value></data>
+  <data name="StepAssetIdentity" xml:space="preserve"><value>Серійний номер і мітки</value></data>
+  <data name="StepLotItem" xml:space="preserve"><value>Яка позиція</value></data>
+  <data name="StepLotDetails" xml:space="preserve"><value>Дані партії</value></data>
+  <data name="StepKitBasics" xml:space="preserve"><value>Назвіть комплект</value></data>
+  <data name="StepKitContents" xml:space="preserve"><value>Вміст комплекту</value></data>
+  <data name="M4StepOrderHeader" xml:space="preserve"><value>Дані замовлення</value></data>
+  <data name="M4StepOrderLines" xml:space="preserve"><value>Рядки замовлення</value></data>
+  <data name="M5StepCountBasics" xml:space="preserve"><value>Назвіть інвентаризацію</value></data>
+  <data name="M5StepCountScope" xml:space="preserve"><value>Обсяг</value></data>
+  <data name="M5StepReportKind" xml:space="preserve"><value>Оберіть звіт</value></data>
+  <data name="M5StepReportFilters" xml:space="preserve"><value>Звузьте вибірку</value></data>
+  <data name="HelpFieldAmount" xml:space="preserve"><value>Скільки одиниць, в одиниці виміру позиції.</value></data>
+  <data name="HelpFieldAsset" xml:space="preserve"><value>Для серіалізованих позицій оберіть конкретний примірник.</value></data>
+  <data name="HelpFieldCategory" xml:space="preserve"><value>Необов'язкове групування для списків і звітів.</value></data>
+  <data name="HelpFieldCode" xml:space="preserve"><value>Ваш власний номенклатурний номер, якщо він є.</value></data>
+  <data name="HelpFieldCountLocation" xml:space="preserve"><value>Залиште порожнім, щоб рахувати все.</value></data>
+  <data name="HelpFieldCurrency" xml:space="preserve"><value>Трилітерний код валюти, наприклад USD або EUR.</value></data>
+  <data name="HelpFieldDefaultLocation" xml:space="preserve"><value>Новий запас потрапляє сюди, якщо розташування не обрано.</value></data>
+  <data name="HelpFieldExpectedReturn" xml:space="preserve"><value>Прострочені повернення позначаються на екрані сповіщень.</value></data>
+  <data name="HelpFieldExpiration" xml:space="preserve"><value>Дата, після якої запас стає непридатним.</value></data>
+  <data name="HelpFieldFromLocation" xml:space="preserve"><value>Звідки вибуває запас. Залиште порожнім при надходженні нового.</value></data>
+  <data name="HelpFieldHolder" xml:space="preserve"><value>Оберіть особу або техніку, не обидва.</value></data>
+  <data name="HelpFieldIsActive" xml:space="preserve"><value>Неактивні позиції залишаються в історії, але їх не можна обрати для нових рухів.</value></data>
+  <data name="HelpFieldIsControlledSubstance" xml:space="preserve"><value>Рухи потребують свідка та зберігаються для аудиту.</value></data>
+  <data name="HelpFieldIsKit" xml:space="preserve"><value>Позначте як контейнер комплекту, а не окрему складську позицію.</value></data>
+  <data name="HelpFieldLocationType" xml:space="preserve"><value>Частина, техніка, особа, контейнер або підрозташування іншого місця.</value></data>
+  <data name="HelpFieldLot" xml:space="preserve"><value>Оберіть партію походження, якщо позиція обліковується партіями.</value></data>
+  <data name="HelpFieldMinimum" xml:space="preserve"><value>Створювати сповіщення, коли залишок падає нижче цього значення.</value></data>
+  <data name="HelpFieldNote" xml:space="preserve"><value>Чому це сталося. Примітки показуються в журналі та звітах.</value></data>
+  <data name="HelpFieldParent" xml:space="preserve"><value>Необов'язково. Вкладіть цей запис в інший.</value></data>
+  <data name="HelpFieldReorderPoint" xml:space="preserve"><value>Пропонувати дозамовлення, коли залишок досягне цього значення.</value></data>
+  <data name="HelpFieldReportRange" xml:space="preserve"><value>Звіти-зрізи ігнорують діапазон дат.</value></data>
+  <data name="HelpFieldRequiresExpiration" xml:space="preserve"><value>Вимагати термін придатності, щоб позиція потрапляла до сповіщень.</value></data>
+  <data name="HelpFieldRequiresLotTracking" xml:space="preserve"><value>Вимагати номер партії під час кожного оприбуткування.</value></data>
+  <data name="HelpFieldReturnCondition" xml:space="preserve"><value>Стан, у якому спорядження повернулося.</value></data>
+  <data name="HelpFieldSerialNumber" xml:space="preserve"><value>Серійний номер виробника. Має бути унікальним для цієї позиції.</value></data>
+  <data name="HelpFieldToLocation" xml:space="preserve"><value>Куди йде запас. Залиште порожнім при списанні чи використанні.</value></data>
+  <data name="HelpFieldTrackingMode" xml:space="preserve"><value>Насипний облік рахує кількість. Серіалізований відстежує кожну одиницю окремо з власним номером та історією.</value></data>
+  <data name="HelpFieldUnitCost" xml:space="preserve"><value>Вартість однієї одиниці, використовується для оцінки.</value></data>
+  <data name="HelpFieldUnitOfMeasure" xml:space="preserve"><value>Як ви рахуєте: штука, коробка, літр, метр.</value></data>
+  <data name="M4AccountNumberHelp" xml:space="preserve"><value>Номер рахунку, за яким вас знає цей постачальник.</value></data>
+  <data name="M4CompanyContactHelp" xml:space="preserve"><value>Оберіть контакт компанії, до якого належить цей постачальник.</value></data>
+  <data name="M4NewVendorHint" xml:space="preserve"><value>Постачальник — це контакт компанії, у якої ви купуєте. Спершу додайте контакт, якщо його немає.</value></data>
+  <data name="M4PurchaseOrderNumberHelp" xml:space="preserve"><value>Ваш номер цього замовлення. Він з'явиться в журналі під час оприбуткування.</value></data>
+  <data name="M4StepOrderHeaderHint" xml:space="preserve"><value>У кого купуєте, за яким номером і в якій валюті.</value></data>
+  <data name="M4StepOrderLinesHint" xml:space="preserve"><value>Один рядок на позицію. Кількості та вартості тут — основа для оприбуткування.</value></data>
+  <data name="M5StepCountBasicsHint" xml:space="preserve"><value>Інвентаризація фіксує зріз запасу, щоб порівняти його з тим, що на полиці.</value></data>
+  <data name="M5StepCountScopeHint" xml:space="preserve"><value>Порахуйте одне розташування або залиште порожнім для всього підрозділу.</value></data>
+  <data name="M5StepReportKindHint" xml:space="preserve"><value>Звіт визначає, які фільтри наступного кроку застосовуються.</value></data>
+  <data name="M5StepReportFiltersHint" xml:space="preserve"><value>Залиште фільтр порожнім, щоб включити все. Недоступні фільтри неактивні.</value></data>
+  <data name="StepAssetItemHint" xml:space="preserve"><value>Актив — це фізична одиниця позиції. Вкажіть позицію та де вона буде.</value></data>
+  <data name="StepAssetIdentityHint" xml:space="preserve"><value>Як ідентифікується ця одиниця, коли її беруть або сканують.</value></data>
+  <data name="StepIssueWhatHint" xml:space="preserve"><value>Оберіть позицію та місце, звідки її беруть.</value></data>
+  <data name="StepIssueWhenHint" xml:space="preserve"><value>Коли очікуєте повернення і що варто зафіксувати про передачу.</value></data>
+  <data name="StepItemBasicsHint" xml:space="preserve"><value>Те, що люди побачать, шукаючи це у списку.</value></data>
+  <data name="StepItemTrackingHint" xml:space="preserve"><value>Ці відповіді визначають, що система запитає далі, і їх важко змінити за наявності запасу.</value></data>
+  <data name="StepItemStockHint" xml:space="preserve"><value>Необов'язкові пороги для сповіщень про низький запас та вартість для оцінки.</value></data>
+  <data name="StepKitBasicsHint" xml:space="preserve"><value>Комплекти видають цілком, тож дайте назву, зрозумілу вашим підрозділам.</value></data>
+  <data name="StepKitContentsHint" xml:space="preserve"><value>Перелічіть кожну позицію комплекту та її кількість.</value></data>
+  <data name="StepKitIssueHint" xml:space="preserve"><value>Підтвердьте, який саме примірник і з якої полиці береться кожна частина комплекту.</value></data>
+  <data name="StepLocationBasicsHint" xml:space="preserve"><value>Назва з'являється в кожному списку, що запитує про місце.</value></data>
+  <data name="StepLocationScopeHint" xml:space="preserve"><value>Заповніть лише поле, що відповідає обраному типу; решту залиште порожньою.</value></data>
+  <data name="StepLotDetailsHint" xml:space="preserve"><value>Номер партії, надрукований на упаковці, а також вартість і термін придатності.</value></data>
+  <data name="StepLotItemHint" xml:space="preserve"><value>Партія завжди належить одній позиції, тож оберіть її спершу.</value></data>
+  <data name="StepMovementWhatHint" xml:space="preserve"><value>Тип руху визначає, які з наведених нижче полів буде використано.</value></data>
+  <data name="StepMovementWhereHint" xml:space="preserve"><value>Надходження потребує лише призначення; списання чи використання — лише джерела.</value></data>
+  <data name="StepMovementAmountHint" xml:space="preserve"><value>Кількість і причина. Обидва потраплять до створеного запису журналу.</value></data>
+  <data name="StepReturnHint" xml:space="preserve"><value>Вкажіть, скільки повернулося, куди це потрапило та в якому стані.</value></data>
+  <data name="Inactive" xml:space="preserve"><value>Неактивний</value></data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Records/Records.ar.resx
+++ b/Core/Resgrid.Localization/Areas/User/Records/Records.ar.resx
@@ -1992,4 +1992,116 @@
   <data name="ReadinessUnits" xml:space="preserve"><value>لوحة جاهزية الوحدات</value></data>
   <data name="ReadinessUnknownCosts" xml:space="preserve"><value>بنود بدون سعر</value></data>
   <data name="ReadinessWorkOrders" xml:space="preserve"><value>أوامر العمل</value></data>
+  <data name="LegalHoldsHeader" xml:space="preserve"><value>حالات حفظ السجلات</value></data>
+  <data name="LegalHoldsIntro" xml:space="preserve"><value>استخدم حفظ السجلات للتقاضي أو التحقيق أو طلب السجلات. يحمي الحفظ أيضًا التحليل والأدلة، ورفع الإفصاح لا يرفعه.</value></data>
+  <data name="PlaceHold" xml:space="preserve"><value>فرض حفظ السجلات</value></data>
+  <data name="ReleaseHold" xml:space="preserve"><value>رفع الحفظ</value></data>
+  <data name="ReleaseHoldReason" xml:space="preserve"><value>الصلاحية وسبب رفع الحفظ</value></data>
+  <data name="NoHolds" xml:space="preserve"><value>لم يتم فرض أي حفظ للسجلات.</value></data>
+  <data name="HoldActive" xml:space="preserve"><value>الحفظ ساري</value></data>
+  <data name="HoldScope" xml:space="preserve"><value>النطاق</value></data>
+  <data name="HoldPeriod" xml:space="preserve"><value>الفترة المحفوظة</value></data>
+  <data name="HoldRecordId" xml:space="preserve"><value>معرّف سجل محدّد</value></data>
+  <data name="HoldRecordIdHelp" xml:space="preserve"><value>اتركه فارغًا لحفظ كل ما يطابق تعريفًا ونطاقًا زمنيًا بدلًا من ذلك.</value></data>
+  <data name="HoldDefinition" xml:space="preserve"><value>نطاق التعريف</value></data>
+  <data name="HoldNerisScope" xml:space="preserve"><value>حادث وتحليل NERIS</value></data>
+  <data name="HoldScopeHelp" xml:space="preserve"><value>لنطاق التعريف، اترك كلا التاريخين فارغين لحفظ جميع التواريخ. الأوقات بتوقيت UTC.</value></data>
+  <data name="HoldPeriodStart" xml:space="preserve"><value>بداية الفترة (UTC)</value></data>
+  <data name="HoldPeriodEnd" xml:space="preserve"><value>نهاية الفترة (UTC)</value></data>
+  <data name="HoldReason" xml:space="preserve"><value>أساس الحفظ</value></data>
+  <data name="HoldReasonLitigation" xml:space="preserve"><value>تقاضٍ</value></data>
+  <data name="HoldReasonInvestigation" xml:space="preserve"><value>تحقيق</value></data>
+  <data name="HoldReasonRecordsRequest" xml:space="preserve"><value>طلب سجلات عامة</value></data>
+  <data name="HoldReasonOther" xml:space="preserve"><value>أخرى</value></data>
+  <data name="HoldReference" xml:space="preserve"><value>الصلاحية أو مرجع القضية</value></data>
+  <data name="HoldNotes" xml:space="preserve"><value>تعليمات الحفظ وأساسه</value></data>
+  <data name="HoldAllMatching" xml:space="preserve"><value>كل السجلات المطابقة</value></data>
+  <data name="HoldAnyStart" xml:space="preserve"><value>أي بداية</value></data>
+  <data name="HoldAnyEnd" xml:space="preserve"><value>أي نهاية</value></data>
+  <data name="HoldPlacedBy" xml:space="preserve"><value>فُرض بواسطة</value></data>
+  <data name="HoldReleasedBy" xml:space="preserve"><value>رُفع بواسطة</value></data>
+  <data name="Reason" xml:space="preserve"><value>السبب</value></data>
+  <data name="NoRowsHelp" xml:space="preserve"><value>لا يوجد شيء هنا بعد. استخدم الأزرار أعلاه لإنشاء أول واحد.</value></data>
+  <data name="PreviousPage" xml:space="preserve"><value>الصفحة السابقة</value></data>
+  <data name="NextPage" xml:space="preserve"><value>الصفحة التالية</value></data>
+  <data name="ReturnToReport" xml:space="preserve"><value>العودة إلى التقرير</value></data>
+  <data name="EvidenceManifestIntro" xml:space="preserve"><value>يحفظ البيان الملتقط حقائق المصدر المختارة ومجموع التحقق الخاص بها. تصبح عمليات الالتقاط المسودة جزءًا من المراجعة الموقّعة، وتبقي التصحيحات الأدلة السابقة في السجل.</value></data>
+  <data name="EvidenceWithheld" xml:space="preserve"><value>أدلة مقيّدة محجوبة</value></data>
+  <data name="EvidenceCurrent" xml:space="preserve"><value>حالي</value></data>
+  <data name="EvidenceDraft" xml:space="preserve"><value>التقاط مسودة</value></data>
+  <data name="EvidenceSignedRevision" xml:space="preserve"><value>مراجعة موقّعة</value></data>
+  <data name="EvidenceSourceVersion" xml:space="preserve"><value>إصدار المصدر</value></data>
+  <data name="EvidenceDownloadManifest" xml:space="preserve"><value>تنزيل البيان المُتحقّق</value></data>
+  <data name="EvidenceLoadSource" xml:space="preserve"><value>تحميل المصدر</value></data>
+  <data name="EvidenceLoadMessages" xml:space="preserve"><value>تحميل الرسائل</value></data>
+  <data name="EvidenceChannel" xml:space="preserve"><value>قناة الحادث</value></data>
+  <data name="EvidenceChooseChannel" xml:space="preserve"><value>اختر قناة</value></data>
+  <data name="EvidenceRestricted" xml:space="preserve"><value>يتطلب وصولًا مقيّدًا</value></data>
+  <data name="EvidenceUnavailableNotice" xml:space="preserve"><value>لن تُسجَّل أي أدلة لمصدر غير متاح.</value></data>
+  <data name="EvidenceCoverageStart" xml:space="preserve"><value>بداية التغطية (UTC)</value></data>
+  <data name="EvidenceCoverageEnd" xml:space="preserve"><value>نهاية التغطية (UTC)</value></data>
+  <data name="EvidenceValidityTime" xml:space="preserve"><value>وقت الحادث لتحديد الصلاحية (UTC)</value></data>
+  <data name="EvidencePersonnel" xml:space="preserve"><value>الأفراد</value></data>
+  <data name="EvidenceMessages" xml:space="preserve"><value>الرسائل</value></data>
+  <data name="EvidenceNoChoices" xml:space="preserve"><value>لا توجد عناصر متاحة في هذه الصفحة.</value></data>
+  <data name="EvidenceEdited" xml:space="preserve"><value>مُعدّل</value></data>
+  <data name="EvidencePageWarning" xml:space="preserve"><value>ستُمسح التحديدات غير الملتقطة في هذه الصفحة.</value></data>
+  <data name="EvidenceTrackingHelp" xml:space="preserve"><value>اختر 20 مركبة كحد أقصى ونافذة لا تتجاوز 24 ساعة. تُؤخذ حتى 24 نقطة لكل مركبة؛ التقط النوافذ الأخرى بشكل منفصل.</value></data>
+  <data name="EvidenceCertificationHelp" xml:space="preserve"><value>اختر الأفراد الذين تخص حالة مؤهلاتهم هذا التقرير. تبقى أرقام الشهادات والملفات في قسم الشهادات.</value></data>
+  <data name="EvidenceRunCardHelp" xml:space="preserve"><value>يلتقط قرارات الإرسال التي سجّلتها بطاقات الاستجابة لبلاغ هذا التقرير. القرار غير المسجَّل لا يمكن استعادته لاحقًا.</value></data>
+  <data name="EvidenceInventoryHelp" xml:space="preserve"><value>يحدّث الأدلة لكل استهلاك مخزون مسجَّل. ولا يستهلك المخزون مرة أخرى.</value></data>
+  <data name="EvidenceChatHelp" xml:space="preserve"><value>اختر الرسائل المراد حفظها؛ وتُدرج ردود السلسلة. كل صفحة عملية التقاط منفصلة، فالتقط هذه الصفحة قبل الانتقال. تُعرض نصوص الرسائل كنص.</value></data>
+  <data name="SubmissionRecoveryHeader" xml:space="preserve"><value>سجل الإرسال والاسترداد</value></data>
+  <data name="SubmissionRecoveryIntro" xml:space="preserve"><value>كل محاولة تسليم واستجابة الوجهة لهذا الإيداع، مع أدوات تسوية المحاولة الفاشلة.</value></data>
+  <data name="SubmissionNoIdentifier" xml:space="preserve"><value>لم يُسجَّل معرّف</value></data>
+  <data name="SubmissionLatestIssue" xml:space="preserve"><value>آخر مشكلة</value></data>
+  <data name="SubmissionExchangeHeader" xml:space="preserve"><value>سجل التسليم والاستجابة</value></data>
+  <data name="SubmissionExchangeIntro" xml:space="preserve"><value>الأوقات بتوقيت UTC. تبقى الاستجابات السابقة متاحة بعد الرفض وإعادة المحاولة والتصحيح.</value></data>
+  <data name="SubmissionNoExchanges" xml:space="preserve"><value>لم يُسجَّل سجل تبادل لهذا الإيداع القديم.</value></data>
+  <data name="SubmissionOperation" xml:space="preserve"><value>العملية والمرحلة</value></data>
+  <data name="SubmissionResponse" xml:space="preserve"><value>استجابة الوجهة</value></data>
+  <data name="SubmissionLastResponseHeader" xml:space="preserve"><value>آخر استجابة وجهة مخزّنة</value></data>
+  <data name="SubmissionBindHeader" xml:space="preserve"><value>ربط إيداع لم يُرسل</value></data>
+  <data name="SubmissionBindIntro" xml:space="preserve"><value>راجع كيان NERIS والوجهة الحاليين للإدارة. يؤدي الربط إلى وضع هذا الإيداع في قائمة الإرسال.</value></data>
+  <data name="SubmissionBindAction" xml:space="preserve"><value>اربط وأدرج في القائمة</value></data>
+  <data name="SubmissionVerifyHeader" xml:space="preserve"><value>تحقّق من إيداع قائم لدى الوجهة</value></data>
+  <data name="SubmissionVerifyIntro" xml:space="preserve"><value>حدّد موقع الإيداع في الوجهة الأصلية. يُطابق معرّفه مع التقرير في القائمة قبل استئناف الاستطلاع.</value></data>
+  <data name="SubmissionVerifyAction" xml:space="preserve"><value>تأكيد الاستلام</value></data>
+  <data name="SubmissionAbsenceHeader" xml:space="preserve"><value>تسجيل غياب مُتحقّق منه للإيداع</value></data>
+  <data name="SubmissionAbsenceIntro" xml:space="preserve"><value>استخدمه فقط بعد تأكيد الوجهة أو فريق دعمها أن الإيداع لم يُنشأ قط؛ ونتيجة البحث الفارغة لا تكفي. يسجّل تحقّقك ويرفع حظر الاسترداد. ولا يرسل شيئًا ولا يجدول إعادة محاولة.</value></data>
+  <data name="SubmissionVerificationReference" xml:space="preserve"><value>مرجع التحقّق أو الدعم لدى الوجهة</value></data>
+  <data name="SubmissionAbsenceReason" xml:space="preserve"><value>ما الذي جرى التحقق منه ومن قام به</value></data>
+  <data name="SubmissionAbsenceConfirm" xml:space="preserve"><value>لقد تحققت من أن الوجهة الأصلية لم تنشئ هذا الإيداع.</value></data>
+  <data name="SubmissionAbsenceAction" xml:space="preserve"><value>سجّل التحقّق دون إرسال</value></data>
+  <data name="SubmissionStateQueued" xml:space="preserve"><value>في القائمة</value></data>
+  <data name="SubmissionStateInFlight" xml:space="preserve"><value>قيد الإرسال</value></data>
+  <data name="SubmissionStateAccepted" xml:space="preserve"><value>مقبول</value></data>
+  <data name="SubmissionStateRejected" xml:space="preserve"><value>مرفوض</value></data>
+  <data name="SubmissionStateFailed" xml:space="preserve"><value>فشل</value></data>
+  <data name="SubmissionStateSuperseded" xml:space="preserve"><value>استُبدل بمراجعة أحدث</value></data>
+  <data name="SubmissionStateAwaitingDestination" xml:space="preserve"><value>بانتظار مراجعة الوجهة</value></data>
+  <data name="NewRunCallHeader" xml:space="preserve"><value>إنشاء بلاغ لهذه المهمة</value></data>
+  <data name="NewRunCallIntro" xml:space="preserve"><value>سجّل حادثًا سابقًا واربطه بهذه المهمة. يُنشأ البلاغ مغلقًا ولا يستدعي أحدًا.</value></data>
+  <data name="NewRunCallName" xml:space="preserve"><value>اسم البلاغ</value></data>
+  <data name="NewRunCallOccurredOn" xml:space="preserve"><value>وقع في (التوقيت المحلي للإدارة)</value></data>
+  <data name="NewRunCallAddress" xml:space="preserve"><value>العنوان</value></data>
+  <data name="NewRunCallNature" xml:space="preserve"><value>طبيعة البلاغ</value></data>
+  <data name="NewRunCallAction" xml:space="preserve"><value>أنشئ البلاغ واربطه</value></data>
+  <data name="DiffRevisionRange" xml:space="preserve"><value>المراجعة {0} مقارنةً بالمراجعة {1}</value></data>
+  <data name="DiffPrint" xml:space="preserve"><value>اطبع المقارنة بصيغة PDF</value></data>
+  <data name="CustomFieldsHeader" xml:space="preserve"><value>الحقول المخصصة للإدارة</value></data>
+  <data name="NewRunCallSaveFirst" xml:space="preserve"><value>احفظ المسودة لإنشاء بلاغ سابق وربطه.</value></data>
+  <data name="ParticipantInclude" xml:space="preserve"><value>تضمين</value></data>
+  <data name="ParticipantChoose" xml:space="preserve"><value>اختر مشاركًا</value></data>
+  <data name="ParticipantLabel" xml:space="preserve"><value>مشارك</value></data>
+  <data name="ParticipantRoleLabel" xml:space="preserve"><value>دور المشارك</value></data>
+  <data name="ParticipantUnitLabel" xml:space="preserve"><value>المركبة المخصصة</value></data>
+  <data name="ParticipantNoUnit" xml:space="preserve"><value>لا توجد مركبة مخصصة</value></data>
+  <data name="ParticipantPreviousUnit" xml:space="preserve"><value>مركبة مخصصة سابقًا</value></data>
+  <data name="ParticipantAdd" xml:space="preserve"><value>إضافة مشارك</value></data>
+  <data name="ParticipantRoleFor" xml:space="preserve"><value>دور {0}</value></data>
+  <data name="FileClassification" xml:space="preserve"><value>تصنيف الملف</value></data>
+  <data name="FileClassificationHelp" xml:space="preserve"><value>ينطبق أيضًا على أسماء الملفات وأوصافها، لا على الملف وحده.</value></data>
+  <data name="ClassificationRestricted" xml:space="preserve"><value>مقيّد</value></data>
+  <data name="ClassificationUnrestricted" xml:space="preserve"><value>محتوى تشغيلي غير مقيّد</value></data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Records/Records.ar.resx
+++ b/Core/Resgrid.Localization/Areas/User/Records/Records.ar.resx
@@ -2104,4 +2104,9 @@
   <data name="FileClassificationHelp" xml:space="preserve"><value>ينطبق أيضًا على أسماء الملفات وأوصافها، لا على الملف وحده.</value></data>
   <data name="ClassificationRestricted" xml:space="preserve"><value>مقيّد</value></data>
   <data name="ClassificationUnrestricted" xml:space="preserve"><value>محتوى تشغيلي غير مقيّد</value></data>
+  <data name="ReportsMenu" xml:space="preserve"><value>التقارير</value></data>
+  <data name="ManageMenu" xml:space="preserve"><value>إدارة</value></data>
+  <data name="ExportListHeader" xml:space="preserve"><value>تصدير هذه القائمة</value></data>
+  <data name="MoreMenu" xml:space="preserve"><value>المزيد</value></data>
+  <data name="InventoryUsage" xml:space="preserve"><value>استخدام المخزون</value></data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Records/Records.de.resx
+++ b/Core/Resgrid.Localization/Areas/User/Records/Records.de.resx
@@ -1992,4 +1992,116 @@
   <data name="ReadinessUnits" xml:space="preserve"><value>Bereitschaftstafel der Einheiten</value></data>
   <data name="ReadinessUnknownCosts" xml:space="preserve"><value>Unbepreiste Positionen</value></data>
   <data name="ReadinessWorkOrders" xml:space="preserve"><value>Arbeitsaufträge</value></data>
+  <data name="LegalHoldsHeader" xml:space="preserve"><value>Aufbewahrungssperren für Akten</value></data>
+  <data name="LegalHoldsIntro" xml:space="preserve"><value>Nutzen Sie eine Aufbewahrungssperre für Rechtsstreit, Ermittlung oder Aktenanfrage. Eine Sperre schützt auch Analyse und Nachweise; die Freigabe einer Offenlegung hebt die Sperre nicht auf.</value></data>
+  <data name="PlaceHold" xml:space="preserve"><value>Aufbewahrungssperre setzen</value></data>
+  <data name="ReleaseHold" xml:space="preserve"><value>Sperre aufheben</value></data>
+  <data name="ReleaseHoldReason" xml:space="preserve"><value>Befugnis und Grund für die Aufhebung der Aufbewahrung</value></data>
+  <data name="NoHolds" xml:space="preserve"><value>Es wurden keine Aufbewahrungssperren gesetzt.</value></data>
+  <data name="HoldActive" xml:space="preserve"><value>Sperre aktiv</value></data>
+  <data name="HoldScope" xml:space="preserve"><value>Geltungsbereich</value></data>
+  <data name="HoldPeriod" xml:space="preserve"><value>Aufbewahrungszeitraum</value></data>
+  <data name="HoldRecordId" xml:space="preserve"><value>Bestimmte Aktenkennung</value></data>
+  <data name="HoldRecordIdHelp" xml:space="preserve"><value>Leer lassen, um stattdessen alles zu sperren, was Definition und Zeitraum entspricht.</value></data>
+  <data name="HoldDefinition" xml:space="preserve"><value>Definitionsbereich</value></data>
+  <data name="HoldNerisScope" xml:space="preserve"><value>NERIS-Einsatz und Analyse</value></data>
+  <data name="HoldScopeHelp" xml:space="preserve"><value>Bei einem Definitionsbereich beide Daten leer lassen, um alle Zeiträume aufzubewahren. Zeiten sind UTC.</value></data>
+  <data name="HoldPeriodStart" xml:space="preserve"><value>Beginn des Zeitraums (UTC)</value></data>
+  <data name="HoldPeriodEnd" xml:space="preserve"><value>Ende des Zeitraums (UTC)</value></data>
+  <data name="HoldReason" xml:space="preserve"><value>Grundlage der Sperre</value></data>
+  <data name="HoldReasonLitigation" xml:space="preserve"><value>Rechtsstreit</value></data>
+  <data name="HoldReasonInvestigation" xml:space="preserve"><value>Ermittlung</value></data>
+  <data name="HoldReasonRecordsRequest" xml:space="preserve"><value>Auskunftsersuchen</value></data>
+  <data name="HoldReasonOther" xml:space="preserve"><value>Sonstiges</value></data>
+  <data name="HoldReference" xml:space="preserve"><value>Befugnis- oder Aktenzeichen</value></data>
+  <data name="HoldNotes" xml:space="preserve"><value>Aufbewahrungsanweisungen und Grundlage</value></data>
+  <data name="HoldAllMatching" xml:space="preserve"><value>Alle passenden Akten</value></data>
+  <data name="HoldAnyStart" xml:space="preserve"><value>Beliebiger Beginn</value></data>
+  <data name="HoldAnyEnd" xml:space="preserve"><value>Beliebiges Ende</value></data>
+  <data name="HoldPlacedBy" xml:space="preserve"><value>Gesetzt von</value></data>
+  <data name="HoldReleasedBy" xml:space="preserve"><value>Aufgehoben von</value></data>
+  <data name="Reason" xml:space="preserve"><value>Begründung</value></data>
+  <data name="NoRowsHelp" xml:space="preserve"><value>Hier ist noch nichts. Legen Sie über die Schaltflächen oben den ersten Eintrag an.</value></data>
+  <data name="PreviousPage" xml:space="preserve"><value>Vorherige Seite</value></data>
+  <data name="NextPage" xml:space="preserve"><value>Nächste Seite</value></data>
+  <data name="ReturnToReport" xml:space="preserve"><value>Zurück zum Bericht</value></data>
+  <data name="EvidenceManifestIntro" xml:space="preserve"><value>Ein erfasstes Manifest bewahrt die gewählten Quelldaten und ihre Prüfsumme. Entwurfserfassungen werden Teil der signierten Revision; Korrekturen belassen frühere Nachweise in der Historie.</value></data>
+  <data name="EvidenceWithheld" xml:space="preserve"><value>Eingeschränkte Nachweise zurückgehalten</value></data>
+  <data name="EvidenceCurrent" xml:space="preserve"><value>Aktuell</value></data>
+  <data name="EvidenceDraft" xml:space="preserve"><value>Entwurfserfassung</value></data>
+  <data name="EvidenceSignedRevision" xml:space="preserve"><value>Signierte Revision</value></data>
+  <data name="EvidenceSourceVersion" xml:space="preserve"><value>Quellversion</value></data>
+  <data name="EvidenceDownloadManifest" xml:space="preserve"><value>Geprüftes Manifest herunterladen</value></data>
+  <data name="EvidenceLoadSource" xml:space="preserve"><value>Quelle laden</value></data>
+  <data name="EvidenceLoadMessages" xml:space="preserve"><value>Nachrichten laden</value></data>
+  <data name="EvidenceChannel" xml:space="preserve"><value>Einsatzkanal</value></data>
+  <data name="EvidenceChooseChannel" xml:space="preserve"><value>Kanal auswählen</value></data>
+  <data name="EvidenceRestricted" xml:space="preserve"><value>eingeschränkter Zugriff erforderlich</value></data>
+  <data name="EvidenceUnavailableNotice" xml:space="preserve"><value>Für eine nicht verfügbare Quelle werden keine Nachweise erfasst.</value></data>
+  <data name="EvidenceCoverageStart" xml:space="preserve"><value>Beginn des Erfassungszeitraums (UTC)</value></data>
+  <data name="EvidenceCoverageEnd" xml:space="preserve"><value>Ende des Erfassungszeitraums (UTC)</value></data>
+  <data name="EvidenceValidityTime" xml:space="preserve"><value>Einsatzzeitpunkt für die Gültigkeit (UTC)</value></data>
+  <data name="EvidencePersonnel" xml:space="preserve"><value>Einsatzkräfte</value></data>
+  <data name="EvidenceMessages" xml:space="preserve"><value>Nachrichten</value></data>
+  <data name="EvidenceNoChoices" xml:space="preserve"><value>Auf dieser Seite sind keine zugänglichen Einträge vorhanden.</value></data>
+  <data name="EvidenceEdited" xml:space="preserve"><value>bearbeitet</value></data>
+  <data name="EvidencePageWarning" xml:space="preserve"><value>Nicht erfasste Auswahlen auf dieser Seite gehen verloren.</value></data>
+  <data name="EvidenceTrackingHelp" xml:space="preserve"><value>Wählen Sie höchstens 20 Fahrzeuge und ein Fenster von höchstens 24 Stunden. Je Fahrzeug werden bis zu 24 Positionen aus diesem Fenster erfasst; weitere Fenster separat erfassen.</value></data>
+  <data name="EvidenceCertificationHelp" xml:space="preserve"><value>Wählen Sie die Einsatzkräfte, deren Qualifikationsstatus in diesen Bericht gehört. Zertifikatsnummern und Dokumente verbleiben in den Qualifikationen.</value></data>
+  <data name="EvidenceRunCardHelp" xml:space="preserve"><value>Erfasst die von Run Cards für den Einsatz dieses Berichts protokollierten Dispositionsentscheidungen. Eine nie protokollierte Entscheidung lässt sich nicht nachträglich rekonstruieren.</value></data>
+  <data name="EvidenceInventoryHelp" xml:space="preserve"><value>Aktualisiert die Nachweise für jeden erfassten Materialverbrauch. Es wird kein Bestand erneut verbraucht.</value></data>
+  <data name="EvidenceChatHelp" xml:space="preserve"><value>Wählen Sie die zu bewahrenden Nachrichten; Thread-Antworten sind enthalten. Jede Seite ist eine eigene Erfassung, also diese Seite vor dem Weiterblättern erfassen. Nachrichtentexte werden als Text angezeigt.</value></data>
+  <data name="SubmissionRecoveryHeader" xml:space="preserve"><value>Übermittlungsverlauf und Wiederherstellung</value></data>
+  <data name="SubmissionRecoveryIntro" xml:space="preserve"><value>Alle Zustellversuche und Antworten des Ziels für diese Meldung sowie die Werkzeuge zur Bereinigung eines Fehlversuchs.</value></data>
+  <data name="SubmissionNoIdentifier" xml:space="preserve"><value>Keine Kennung erfasst</value></data>
+  <data name="SubmissionLatestIssue" xml:space="preserve"><value>Letztes Problem</value></data>
+  <data name="SubmissionExchangeHeader" xml:space="preserve"><value>Zustell- und Antwortverlauf</value></data>
+  <data name="SubmissionExchangeIntro" xml:space="preserve"><value>Zeiten in UTC. Frühere Antworten bleiben nach Ablehnung, Wiederholung und Korrektur verfügbar.</value></data>
+  <data name="SubmissionNoExchanges" xml:space="preserve"><value>Für diese Alt-Übermittlung wurde kein Austauschverlauf erfasst.</value></data>
+  <data name="SubmissionOperation" xml:space="preserve"><value>Vorgang und Phase</value></data>
+  <data name="SubmissionResponse" xml:space="preserve"><value>Antwort des Ziels</value></data>
+  <data name="SubmissionLastResponseHeader" xml:space="preserve"><value>Zuletzt gespeicherte Antwort des Ziels</value></data>
+  <data name="SubmissionBindHeader" xml:space="preserve"><value>Nicht gesendete Übermittlung zuordnen</value></data>
+  <data name="SubmissionBindIntro" xml:space="preserve"><value>Prüfen Sie die aktuelle NERIS-Einheit und das Ziel der Abteilung. Das Zuordnen stellt diese Übermittlung zur Zustellung ein.</value></data>
+  <data name="SubmissionBindAction" xml:space="preserve"><value>Zuordnen und einreihen</value></data>
+  <data name="SubmissionVerifyHeader" xml:space="preserve"><value>Bestehende Meldung beim Ziel prüfen</value></data>
+  <data name="SubmissionVerifyIntro" xml:space="preserve"><value>Suchen Sie die Meldung im ursprünglichen Ziel. Ihre Kennung wird vor Wiederaufnahme der Abfrage gegen den eingereihten Bericht geprüft.</value></data>
+  <data name="SubmissionVerifyAction" xml:space="preserve"><value>Eingang bestätigen</value></data>
+  <data name="SubmissionAbsenceHeader" xml:space="preserve"><value>Geprüftes Fehlen einer Meldung erfassen</value></data>
+  <data name="SubmissionAbsenceIntro" xml:space="preserve"><value>Nur verwenden, wenn das Ziel oder dessen Support bestätigt, dass die Meldung nie erstellt wurde; ein leeres Suchergebnis genügt nicht. Es erfasst Ihre Prüfung und hebt die Sperre auf. Es sendet nichts und plant keine Wiederholung.</value></data>
+  <data name="SubmissionVerificationReference" xml:space="preserve"><value>Prüf- oder Supportreferenz des Ziels</value></data>
+  <data name="SubmissionAbsenceReason" xml:space="preserve"><value>Was wurde geprüft und von wem</value></data>
+  <data name="SubmissionAbsenceConfirm" xml:space="preserve"><value>Ich habe geprüft, dass das ursprüngliche Ziel diese Meldung nicht erstellt hat.</value></data>
+  <data name="SubmissionAbsenceAction" xml:space="preserve"><value>Prüfung erfassen, ohne zu senden</value></data>
+  <data name="SubmissionStateQueued" xml:space="preserve"><value>In Warteschlange</value></data>
+  <data name="SubmissionStateInFlight" xml:space="preserve"><value>Wird übertragen</value></data>
+  <data name="SubmissionStateAccepted" xml:space="preserve"><value>Angenommen</value></data>
+  <data name="SubmissionStateRejected" xml:space="preserve"><value>Abgelehnt</value></data>
+  <data name="SubmissionStateFailed" xml:space="preserve"><value>Fehlgeschlagen</value></data>
+  <data name="SubmissionStateSuperseded" xml:space="preserve"><value>Durch neuere Revision ersetzt</value></data>
+  <data name="SubmissionStateAwaitingDestination" xml:space="preserve"><value>Wartet auf Prüfung durch das Ziel</value></data>
+  <data name="NewRunCallHeader" xml:space="preserve"><value>Einsatz für diesen Lauf anlegen</value></data>
+  <data name="NewRunCallIntro" xml:space="preserve"><value>Erfassen Sie einen vergangenen Einsatz und verknüpfen Sie ihn mit diesem Lauf. Der Einsatz wird geschlossen angelegt und alarmiert niemanden.</value></data>
+  <data name="NewRunCallName" xml:space="preserve"><value>Einsatzbezeichnung</value></data>
+  <data name="NewRunCallOccurredOn" xml:space="preserve"><value>Zeitpunkt (Ortszeit der Abteilung)</value></data>
+  <data name="NewRunCallAddress" xml:space="preserve"><value>Adresse</value></data>
+  <data name="NewRunCallNature" xml:space="preserve"><value>Art des Einsatzes</value></data>
+  <data name="NewRunCallAction" xml:space="preserve"><value>Einsatz anlegen und verknüpfen</value></data>
+  <data name="DiffRevisionRange" xml:space="preserve"><value>Revision {0} im Vergleich zu Revision {1}</value></data>
+  <data name="DiffPrint" xml:space="preserve"><value>Vergleich als PDF drucken</value></data>
+  <data name="CustomFieldsHeader" xml:space="preserve"><value>Benutzerdefinierte Felder der Abteilung</value></data>
+  <data name="NewRunCallSaveFirst" xml:space="preserve"><value>Speichern Sie den Entwurf, um einen historischen Einsatz anzulegen und zu verknüpfen.</value></data>
+  <data name="ParticipantInclude" xml:space="preserve"><value>Einbeziehen</value></data>
+  <data name="ParticipantChoose" xml:space="preserve"><value>Beteiligten auswählen</value></data>
+  <data name="ParticipantLabel" xml:space="preserve"><value>Beteiligter</value></data>
+  <data name="ParticipantRoleLabel" xml:space="preserve"><value>Rolle des Beteiligten</value></data>
+  <data name="ParticipantUnitLabel" xml:space="preserve"><value>Zugewiesenes Fahrzeug</value></data>
+  <data name="ParticipantNoUnit" xml:space="preserve"><value>Kein zugewiesenes Fahrzeug</value></data>
+  <data name="ParticipantPreviousUnit" xml:space="preserve"><value>Zuvor zugewiesenes Fahrzeug</value></data>
+  <data name="ParticipantAdd" xml:space="preserve"><value>Beteiligten hinzufügen</value></data>
+  <data name="ParticipantRoleFor" xml:space="preserve"><value>Rolle für {0}</value></data>
+  <data name="FileClassification" xml:space="preserve"><value>Einstufung der Datei</value></data>
+  <data name="FileClassificationHelp" xml:space="preserve"><value>Gilt auch für Dateinamen und Beschreibungen, nicht nur für die Datei selbst.</value></data>
+  <data name="ClassificationRestricted" xml:space="preserve"><value>Eingeschränkt</value></data>
+  <data name="ClassificationUnrestricted" xml:space="preserve"><value>Uneingeschränkter Einsatzinhalt</value></data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Records/Records.de.resx
+++ b/Core/Resgrid.Localization/Areas/User/Records/Records.de.resx
@@ -2104,4 +2104,9 @@
   <data name="FileClassificationHelp" xml:space="preserve"><value>Gilt auch für Dateinamen und Beschreibungen, nicht nur für die Datei selbst.</value></data>
   <data name="ClassificationRestricted" xml:space="preserve"><value>Eingeschränkt</value></data>
   <data name="ClassificationUnrestricted" xml:space="preserve"><value>Uneingeschränkter Einsatzinhalt</value></data>
+  <data name="ReportsMenu" xml:space="preserve"><value>Berichte</value></data>
+  <data name="ManageMenu" xml:space="preserve"><value>Verwalten</value></data>
+  <data name="ExportListHeader" xml:space="preserve"><value>Diese Liste exportieren</value></data>
+  <data name="MoreMenu" xml:space="preserve"><value>Mehr</value></data>
+  <data name="InventoryUsage" xml:space="preserve"><value>Bestandsverbrauch</value></data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Records/Records.el.resx
+++ b/Core/Resgrid.Localization/Areas/User/Records/Records.el.resx
@@ -1992,4 +1992,116 @@
   <data name="ReadinessUnits" xml:space="preserve"><value>Πίνακας ετοιμότητας μονάδων</value></data>
   <data name="ReadinessUnknownCosts" xml:space="preserve"><value>Γραμμές χωρίς τιμή</value></data>
   <data name="ReadinessWorkOrders" xml:space="preserve"><value>Εντολές εργασίας</value></data>
+  <data name="LegalHoldsHeader" xml:space="preserve"><value>Δεσμεύσεις διατήρησης αρχείων</value></data>
+  <data name="LegalHoldsIntro" xml:space="preserve"><value>Χρησιμοποιήστε δέσμευση διατήρησης για δικαστική διαφορά, έρευνα ή αίτημα αρχείων. Προστατεύει και την ανάλυση και τα τεκμήρια· η αποδέσμευση γνωστοποίησης δεν την αίρει.</value></data>
+  <data name="PlaceHold" xml:space="preserve"><value>Επιβολή δέσμευσης διατήρησης</value></data>
+  <data name="ReleaseHold" xml:space="preserve"><value>Άρση δέσμευσης</value></data>
+  <data name="ReleaseHoldReason" xml:space="preserve"><value>Αρμοδιότητα και λόγος άρσης της διατήρησης</value></data>
+  <data name="NoHolds" xml:space="preserve"><value>Δεν έχουν επιβληθεί δεσμεύσεις διατήρησης.</value></data>
+  <data name="HoldActive" xml:space="preserve"><value>Δέσμευση σε ισχύ</value></data>
+  <data name="HoldScope" xml:space="preserve"><value>Εύρος</value></data>
+  <data name="HoldPeriod" xml:space="preserve"><value>Διατηρούμενη περίοδος</value></data>
+  <data name="HoldRecordId" xml:space="preserve"><value>Συγκεκριμένο αναγνωριστικό αρχείου</value></data>
+  <data name="HoldRecordIdHelp" xml:space="preserve"><value>Αφήστε κενό για να δεσμεύσετε ό,τι ταιριάζει σε ορισμό και εύρος ημερομηνιών.</value></data>
+  <data name="HoldDefinition" xml:space="preserve"><value>Εύρος ορισμού</value></data>
+  <data name="HoldNerisScope" xml:space="preserve"><value>Συμβάν και ανάλυση NERIS</value></data>
+  <data name="HoldScopeHelp" xml:space="preserve"><value>Για εύρος ορισμού, αφήστε και τις δύο ημερομηνίες κενές για να διατηρηθούν όλες. Ώρες σε UTC.</value></data>
+  <data name="HoldPeriodStart" xml:space="preserve"><value>Έναρξη περιόδου (UTC)</value></data>
+  <data name="HoldPeriodEnd" xml:space="preserve"><value>Λήξη περιόδου (UTC)</value></data>
+  <data name="HoldReason" xml:space="preserve"><value>Βάση της δέσμευσης</value></data>
+  <data name="HoldReasonLitigation" xml:space="preserve"><value>Δικαστική διαφορά</value></data>
+  <data name="HoldReasonInvestigation" xml:space="preserve"><value>Έρευνα</value></data>
+  <data name="HoldReasonRecordsRequest" xml:space="preserve"><value>Αίτημα δημόσιων αρχείων</value></data>
+  <data name="HoldReasonOther" xml:space="preserve"><value>Άλλο</value></data>
+  <data name="HoldReference" xml:space="preserve"><value>Αρμοδιότητα ή αριθμός υπόθεσης</value></data>
+  <data name="HoldNotes" xml:space="preserve"><value>Οδηγίες διατήρησης και βάση</value></data>
+  <data name="HoldAllMatching" xml:space="preserve"><value>Όλα τα σχετικά αρχεία</value></data>
+  <data name="HoldAnyStart" xml:space="preserve"><value>Οποιαδήποτε έναρξη</value></data>
+  <data name="HoldAnyEnd" xml:space="preserve"><value>Οποιαδήποτε λήξη</value></data>
+  <data name="HoldPlacedBy" xml:space="preserve"><value>Επιβλήθηκε από</value></data>
+  <data name="HoldReleasedBy" xml:space="preserve"><value>Άρθηκε από</value></data>
+  <data name="Reason" xml:space="preserve"><value>Αιτία</value></data>
+  <data name="NoRowsHelp" xml:space="preserve"><value>Δεν υπάρχει τίποτα ακόμη. Χρησιμοποιήστε τα κουμπιά παραπάνω για να δημιουργήσετε το πρώτο.</value></data>
+  <data name="PreviousPage" xml:space="preserve"><value>Προηγούμενη σελίδα</value></data>
+  <data name="NextPage" xml:space="preserve"><value>Επόμενη σελίδα</value></data>
+  <data name="ReturnToReport" xml:space="preserve"><value>Επιστροφή στην αναφορά</value></data>
+  <data name="EvidenceManifestIntro" xml:space="preserve"><value>Ένα καταγεγραμμένο μανιφέστο διατηρεί τα επιλεγμένα στοιχεία πηγής και το άθροισμα ελέγχου τους. Οι προσχέδιες καταγραφές εντάσσονται στην υπογεγραμμένη αναθεώρηση και οι διορθώσεις κρατούν τα προηγούμενα τεκμήρια στο ιστορικό.</value></data>
+  <data name="EvidenceWithheld" xml:space="preserve"><value>Παρακράτηση περιορισμένων τεκμηρίων</value></data>
+  <data name="EvidenceCurrent" xml:space="preserve"><value>Τρέχον</value></data>
+  <data name="EvidenceDraft" xml:space="preserve"><value>Προσχέδια καταγραφή</value></data>
+  <data name="EvidenceSignedRevision" xml:space="preserve"><value>Υπογεγραμμένη αναθεώρηση</value></data>
+  <data name="EvidenceSourceVersion" xml:space="preserve"><value>Έκδοση πηγής</value></data>
+  <data name="EvidenceDownloadManifest" xml:space="preserve"><value>Λήψη επαληθευμένου μανιφέστου</value></data>
+  <data name="EvidenceLoadSource" xml:space="preserve"><value>Φόρτωση πηγής</value></data>
+  <data name="EvidenceLoadMessages" xml:space="preserve"><value>Φόρτωση μηνυμάτων</value></data>
+  <data name="EvidenceChannel" xml:space="preserve"><value>Κανάλι συμβάντος</value></data>
+  <data name="EvidenceChooseChannel" xml:space="preserve"><value>Επιλέξτε κανάλι</value></data>
+  <data name="EvidenceRestricted" xml:space="preserve"><value>απαιτείται περιορισμένη πρόσβαση</value></data>
+  <data name="EvidenceUnavailableNotice" xml:space="preserve"><value>Δεν καταγράφονται τεκμήρια για μη διαθέσιμη πηγή.</value></data>
+  <data name="EvidenceCoverageStart" xml:space="preserve"><value>Έναρξη κάλυψης (UTC)</value></data>
+  <data name="EvidenceCoverageEnd" xml:space="preserve"><value>Λήξη κάλυψης (UTC)</value></data>
+  <data name="EvidenceValidityTime" xml:space="preserve"><value>Ώρα συμβάντος για την ισχύ (UTC)</value></data>
+  <data name="EvidencePersonnel" xml:space="preserve"><value>Προσωπικό</value></data>
+  <data name="EvidenceMessages" xml:space="preserve"><value>Μηνύματα</value></data>
+  <data name="EvidenceNoChoices" xml:space="preserve"><value>Δεν υπάρχουν προσβάσιμα στοιχεία σε αυτή τη σελίδα.</value></data>
+  <data name="EvidenceEdited" xml:space="preserve"><value>επεξεργασμένο</value></data>
+  <data name="EvidencePageWarning" xml:space="preserve"><value>Οι μη καταγεγραμμένες επιλογές αυτής της σελίδας θα καθαριστούν.</value></data>
+  <data name="EvidenceTrackingHelp" xml:space="preserve"><value>Επιλέξτε έως 20 οχήματα και παράθυρο έως 24 ωρών. Δειγματοληπτούνται έως 24 στίγματα ανά όχημα· καταγράψτε άλλα παράθυρα ξεχωριστά.</value></data>
+  <data name="EvidenceCertificationHelp" xml:space="preserve"><value>Επιλέξτε το προσωπικό του οποίου η κατάσταση προσόντων ανήκει σε αυτή την αναφορά. Οι αριθμοί πιστοποιητικών και τα αρχεία παραμένουν στις Πιστοποιήσεις.</value></data>
+  <data name="EvidenceRunCardHelp" xml:space="preserve"><value>Καταγράφει τις αποφάσεις διάθεσης που κατέγραψαν τα Run Cards για το συμβάν της αναφοράς. Μια απόφαση που δεν καταγράφηκε δεν ανακατασκευάζεται.</value></data>
+  <data name="EvidenceInventoryHelp" xml:space="preserve"><value>Ανανεώνει τα τεκμήρια για κάθε καταγεγραμμένη ανάλωση αποθέματος. Δεν αναλώνει ξανά απόθεμα.</value></data>
+  <data name="EvidenceChatHelp" xml:space="preserve"><value>Επιλέξτε τα μηνύματα προς διατήρηση· περιλαμβάνονται οι απαντήσεις νήματος. Κάθε σελίδα είναι ξεχωριστή καταγραφή, οπότε καταγράψτε αυτήν πριν προχωρήσετε. Τα κείμενα εμφανίζονται ως απλό κείμενο.</value></data>
+  <data name="SubmissionRecoveryHeader" xml:space="preserve"><value>Ιστορικό υποβολής και αποκατάσταση</value></data>
+  <data name="SubmissionRecoveryIntro" xml:space="preserve"><value>Κάθε προσπάθεια παράδοσης και απόκριση προορισμού για αυτή την υποβολή, με τα εργαλεία συμφωνίας μιας αποτυχημένης.</value></data>
+  <data name="SubmissionNoIdentifier" xml:space="preserve"><value>Δεν καταγράφηκε αναγνωριστικό</value></data>
+  <data name="SubmissionLatestIssue" xml:space="preserve"><value>Τελευταίο ζήτημα</value></data>
+  <data name="SubmissionExchangeHeader" xml:space="preserve"><value>Ιστορικό παράδοσης και απόκρισης</value></data>
+  <data name="SubmissionExchangeIntro" xml:space="preserve"><value>Ώρες σε UTC. Οι προηγούμενες αποκρίσεις παραμένουν διαθέσιμες μετά από απόρριψη, επανάληψη και διόρθωση.</value></data>
+  <data name="SubmissionNoExchanges" xml:space="preserve"><value>Δεν καταγράφηκε ιστορικό ανταλλαγής για αυτή την παλαιά υποβολή.</value></data>
+  <data name="SubmissionOperation" xml:space="preserve"><value>Λειτουργία και στάδιο</value></data>
+  <data name="SubmissionResponse" xml:space="preserve"><value>Απόκριση προορισμού</value></data>
+  <data name="SubmissionLastResponseHeader" xml:space="preserve"><value>Τελευταία αποθηκευμένη απόκριση προορισμού</value></data>
+  <data name="SubmissionBindHeader" xml:space="preserve"><value>Σύνδεση μη απεσταλμένης υποβολής</value></data>
+  <data name="SubmissionBindIntro" xml:space="preserve"><value>Ελέγξτε την τρέχουσα οντότητα NERIS και τον προορισμό της υπηρεσίας. Η σύνδεση θέτει την υποβολή σε ουρά παράδοσης.</value></data>
+  <data name="SubmissionBindAction" xml:space="preserve"><value>Σύνδεση και ουρά</value></data>
+  <data name="SubmissionVerifyHeader" xml:space="preserve"><value>Επαλήθευση υπάρχουσας υποβολής στον προορισμό</value></data>
+  <data name="SubmissionVerifyIntro" xml:space="preserve"><value>Εντοπίστε την υποβολή στον αρχικό προορισμό. Το αναγνωριστικό της ελέγχεται έναντι της αναφοράς σε ουρά πριν συνεχιστεί η άντληση.</value></data>
+  <data name="SubmissionVerifyAction" xml:space="preserve"><value>Επιβεβαίωση παραλαβής</value></data>
+  <data name="SubmissionAbsenceHeader" xml:space="preserve"><value>Καταγραφή επαληθευμένης απουσίας υποβολής</value></data>
+  <data name="SubmissionAbsenceIntro" xml:space="preserve"><value>Χρησιμοποιήστε το μόνο αφού ο προορισμός ή η υποστήριξή του επιβεβαιώσει ότι η υποβολή δεν δημιουργήθηκε ποτέ· ένα κενό αποτέλεσμα αναζήτησης δεν αρκεί. Καταγράφει την επαλήθευσή σας και αίρει το μπλοκάρισμα. Δεν στέλνει τίποτα ούτε προγραμματίζει επανάληψη.</value></data>
+  <data name="SubmissionVerificationReference" xml:space="preserve"><value>Αναφορά επαλήθευσης ή υποστήριξης προορισμού</value></data>
+  <data name="SubmissionAbsenceReason" xml:space="preserve"><value>Τι επαληθεύτηκε και από ποιον</value></data>
+  <data name="SubmissionAbsenceConfirm" xml:space="preserve"><value>Επαλήθευσα ότι ο αρχικός προορισμός δεν δημιούργησε αυτή την υποβολή.</value></data>
+  <data name="SubmissionAbsenceAction" xml:space="preserve"><value>Καταγραφή επαλήθευσης χωρίς αποστολή</value></data>
+  <data name="SubmissionStateQueued" xml:space="preserve"><value>Σε ουρά</value></data>
+  <data name="SubmissionStateInFlight" xml:space="preserve"><value>Σε μεταφορά</value></data>
+  <data name="SubmissionStateAccepted" xml:space="preserve"><value>Έγινε αποδεκτή</value></data>
+  <data name="SubmissionStateRejected" xml:space="preserve"><value>Απορρίφθηκε</value></data>
+  <data name="SubmissionStateFailed" xml:space="preserve"><value>Απέτυχε</value></data>
+  <data name="SubmissionStateSuperseded" xml:space="preserve"><value>Αντικαταστάθηκε από νεότερη αναθεώρηση</value></data>
+  <data name="SubmissionStateAwaitingDestination" xml:space="preserve"><value>Αναμονή ελέγχου από τον προορισμό</value></data>
+  <data name="NewRunCallHeader" xml:space="preserve"><value>Δημιουργία συμβάντος για αυτή την έξοδο</value></data>
+  <data name="NewRunCallIntro" xml:space="preserve"><value>Καταγράψτε ένα παρελθόν συμβάν και συνδέστε το με αυτή την έξοδο. Το συμβάν δημιουργείται κλειστό και δεν κινητοποιεί κανέναν.</value></data>
+  <data name="NewRunCallName" xml:space="preserve"><value>Όνομα συμβάντος</value></data>
+  <data name="NewRunCallOccurredOn" xml:space="preserve"><value>Συνέβη στις (τοπική ώρα υπηρεσίας)</value></data>
+  <data name="NewRunCallAddress" xml:space="preserve"><value>Διεύθυνση</value></data>
+  <data name="NewRunCallNature" xml:space="preserve"><value>Φύση του συμβάντος</value></data>
+  <data name="NewRunCallAction" xml:space="preserve"><value>Δημιουργία και σύνδεση συμβάντος</value></data>
+  <data name="DiffRevisionRange" xml:space="preserve"><value>Αναθεώρηση {0} σε σύγκριση με την αναθεώρηση {1}</value></data>
+  <data name="DiffPrint" xml:space="preserve"><value>Εκτύπωση σύγκρισης σε PDF</value></data>
+  <data name="CustomFieldsHeader" xml:space="preserve"><value>Προσαρμοσμένα πεδία υπηρεσίας</value></data>
+  <data name="NewRunCallSaveFirst" xml:space="preserve"><value>Αποθηκεύστε το προσχέδιο για να δημιουργήσετε και να συνδέσετε ένα παρελθόν συμβάν.</value></data>
+  <data name="ParticipantInclude" xml:space="preserve"><value>Συμπερίληψη</value></data>
+  <data name="ParticipantChoose" xml:space="preserve"><value>Επιλέξτε συμμετέχοντα</value></data>
+  <data name="ParticipantLabel" xml:space="preserve"><value>Συμμετέχων</value></data>
+  <data name="ParticipantRoleLabel" xml:space="preserve"><value>Ρόλος συμμετέχοντα</value></data>
+  <data name="ParticipantUnitLabel" xml:space="preserve"><value>Ανατεθειμένο όχημα</value></data>
+  <data name="ParticipantNoUnit" xml:space="preserve"><value>Κανένα ανατεθειμένο όχημα</value></data>
+  <data name="ParticipantPreviousUnit" xml:space="preserve"><value>Προηγουμένως ανατεθειμένο όχημα</value></data>
+  <data name="ParticipantAdd" xml:space="preserve"><value>Προσθήκη συμμετέχοντα</value></data>
+  <data name="ParticipantRoleFor" xml:space="preserve"><value>Ρόλος για {0}</value></data>
+  <data name="FileClassification" xml:space="preserve"><value>Διαβάθμιση αρχείου</value></data>
+  <data name="FileClassificationHelp" xml:space="preserve"><value>Ισχύει και για τα ονόματα και τις περιγραφές αρχείων, όχι μόνο για το αρχείο.</value></data>
+  <data name="ClassificationRestricted" xml:space="preserve"><value>Περιορισμένο</value></data>
+  <data name="ClassificationUnrestricted" xml:space="preserve"><value>Απεριόριστο επιχειρησιακό περιεχόμενο</value></data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Records/Records.el.resx
+++ b/Core/Resgrid.Localization/Areas/User/Records/Records.el.resx
@@ -2104,4 +2104,9 @@
   <data name="FileClassificationHelp" xml:space="preserve"><value>Ισχύει και για τα ονόματα και τις περιγραφές αρχείων, όχι μόνο για το αρχείο.</value></data>
   <data name="ClassificationRestricted" xml:space="preserve"><value>Περιορισμένο</value></data>
   <data name="ClassificationUnrestricted" xml:space="preserve"><value>Απεριόριστο επιχειρησιακό περιεχόμενο</value></data>
+  <data name="ReportsMenu" xml:space="preserve"><value>Αναφορές</value></data>
+  <data name="ManageMenu" xml:space="preserve"><value>Διαχείριση</value></data>
+  <data name="ExportListHeader" xml:space="preserve"><value>Εξαγωγή αυτής της λίστας</value></data>
+  <data name="MoreMenu" xml:space="preserve"><value>Περισσότερα</value></data>
+  <data name="InventoryUsage" xml:space="preserve"><value>Χρήση αποθεμάτων</value></data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Records/Records.en.resx
+++ b/Core/Resgrid.Localization/Areas/User/Records/Records.en.resx
@@ -2104,4 +2104,9 @@
   <data name="FileClassificationHelp" xml:space="preserve"><value>Applies to the file names and descriptions as well as the file itself.</value></data>
   <data name="ClassificationRestricted" xml:space="preserve"><value>Restricted</value></data>
   <data name="ClassificationUnrestricted" xml:space="preserve"><value>Unrestricted operational content</value></data>
+  <data name="ReportsMenu" xml:space="preserve"><value>Reports</value></data>
+  <data name="ManageMenu" xml:space="preserve"><value>Manage</value></data>
+  <data name="ExportListHeader" xml:space="preserve"><value>Export this list</value></data>
+  <data name="MoreMenu" xml:space="preserve"><value>More</value></data>
+  <data name="InventoryUsage" xml:space="preserve"><value>Inventory usage</value></data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Records/Records.en.resx
+++ b/Core/Resgrid.Localization/Areas/User/Records/Records.en.resx
@@ -1992,4 +1992,116 @@
   <data name="ReadinessUnits" xml:space="preserve"><value>Unit readiness board</value></data>
   <data name="ReadinessUnknownCosts" xml:space="preserve"><value>Unpriced lines</value></data>
   <data name="ReadinessWorkOrders" xml:space="preserve"><value>Work orders</value></data>
+  <data name="LegalHoldsHeader" xml:space="preserve"><value>Records preservation holds</value></data>
+  <data name="LegalHoldsIntro" xml:space="preserve"><value>Use a preservation hold for litigation, investigation or a records request. A hold on a record also protects its analysis and evidence, and releasing a disclosure does not release the hold.</value></data>
+  <data name="PlaceHold" xml:space="preserve"><value>Place preservation hold</value></data>
+  <data name="ReleaseHold" xml:space="preserve"><value>Release hold</value></data>
+  <data name="ReleaseHoldReason" xml:space="preserve"><value>Authority and reason for releasing preservation</value></data>
+  <data name="NoHolds" xml:space="preserve"><value>No preservation holds have been placed.</value></data>
+  <data name="HoldActive" xml:space="preserve"><value>Hold in force</value></data>
+  <data name="HoldScope" xml:space="preserve"><value>Scope</value></data>
+  <data name="HoldPeriod" xml:space="preserve"><value>Preserved period</value></data>
+  <data name="HoldRecordId" xml:space="preserve"><value>Specific record identifier</value></data>
+  <data name="HoldRecordIdHelp" xml:space="preserve"><value>Leave blank to hold everything matching a definition and date scope instead.</value></data>
+  <data name="HoldDefinition" xml:space="preserve"><value>Definition scope</value></data>
+  <data name="HoldNerisScope" xml:space="preserve"><value>NERIS incident and analysis</value></data>
+  <data name="HoldScopeHelp" xml:space="preserve"><value>For a definition scope, leave both dates blank to preserve every date. Times are UTC.</value></data>
+  <data name="HoldPeriodStart" xml:space="preserve"><value>Period start (UTC)</value></data>
+  <data name="HoldPeriodEnd" xml:space="preserve"><value>Period end (UTC)</value></data>
+  <data name="HoldReason" xml:space="preserve"><value>Basis for the hold</value></data>
+  <data name="HoldReasonLitigation" xml:space="preserve"><value>Litigation</value></data>
+  <data name="HoldReasonInvestigation" xml:space="preserve"><value>Investigation</value></data>
+  <data name="HoldReasonRecordsRequest" xml:space="preserve"><value>Public records request</value></data>
+  <data name="HoldReasonOther" xml:space="preserve"><value>Other</value></data>
+  <data name="HoldReference" xml:space="preserve"><value>Authority or case reference</value></data>
+  <data name="HoldNotes" xml:space="preserve"><value>Preservation instructions and basis</value></data>
+  <data name="HoldAllMatching" xml:space="preserve"><value>All matching records</value></data>
+  <data name="HoldAnyStart" xml:space="preserve"><value>Any start</value></data>
+  <data name="HoldAnyEnd" xml:space="preserve"><value>Any end</value></data>
+  <data name="HoldPlacedBy" xml:space="preserve"><value>Placed by</value></data>
+  <data name="HoldReleasedBy" xml:space="preserve"><value>Released by</value></data>
+  <data name="Reason" xml:space="preserve"><value>Reason</value></data>
+  <data name="NoRowsHelp" xml:space="preserve"><value>Nothing here yet. Use the buttons above to create the first one.</value></data>
+  <data name="PreviousPage" xml:space="preserve"><value>Previous page</value></data>
+  <data name="NextPage" xml:space="preserve"><value>Next page</value></data>
+  <data name="ReturnToReport" xml:space="preserve"><value>Return to report</value></data>
+  <data name="EvidenceManifestIntro" xml:space="preserve"><value>A captured manifest preserves the selected source facts and their checksum. Draft captures become part of the signed revision, and corrections keep the earlier evidence in the history.</value></data>
+  <data name="EvidenceWithheld" xml:space="preserve"><value>Restricted evidence withheld</value></data>
+  <data name="EvidenceCurrent" xml:space="preserve"><value>Current</value></data>
+  <data name="EvidenceDraft" xml:space="preserve"><value>Draft capture</value></data>
+  <data name="EvidenceSignedRevision" xml:space="preserve"><value>Signed revision</value></data>
+  <data name="EvidenceSourceVersion" xml:space="preserve"><value>Source version</value></data>
+  <data name="EvidenceDownloadManifest" xml:space="preserve"><value>Download verified manifest</value></data>
+  <data name="EvidenceLoadSource" xml:space="preserve"><value>Load source</value></data>
+  <data name="EvidenceLoadMessages" xml:space="preserve"><value>Load messages</value></data>
+  <data name="EvidenceChannel" xml:space="preserve"><value>Incident channel</value></data>
+  <data name="EvidenceChooseChannel" xml:space="preserve"><value>Choose a channel</value></data>
+  <data name="EvidenceRestricted" xml:space="preserve"><value>restricted access required</value></data>
+  <data name="EvidenceUnavailableNotice" xml:space="preserve"><value>No evidence will be recorded for an unavailable source.</value></data>
+  <data name="EvidenceCoverageStart" xml:space="preserve"><value>Coverage start (UTC)</value></data>
+  <data name="EvidenceCoverageEnd" xml:space="preserve"><value>Coverage end (UTC)</value></data>
+  <data name="EvidenceValidityTime" xml:space="preserve"><value>Incident time for validity (UTC)</value></data>
+  <data name="EvidencePersonnel" xml:space="preserve"><value>Personnel</value></data>
+  <data name="EvidenceMessages" xml:space="preserve"><value>Messages</value></data>
+  <data name="EvidenceNoChoices" xml:space="preserve"><value>No accessible items on this page.</value></data>
+  <data name="EvidenceEdited" xml:space="preserve"><value>edited</value></data>
+  <data name="EvidencePageWarning" xml:space="preserve"><value>Uncaptured selections on this page will be cleared.</value></data>
+  <data name="EvidenceTrackingHelp" xml:space="preserve"><value>Choose at most 20 units and a window of at most 24 hours. Up to 24 fixes per unit are sampled across that window; capture additional windows separately.</value></data>
+  <data name="EvidenceCertificationHelp" xml:space="preserve"><value>Choose the personnel whose qualification status belongs in this report. Certificate numbers and document files stay in Certifications.</value></data>
+  <data name="EvidenceRunCardHelp" xml:space="preserve"><value>Captures the dispatch decisions Run Cards recorded for this report's call. A decision that was never recorded cannot be reconstructed afterwards.</value></data>
+  <data name="EvidenceInventoryHelp" xml:space="preserve"><value>Refreshes the evidence for every recorded inventory consumption. It does not consume stock again.</value></data>
+  <data name="EvidenceChatHelp" xml:space="preserve"><value>Select the messages to preserve; thread replies are included. Each page is a separate capture, so capture this page before moving on. Message bodies are shown as text.</value></data>
+  <data name="SubmissionRecoveryHeader" xml:space="preserve"><value>Submission history and recovery</value></data>
+  <data name="SubmissionRecoveryIntro" xml:space="preserve"><value>Every delivery attempt and destination response for this filing, and the tools to reconcile one that went wrong.</value></data>
+  <data name="SubmissionNoIdentifier" xml:space="preserve"><value>No identifier recorded</value></data>
+  <data name="SubmissionLatestIssue" xml:space="preserve"><value>Latest issue</value></data>
+  <data name="SubmissionExchangeHeader" xml:space="preserve"><value>Delivery and response history</value></data>
+  <data name="SubmissionExchangeIntro" xml:space="preserve"><value>Times are UTC. Earlier responses stay available after a rejection, a retry and a correction.</value></data>
+  <data name="SubmissionNoExchanges" xml:space="preserve"><value>No exchange history was recorded for this legacy submission.</value></data>
+  <data name="SubmissionOperation" xml:space="preserve"><value>Operation and stage</value></data>
+  <data name="SubmissionResponse" xml:space="preserve"><value>Destination response</value></data>
+  <data name="SubmissionLastResponseHeader" xml:space="preserve"><value>Last stored destination response</value></data>
+  <data name="SubmissionBindHeader" xml:space="preserve"><value>Bind an unsent submission</value></data>
+  <data name="SubmissionBindIntro" xml:space="preserve"><value>Review the department's current NERIS entity and destination. Binding this unsent submission queues it for delivery.</value></data>
+  <data name="SubmissionBindAction" xml:space="preserve"><value>Bind and queue</value></data>
+  <data name="SubmissionVerifyHeader" xml:space="preserve"><value>Verify an existing destination filing</value></data>
+  <data name="SubmissionVerifyIntro" xml:space="preserve"><value>Locate the filing in the original destination. Its identifier is checked against the queued report before polling resumes.</value></data>
+  <data name="SubmissionVerifyAction" xml:space="preserve"><value>Verify receipt</value></data>
+  <data name="SubmissionAbsenceHeader" xml:space="preserve"><value>Record a verified absence of a filing</value></data>
+  <data name="SubmissionAbsenceIntro" xml:space="preserve"><value>Use this only after the destination or its support team confirms the filing was never created; an empty search result is not enough. It records your verification and clears the recovery block. It sends nothing and schedules no retry.</value></data>
+  <data name="SubmissionVerificationReference" xml:space="preserve"><value>Destination verification or support reference</value></data>
+  <data name="SubmissionAbsenceReason" xml:space="preserve"><value>What was verified, and by whom</value></data>
+  <data name="SubmissionAbsenceConfirm" xml:space="preserve"><value>I verified that the original destination did not create this filing.</value></data>
+  <data name="SubmissionAbsenceAction" xml:space="preserve"><value>Record verification without sending</value></data>
+  <data name="SubmissionStateQueued" xml:space="preserve"><value>Queued</value></data>
+  <data name="SubmissionStateInFlight" xml:space="preserve"><value>In flight</value></data>
+  <data name="SubmissionStateAccepted" xml:space="preserve"><value>Accepted</value></data>
+  <data name="SubmissionStateRejected" xml:space="preserve"><value>Rejected</value></data>
+  <data name="SubmissionStateFailed" xml:space="preserve"><value>Failed</value></data>
+  <data name="SubmissionStateSuperseded" xml:space="preserve"><value>Superseded by a newer revision</value></data>
+  <data name="SubmissionStateAwaitingDestination" xml:space="preserve"><value>Awaiting destination review</value></data>
+  <data name="NewRunCallHeader" xml:space="preserve"><value>Create a call for this run</value></data>
+  <data name="NewRunCallIntro" xml:space="preserve"><value>Record a past incident and link it to this run. The call is created closed and dispatches nobody.</value></data>
+  <data name="NewRunCallName" xml:space="preserve"><value>Call name</value></data>
+  <data name="NewRunCallOccurredOn" xml:space="preserve"><value>Occurred at (department local time)</value></data>
+  <data name="NewRunCallAddress" xml:space="preserve"><value>Address</value></data>
+  <data name="NewRunCallNature" xml:space="preserve"><value>Nature of the call</value></data>
+  <data name="NewRunCallAction" xml:space="preserve"><value>Create and link call</value></data>
+  <data name="DiffRevisionRange" xml:space="preserve"><value>Revision {0} compared with revision {1}</value></data>
+  <data name="DiffPrint" xml:space="preserve"><value>Print comparison as PDF</value></data>
+  <data name="CustomFieldsHeader" xml:space="preserve"><value>Department custom fields</value></data>
+  <data name="NewRunCallSaveFirst" xml:space="preserve"><value>Save the draft to create and link a historical call.</value></data>
+  <data name="ParticipantInclude" xml:space="preserve"><value>Include</value></data>
+  <data name="ParticipantChoose" xml:space="preserve"><value>Choose a participant</value></data>
+  <data name="ParticipantLabel" xml:space="preserve"><value>Participant</value></data>
+  <data name="ParticipantRoleLabel" xml:space="preserve"><value>Participant role</value></data>
+  <data name="ParticipantUnitLabel" xml:space="preserve"><value>Assigned unit</value></data>
+  <data name="ParticipantNoUnit" xml:space="preserve"><value>No assigned unit</value></data>
+  <data name="ParticipantPreviousUnit" xml:space="preserve"><value>Previously assigned unit</value></data>
+  <data name="ParticipantAdd" xml:space="preserve"><value>Add participant</value></data>
+  <data name="ParticipantRoleFor" xml:space="preserve"><value>Role for {0}</value></data>
+  <data name="FileClassification" xml:space="preserve"><value>File classification</value></data>
+  <data name="FileClassificationHelp" xml:space="preserve"><value>Applies to the file names and descriptions as well as the file itself.</value></data>
+  <data name="ClassificationRestricted" xml:space="preserve"><value>Restricted</value></data>
+  <data name="ClassificationUnrestricted" xml:space="preserve"><value>Unrestricted operational content</value></data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Records/Records.es.resx
+++ b/Core/Resgrid.Localization/Areas/User/Records/Records.es.resx
@@ -1992,4 +1992,116 @@
   <data name="ReadinessUnits" xml:space="preserve"><value>Tablero de preparación de unidades</value></data>
   <data name="ReadinessUnknownCosts" xml:space="preserve"><value>Líneas sin precio</value></data>
   <data name="ReadinessWorkOrders" xml:space="preserve"><value>Órdenes de trabajo</value></data>
+  <data name="LegalHoldsHeader" xml:space="preserve"><value>Retenciones de conservación de registros</value></data>
+  <data name="LegalHoldsIntro" xml:space="preserve"><value>Use una retención de conservación para litigios, investigaciones o solicitudes de registros. La retención también protege su análisis y evidencia; liberar una divulgación no la levanta.</value></data>
+  <data name="PlaceHold" xml:space="preserve"><value>Aplicar retención de conservación</value></data>
+  <data name="ReleaseHold" xml:space="preserve"><value>Liberar retención</value></data>
+  <data name="ReleaseHoldReason" xml:space="preserve"><value>Autoridad y motivo para liberar la conservación</value></data>
+  <data name="NoHolds" xml:space="preserve"><value>No se han aplicado retenciones de conservación.</value></data>
+  <data name="HoldActive" xml:space="preserve"><value>Retención vigente</value></data>
+  <data name="HoldScope" xml:space="preserve"><value>Alcance</value></data>
+  <data name="HoldPeriod" xml:space="preserve"><value>Periodo conservado</value></data>
+  <data name="HoldRecordId" xml:space="preserve"><value>Identificador de registro concreto</value></data>
+  <data name="HoldRecordIdHelp" xml:space="preserve"><value>Déjelo en blanco para retener todo lo que coincida con una definición y un rango de fechas.</value></data>
+  <data name="HoldDefinition" xml:space="preserve"><value>Alcance por definición</value></data>
+  <data name="HoldNerisScope" xml:space="preserve"><value>Incidente y análisis NERIS</value></data>
+  <data name="HoldScopeHelp" xml:space="preserve"><value>Para un alcance por definición, deje ambas fechas vacías para conservar todas. Las horas son UTC.</value></data>
+  <data name="HoldPeriodStart" xml:space="preserve"><value>Inicio del periodo (UTC)</value></data>
+  <data name="HoldPeriodEnd" xml:space="preserve"><value>Fin del periodo (UTC)</value></data>
+  <data name="HoldReason" xml:space="preserve"><value>Base de la retención</value></data>
+  <data name="HoldReasonLitigation" xml:space="preserve"><value>Litigio</value></data>
+  <data name="HoldReasonInvestigation" xml:space="preserve"><value>Investigación</value></data>
+  <data name="HoldReasonRecordsRequest" xml:space="preserve"><value>Solicitud de registros públicos</value></data>
+  <data name="HoldReasonOther" xml:space="preserve"><value>Otro</value></data>
+  <data name="HoldReference" xml:space="preserve"><value>Autoridad o referencia del caso</value></data>
+  <data name="HoldNotes" xml:space="preserve"><value>Instrucciones de conservación y fundamento</value></data>
+  <data name="HoldAllMatching" xml:space="preserve"><value>Todos los registros coincidentes</value></data>
+  <data name="HoldAnyStart" xml:space="preserve"><value>Cualquier inicio</value></data>
+  <data name="HoldAnyEnd" xml:space="preserve"><value>Cualquier fin</value></data>
+  <data name="HoldPlacedBy" xml:space="preserve"><value>Aplicada por</value></data>
+  <data name="HoldReleasedBy" xml:space="preserve"><value>Liberada por</value></data>
+  <data name="Reason" xml:space="preserve"><value>Motivo</value></data>
+  <data name="NoRowsHelp" xml:space="preserve"><value>Aquí todavía no hay nada. Use los botones de arriba para crear el primero.</value></data>
+  <data name="PreviousPage" xml:space="preserve"><value>Página anterior</value></data>
+  <data name="NextPage" xml:space="preserve"><value>Página siguiente</value></data>
+  <data name="ReturnToReport" xml:space="preserve"><value>Volver al informe</value></data>
+  <data name="EvidenceManifestIntro" xml:space="preserve"><value>Un manifiesto capturado conserva los datos de origen seleccionados y su suma de comprobación. Las capturas en borrador pasan a la revisión firmada y las correcciones mantienen la evidencia anterior en el historial.</value></data>
+  <data name="EvidenceWithheld" xml:space="preserve"><value>Evidencia restringida retenida</value></data>
+  <data name="EvidenceCurrent" xml:space="preserve"><value>Vigente</value></data>
+  <data name="EvidenceDraft" xml:space="preserve"><value>Captura en borrador</value></data>
+  <data name="EvidenceSignedRevision" xml:space="preserve"><value>Revisión firmada</value></data>
+  <data name="EvidenceSourceVersion" xml:space="preserve"><value>Versión de origen</value></data>
+  <data name="EvidenceDownloadManifest" xml:space="preserve"><value>Descargar manifiesto verificado</value></data>
+  <data name="EvidenceLoadSource" xml:space="preserve"><value>Cargar origen</value></data>
+  <data name="EvidenceLoadMessages" xml:space="preserve"><value>Cargar mensajes</value></data>
+  <data name="EvidenceChannel" xml:space="preserve"><value>Canal del incidente</value></data>
+  <data name="EvidenceChooseChannel" xml:space="preserve"><value>Elija un canal</value></data>
+  <data name="EvidenceRestricted" xml:space="preserve"><value>requiere acceso restringido</value></data>
+  <data name="EvidenceUnavailableNotice" xml:space="preserve"><value>No se registrará evidencia para un origen no disponible.</value></data>
+  <data name="EvidenceCoverageStart" xml:space="preserve"><value>Inicio de la cobertura (UTC)</value></data>
+  <data name="EvidenceCoverageEnd" xml:space="preserve"><value>Fin de la cobertura (UTC)</value></data>
+  <data name="EvidenceValidityTime" xml:space="preserve"><value>Hora del incidente para la validez (UTC)</value></data>
+  <data name="EvidencePersonnel" xml:space="preserve"><value>Personal</value></data>
+  <data name="EvidenceMessages" xml:space="preserve"><value>Mensajes</value></data>
+  <data name="EvidenceNoChoices" xml:space="preserve"><value>No hay elementos accesibles en esta página.</value></data>
+  <data name="EvidenceEdited" xml:space="preserve"><value>editado</value></data>
+  <data name="EvidencePageWarning" xml:space="preserve"><value>Las selecciones no capturadas de esta página se borrarán.</value></data>
+  <data name="EvidenceTrackingHelp" xml:space="preserve"><value>Elija como máximo 20 unidades y una ventana de 24 horas. Se muestrean hasta 24 posiciones por unidad; capture otras ventanas por separado.</value></data>
+  <data name="EvidenceCertificationHelp" xml:space="preserve"><value>Elija el personal cuyo estado de cualificación corresponde a este informe. Los números de certificado y los archivos quedan en Certificaciones.</value></data>
+  <data name="EvidenceRunCardHelp" xml:space="preserve"><value>Captura las decisiones de despacho que Run Cards registró para el aviso de este informe. Una decisión no registrada no puede reconstruirse después.</value></data>
+  <data name="EvidenceInventoryHelp" xml:space="preserve"><value>Actualiza la evidencia de cada consumo de inventario registrado. No vuelve a consumir existencias.</value></data>
+  <data name="EvidenceChatHelp" xml:space="preserve"><value>Seleccione los mensajes a conservar; se incluyen las respuestas del hilo. Cada página es una captura independiente, así que capture esta antes de avanzar. Los cuerpos se muestran como texto.</value></data>
+  <data name="SubmissionRecoveryHeader" xml:space="preserve"><value>Historial de envío y recuperación</value></data>
+  <data name="SubmissionRecoveryIntro" xml:space="preserve"><value>Todos los intentos de entrega y respuestas del destino de esta presentación, y las herramientas para reconciliar una fallida.</value></data>
+  <data name="SubmissionNoIdentifier" xml:space="preserve"><value>No se registró identificador</value></data>
+  <data name="SubmissionLatestIssue" xml:space="preserve"><value>Último problema</value></data>
+  <data name="SubmissionExchangeHeader" xml:space="preserve"><value>Historial de entrega y respuesta</value></data>
+  <data name="SubmissionExchangeIntro" xml:space="preserve"><value>Las horas son UTC. Las respuestas anteriores siguen disponibles tras un rechazo, un reintento y una corrección.</value></data>
+  <data name="SubmissionNoExchanges" xml:space="preserve"><value>No se registró historial de intercambio para este envío heredado.</value></data>
+  <data name="SubmissionOperation" xml:space="preserve"><value>Operación y fase</value></data>
+  <data name="SubmissionResponse" xml:space="preserve"><value>Respuesta del destino</value></data>
+  <data name="SubmissionLastResponseHeader" xml:space="preserve"><value>Última respuesta del destino almacenada</value></data>
+  <data name="SubmissionBindHeader" xml:space="preserve"><value>Vincular un envío no enviado</value></data>
+  <data name="SubmissionBindIntro" xml:space="preserve"><value>Revise la entidad NERIS y el destino actuales del departamento. Vincular este envío lo pone en cola para su entrega.</value></data>
+  <data name="SubmissionBindAction" xml:space="preserve"><value>Vincular y encolar</value></data>
+  <data name="SubmissionVerifyHeader" xml:space="preserve"><value>Verificar una presentación existente en el destino</value></data>
+  <data name="SubmissionVerifyIntro" xml:space="preserve"><value>Localice la presentación en el destino original. Su identificador se coteja con el informe en cola antes de reanudar el sondeo.</value></data>
+  <data name="SubmissionVerifyAction" xml:space="preserve"><value>Verificar recepción</value></data>
+  <data name="SubmissionAbsenceHeader" xml:space="preserve"><value>Registrar la ausencia verificada de una presentación</value></data>
+  <data name="SubmissionAbsenceIntro" xml:space="preserve"><value>Úselo solo después de que el destino o su soporte confirme que la presentación nunca se creó; un resultado de búsqueda vacío no basta. Registra su verificación y libera el bloqueo. No envía nada ni programa reintentos.</value></data>
+  <data name="SubmissionVerificationReference" xml:space="preserve"><value>Referencia de verificación o soporte del destino</value></data>
+  <data name="SubmissionAbsenceReason" xml:space="preserve"><value>Qué se verificó y quién lo hizo</value></data>
+  <data name="SubmissionAbsenceConfirm" xml:space="preserve"><value>He verificado que el destino original no creó esta presentación.</value></data>
+  <data name="SubmissionAbsenceAction" xml:space="preserve"><value>Registrar verificación sin enviar</value></data>
+  <data name="SubmissionStateQueued" xml:space="preserve"><value>En cola</value></data>
+  <data name="SubmissionStateInFlight" xml:space="preserve"><value>En tránsito</value></data>
+  <data name="SubmissionStateAccepted" xml:space="preserve"><value>Aceptado</value></data>
+  <data name="SubmissionStateRejected" xml:space="preserve"><value>Rechazado</value></data>
+  <data name="SubmissionStateFailed" xml:space="preserve"><value>Fallido</value></data>
+  <data name="SubmissionStateSuperseded" xml:space="preserve"><value>Sustituido por una revisión más reciente</value></data>
+  <data name="SubmissionStateAwaitingDestination" xml:space="preserve"><value>Esperando revisión del destino</value></data>
+  <data name="NewRunCallHeader" xml:space="preserve"><value>Crear un aviso para esta actuación</value></data>
+  <data name="NewRunCallIntro" xml:space="preserve"><value>Registre un incidente pasado y vincúlelo a esta actuación. El aviso se crea cerrado y no despacha a nadie.</value></data>
+  <data name="NewRunCallName" xml:space="preserve"><value>Nombre del aviso</value></data>
+  <data name="NewRunCallOccurredOn" xml:space="preserve"><value>Ocurrió el (hora local del departamento)</value></data>
+  <data name="NewRunCallAddress" xml:space="preserve"><value>Dirección</value></data>
+  <data name="NewRunCallNature" xml:space="preserve"><value>Naturaleza del aviso</value></data>
+  <data name="NewRunCallAction" xml:space="preserve"><value>Crear y vincular el aviso</value></data>
+  <data name="DiffRevisionRange" xml:space="preserve"><value>Revisión {0} comparada con la revisión {1}</value></data>
+  <data name="DiffPrint" xml:space="preserve"><value>Imprimir la comparación en PDF</value></data>
+  <data name="CustomFieldsHeader" xml:space="preserve"><value>Campos personalizados del departamento</value></data>
+  <data name="NewRunCallSaveFirst" xml:space="preserve"><value>Guarde el borrador para crear y vincular un aviso histórico.</value></data>
+  <data name="ParticipantInclude" xml:space="preserve"><value>Incluir</value></data>
+  <data name="ParticipantChoose" xml:space="preserve"><value>Elija un participante</value></data>
+  <data name="ParticipantLabel" xml:space="preserve"><value>Participante</value></data>
+  <data name="ParticipantRoleLabel" xml:space="preserve"><value>Función del participante</value></data>
+  <data name="ParticipantUnitLabel" xml:space="preserve"><value>Unidad asignada</value></data>
+  <data name="ParticipantNoUnit" xml:space="preserve"><value>Sin unidad asignada</value></data>
+  <data name="ParticipantPreviousUnit" xml:space="preserve"><value>Unidad asignada anteriormente</value></data>
+  <data name="ParticipantAdd" xml:space="preserve"><value>Añadir participante</value></data>
+  <data name="ParticipantRoleFor" xml:space="preserve"><value>Función de {0}</value></data>
+  <data name="FileClassification" xml:space="preserve"><value>Clasificación del archivo</value></data>
+  <data name="FileClassificationHelp" xml:space="preserve"><value>Se aplica también a los nombres y descripciones de los archivos, no solo al archivo.</value></data>
+  <data name="ClassificationRestricted" xml:space="preserve"><value>Restringido</value></data>
+  <data name="ClassificationUnrestricted" xml:space="preserve"><value>Contenido operativo sin restricción</value></data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Records/Records.es.resx
+++ b/Core/Resgrid.Localization/Areas/User/Records/Records.es.resx
@@ -2104,4 +2104,9 @@
   <data name="FileClassificationHelp" xml:space="preserve"><value>Se aplica también a los nombres y descripciones de los archivos, no solo al archivo.</value></data>
   <data name="ClassificationRestricted" xml:space="preserve"><value>Restringido</value></data>
   <data name="ClassificationUnrestricted" xml:space="preserve"><value>Contenido operativo sin restricción</value></data>
+  <data name="ReportsMenu" xml:space="preserve"><value>Informes</value></data>
+  <data name="ManageMenu" xml:space="preserve"><value>Administrar</value></data>
+  <data name="ExportListHeader" xml:space="preserve"><value>Exportar esta lista</value></data>
+  <data name="MoreMenu" xml:space="preserve"><value>Más</value></data>
+  <data name="InventoryUsage" xml:space="preserve"><value>Uso de inventario</value></data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Records/Records.fr.resx
+++ b/Core/Resgrid.Localization/Areas/User/Records/Records.fr.resx
@@ -2104,4 +2104,9 @@
   <data name="FileClassificationHelp" xml:space="preserve"><value>S'applique aussi aux noms et descriptions des fichiers, pas seulement au fichier.</value></data>
   <data name="ClassificationRestricted" xml:space="preserve"><value>Restreint</value></data>
   <data name="ClassificationUnrestricted" xml:space="preserve"><value>Contenu opérationnel non restreint</value></data>
+  <data name="ReportsMenu" xml:space="preserve"><value>Rapports</value></data>
+  <data name="ManageMenu" xml:space="preserve"><value>Gérer</value></data>
+  <data name="ExportListHeader" xml:space="preserve"><value>Exporter cette liste</value></data>
+  <data name="MoreMenu" xml:space="preserve"><value>Plus</value></data>
+  <data name="InventoryUsage" xml:space="preserve"><value>Utilisation du stock</value></data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Records/Records.fr.resx
+++ b/Core/Resgrid.Localization/Areas/User/Records/Records.fr.resx
@@ -1992,4 +1992,116 @@
   <data name="ReadinessUnits" xml:space="preserve"><value>Tableau de disponibilité des unités</value></data>
   <data name="ReadinessUnknownCosts" xml:space="preserve"><value>Lignes non chiffrées</value></data>
   <data name="ReadinessWorkOrders" xml:space="preserve"><value>Ordres de travail</value></data>
+  <data name="LegalHoldsHeader" xml:space="preserve"><value>Conservations légales des dossiers</value></data>
+  <data name="LegalHoldsIntro" xml:space="preserve"><value>Utilisez une conservation légale pour un litige, une enquête ou une demande de dossiers. Elle protège aussi l'analyse et les preuves ; lever une divulgation ne la lève pas.</value></data>
+  <data name="PlaceHold" xml:space="preserve"><value>Poser une conservation légale</value></data>
+  <data name="ReleaseHold" xml:space="preserve"><value>Lever la conservation</value></data>
+  <data name="ReleaseHoldReason" xml:space="preserve"><value>Autorité et motif de la levée de la conservation</value></data>
+  <data name="NoHolds" xml:space="preserve"><value>Aucune conservation légale n'a été posée.</value></data>
+  <data name="HoldActive" xml:space="preserve"><value>Conservation en vigueur</value></data>
+  <data name="HoldScope" xml:space="preserve"><value>Périmètre</value></data>
+  <data name="HoldPeriod" xml:space="preserve"><value>Période conservée</value></data>
+  <data name="HoldRecordId" xml:space="preserve"><value>Identifiant de dossier précis</value></data>
+  <data name="HoldRecordIdHelp" xml:space="preserve"><value>Laissez vide pour conserver tout ce qui correspond à une définition et une plage de dates.</value></data>
+  <data name="HoldDefinition" xml:space="preserve"><value>Portée par définition</value></data>
+  <data name="HoldNerisScope" xml:space="preserve"><value>Intervention et analyse NERIS</value></data>
+  <data name="HoldScopeHelp" xml:space="preserve"><value>Pour une portée par définition, laissez les deux dates vides pour tout conserver. Heures en UTC.</value></data>
+  <data name="HoldPeriodStart" xml:space="preserve"><value>Début de la période (UTC)</value></data>
+  <data name="HoldPeriodEnd" xml:space="preserve"><value>Fin de la période (UTC)</value></data>
+  <data name="HoldReason" xml:space="preserve"><value>Fondement de la conservation</value></data>
+  <data name="HoldReasonLitigation" xml:space="preserve"><value>Contentieux</value></data>
+  <data name="HoldReasonInvestigation" xml:space="preserve"><value>Enquête</value></data>
+  <data name="HoldReasonRecordsRequest" xml:space="preserve"><value>Demande de documents publics</value></data>
+  <data name="HoldReasonOther" xml:space="preserve"><value>Autre</value></data>
+  <data name="HoldReference" xml:space="preserve"><value>Autorité ou référence du dossier</value></data>
+  <data name="HoldNotes" xml:space="preserve"><value>Instructions de conservation et fondement</value></data>
+  <data name="HoldAllMatching" xml:space="preserve"><value>Tous les dossiers correspondants</value></data>
+  <data name="HoldAnyStart" xml:space="preserve"><value>Tout début</value></data>
+  <data name="HoldAnyEnd" xml:space="preserve"><value>Toute fin</value></data>
+  <data name="HoldPlacedBy" xml:space="preserve"><value>Posée par</value></data>
+  <data name="HoldReleasedBy" xml:space="preserve"><value>Levée par</value></data>
+  <data name="Reason" xml:space="preserve"><value>Motif</value></data>
+  <data name="NoRowsHelp" xml:space="preserve"><value>Rien pour l'instant. Utilisez les boutons ci-dessus pour créer le premier.</value></data>
+  <data name="PreviousPage" xml:space="preserve"><value>Page précédente</value></data>
+  <data name="NextPage" xml:space="preserve"><value>Page suivante</value></data>
+  <data name="ReturnToReport" xml:space="preserve"><value>Revenir au rapport</value></data>
+  <data name="EvidenceManifestIntro" xml:space="preserve"><value>Un manifeste capturé conserve les faits sources sélectionnés et leur somme de contrôle. Les captures en brouillon rejoignent la révision signée, et les corrections gardent les preuves antérieures dans l'historique.</value></data>
+  <data name="EvidenceWithheld" xml:space="preserve"><value>Preuves restreintes non affichées</value></data>
+  <data name="EvidenceCurrent" xml:space="preserve"><value>À jour</value></data>
+  <data name="EvidenceDraft" xml:space="preserve"><value>Capture en brouillon</value></data>
+  <data name="EvidenceSignedRevision" xml:space="preserve"><value>Révision signée</value></data>
+  <data name="EvidenceSourceVersion" xml:space="preserve"><value>Version source</value></data>
+  <data name="EvidenceDownloadManifest" xml:space="preserve"><value>Télécharger le manifeste vérifié</value></data>
+  <data name="EvidenceLoadSource" xml:space="preserve"><value>Charger la source</value></data>
+  <data name="EvidenceLoadMessages" xml:space="preserve"><value>Charger les messages</value></data>
+  <data name="EvidenceChannel" xml:space="preserve"><value>Canal de l'intervention</value></data>
+  <data name="EvidenceChooseChannel" xml:space="preserve"><value>Choisir un canal</value></data>
+  <data name="EvidenceRestricted" xml:space="preserve"><value>accès restreint requis</value></data>
+  <data name="EvidenceUnavailableNotice" xml:space="preserve"><value>Aucune preuve ne sera enregistrée pour une source indisponible.</value></data>
+  <data name="EvidenceCoverageStart" xml:space="preserve"><value>Début de la couverture (UTC)</value></data>
+  <data name="EvidenceCoverageEnd" xml:space="preserve"><value>Fin de la couverture (UTC)</value></data>
+  <data name="EvidenceValidityTime" xml:space="preserve"><value>Heure de l'intervention pour la validité (UTC)</value></data>
+  <data name="EvidencePersonnel" xml:space="preserve"><value>Personnels</value></data>
+  <data name="EvidenceMessages" xml:space="preserve"><value>Messages du canal</value></data>
+  <data name="EvidenceNoChoices" xml:space="preserve"><value>Aucun élément accessible sur cette page.</value></data>
+  <data name="EvidenceEdited" xml:space="preserve"><value>modifié</value></data>
+  <data name="EvidencePageWarning" xml:space="preserve"><value>Les sélections non capturées de cette page seront effacées.</value></data>
+  <data name="EvidenceTrackingHelp" xml:space="preserve"><value>Choisissez au plus 20 engins et une fenêtre de 24 heures maximum. Jusqu'à 24 positions par engin sont échantillonnées ; capturez les autres fenêtres séparément.</value></data>
+  <data name="EvidenceCertificationHelp" xml:space="preserve"><value>Choisissez les personnels dont le statut de qualification relève de ce rapport. Les numéros de certificat et les fichiers restent dans les Certifications.</value></data>
+  <data name="EvidenceRunCardHelp" xml:space="preserve"><value>Capture les décisions d'engagement enregistrées par les Run Cards pour l'intervention de ce rapport. Une décision jamais enregistrée ne peut être reconstituée.</value></data>
+  <data name="EvidenceInventoryHelp" xml:space="preserve"><value>Actualise les preuves de chaque consommation de stock enregistrée. Aucun stock n'est consommé à nouveau.</value></data>
+  <data name="EvidenceChatHelp" xml:space="preserve"><value>Sélectionnez les messages à conserver ; les réponses du fil sont incluses. Chaque page est une capture distincte : capturez celle-ci avant de continuer. Les corps sont affichés en texte.</value></data>
+  <data name="SubmissionRecoveryHeader" xml:space="preserve"><value>Historique d'envoi et rattrapage</value></data>
+  <data name="SubmissionRecoveryIntro" xml:space="preserve"><value>Chaque tentative d'envoi et réponse de la destination pour ce dépôt, avec les outils pour régulariser un échec.</value></data>
+  <data name="SubmissionNoIdentifier" xml:space="preserve"><value>Aucun identifiant enregistré</value></data>
+  <data name="SubmissionLatestIssue" xml:space="preserve"><value>Dernier incident</value></data>
+  <data name="SubmissionExchangeHeader" xml:space="preserve"><value>Historique d'envoi et de réponse</value></data>
+  <data name="SubmissionExchangeIntro" xml:space="preserve"><value>Heures en UTC. Les réponses antérieures restent disponibles après un rejet, une nouvelle tentative et une correction.</value></data>
+  <data name="SubmissionNoExchanges" xml:space="preserve"><value>Aucun historique d'échange n'a été enregistré pour cet envoi hérité.</value></data>
+  <data name="SubmissionOperation" xml:space="preserve"><value>Opération et étape</value></data>
+  <data name="SubmissionResponse" xml:space="preserve"><value>Réponse de la destination</value></data>
+  <data name="SubmissionLastResponseHeader" xml:space="preserve"><value>Dernière réponse de la destination enregistrée</value></data>
+  <data name="SubmissionBindHeader" xml:space="preserve"><value>Associer un envoi non transmis</value></data>
+  <data name="SubmissionBindIntro" xml:space="preserve"><value>Vérifiez l'entité NERIS et la destination actuelles du service. L'association met cet envoi en file d'attente.</value></data>
+  <data name="SubmissionBindAction" xml:space="preserve"><value>Associer et mettre en file</value></data>
+  <data name="SubmissionVerifyHeader" xml:space="preserve"><value>Vérifier un dépôt existant à la destination</value></data>
+  <data name="SubmissionVerifyIntro" xml:space="preserve"><value>Retrouvez le dépôt dans la destination d'origine. Son identifiant est vérifié face au rapport en file avant la reprise du suivi.</value></data>
+  <data name="SubmissionVerifyAction" xml:space="preserve"><value>Confirmer la réception</value></data>
+  <data name="SubmissionAbsenceHeader" xml:space="preserve"><value>Enregistrer l'absence vérifiée d'un dépôt</value></data>
+  <data name="SubmissionAbsenceIntro" xml:space="preserve"><value>À n'utiliser qu'après confirmation par la destination ou son support que le dépôt n'a jamais été créé ; un résultat de recherche vide ne suffit pas. Cela enregistre votre vérification et lève le blocage. Rien n'est envoyé, aucune reprise n'est planifiée.</value></data>
+  <data name="SubmissionVerificationReference" xml:space="preserve"><value>Référence de vérification ou de support de la destination</value></data>
+  <data name="SubmissionAbsenceReason" xml:space="preserve"><value>Ce qui a été vérifié, et par qui</value></data>
+  <data name="SubmissionAbsenceConfirm" xml:space="preserve"><value>J'ai vérifié que la destination d'origine n'a pas créé ce dépôt.</value></data>
+  <data name="SubmissionAbsenceAction" xml:space="preserve"><value>Enregistrer la vérification sans envoyer</value></data>
+  <data name="SubmissionStateQueued" xml:space="preserve"><value>En file d'attente</value></data>
+  <data name="SubmissionStateInFlight" xml:space="preserve"><value>En cours d'envoi</value></data>
+  <data name="SubmissionStateAccepted" xml:space="preserve"><value>Accepté</value></data>
+  <data name="SubmissionStateRejected" xml:space="preserve"><value>Rejeté</value></data>
+  <data name="SubmissionStateFailed" xml:space="preserve"><value>Échec</value></data>
+  <data name="SubmissionStateSuperseded" xml:space="preserve"><value>Remplacé par une révision plus récente</value></data>
+  <data name="SubmissionStateAwaitingDestination" xml:space="preserve"><value>En attente de l'examen par la destination</value></data>
+  <data name="NewRunCallHeader" xml:space="preserve"><value>Créer une intervention pour cette sortie</value></data>
+  <data name="NewRunCallIntro" xml:space="preserve"><value>Enregistrez une intervention passée et liez-la à cette sortie. L'intervention est créée close et n'engage personne.</value></data>
+  <data name="NewRunCallName" xml:space="preserve"><value>Intitulé de l'intervention</value></data>
+  <data name="NewRunCallOccurredOn" xml:space="preserve"><value>Survenue le (heure locale du service)</value></data>
+  <data name="NewRunCallAddress" xml:space="preserve"><value>Adresse</value></data>
+  <data name="NewRunCallNature" xml:space="preserve"><value>Nature de l'intervention</value></data>
+  <data name="NewRunCallAction" xml:space="preserve"><value>Créer et lier l'intervention</value></data>
+  <data name="DiffRevisionRange" xml:space="preserve"><value>Révision {0} comparée à la révision {1}</value></data>
+  <data name="DiffPrint" xml:space="preserve"><value>Imprimer la comparaison en PDF</value></data>
+  <data name="CustomFieldsHeader" xml:space="preserve"><value>Champs personnalisés du service</value></data>
+  <data name="NewRunCallSaveFirst" xml:space="preserve"><value>Enregistrez le brouillon pour créer et lier une intervention passée.</value></data>
+  <data name="ParticipantInclude" xml:space="preserve"><value>Inclure</value></data>
+  <data name="ParticipantChoose" xml:space="preserve"><value>Choisir un participant</value></data>
+  <data name="ParticipantLabel" xml:space="preserve"><value>Personne impliquée</value></data>
+  <data name="ParticipantRoleLabel" xml:space="preserve"><value>Rôle du participant</value></data>
+  <data name="ParticipantUnitLabel" xml:space="preserve"><value>Engin affecté</value></data>
+  <data name="ParticipantNoUnit" xml:space="preserve"><value>Aucun engin affecté</value></data>
+  <data name="ParticipantPreviousUnit" xml:space="preserve"><value>Engin précédemment affecté</value></data>
+  <data name="ParticipantAdd" xml:space="preserve"><value>Ajouter un participant</value></data>
+  <data name="ParticipantRoleFor" xml:space="preserve"><value>Rôle de {0}</value></data>
+  <data name="FileClassification" xml:space="preserve"><value>Classification du fichier</value></data>
+  <data name="FileClassificationHelp" xml:space="preserve"><value>S'applique aussi aux noms et descriptions des fichiers, pas seulement au fichier.</value></data>
+  <data name="ClassificationRestricted" xml:space="preserve"><value>Restreint</value></data>
+  <data name="ClassificationUnrestricted" xml:space="preserve"><value>Contenu opérationnel non restreint</value></data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Records/Records.it.resx
+++ b/Core/Resgrid.Localization/Areas/User/Records/Records.it.resx
@@ -2104,4 +2104,9 @@
   <data name="FileClassificationHelp" xml:space="preserve"><value>Si applica anche a nomi e descrizioni dei file, non solo al file.</value></data>
   <data name="ClassificationRestricted" xml:space="preserve"><value>Riservato</value></data>
   <data name="ClassificationUnrestricted" xml:space="preserve"><value>Contenuto operativo non riservato</value></data>
+  <data name="ReportsMenu" xml:space="preserve"><value>Rapporti</value></data>
+  <data name="ManageMenu" xml:space="preserve"><value>Gestisci</value></data>
+  <data name="ExportListHeader" xml:space="preserve"><value>Esporta questo elenco</value></data>
+  <data name="MoreMenu" xml:space="preserve"><value>Altro</value></data>
+  <data name="InventoryUsage" xml:space="preserve"><value>Utilizzo dell'inventario</value></data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Records/Records.it.resx
+++ b/Core/Resgrid.Localization/Areas/User/Records/Records.it.resx
@@ -1992,4 +1992,116 @@
   <data name="ReadinessUnits" xml:space="preserve"><value>Quadro di prontezza delle unità</value></data>
   <data name="ReadinessUnknownCosts" xml:space="preserve"><value>Righe senza prezzo</value></data>
   <data name="ReadinessWorkOrders" xml:space="preserve"><value>Ordini di lavoro</value></data>
+  <data name="LegalHoldsHeader" xml:space="preserve"><value>Blocchi di conservazione dei registri</value></data>
+  <data name="LegalHoldsIntro" xml:space="preserve"><value>Usa un blocco di conservazione per contenzioso, indagine o richiesta di atti. Il blocco protegge anche analisi e prove; rilasciare una divulgazione non lo rimuove.</value></data>
+  <data name="PlaceHold" xml:space="preserve"><value>Applica blocco di conservazione</value></data>
+  <data name="ReleaseHold" xml:space="preserve"><value>Rilascia il blocco</value></data>
+  <data name="ReleaseHoldReason" xml:space="preserve"><value>Autorità e motivo del rilascio della conservazione</value></data>
+  <data name="NoHolds" xml:space="preserve"><value>Non è stato applicato alcun blocco di conservazione.</value></data>
+  <data name="HoldActive" xml:space="preserve"><value>Blocco in vigore</value></data>
+  <data name="HoldScope" xml:space="preserve"><value>Ambito</value></data>
+  <data name="HoldPeriod" xml:space="preserve"><value>Periodo conservato</value></data>
+  <data name="HoldRecordId" xml:space="preserve"><value>Identificatore del registro specifico</value></data>
+  <data name="HoldRecordIdHelp" xml:space="preserve"><value>Lascia vuoto per bloccare tutto ciò che corrisponde a una definizione e a un intervallo di date.</value></data>
+  <data name="HoldDefinition" xml:space="preserve"><value>Ambito per definizione</value></data>
+  <data name="HoldNerisScope" xml:space="preserve"><value>Intervento e analisi NERIS</value></data>
+  <data name="HoldScopeHelp" xml:space="preserve"><value>Per un ambito per definizione, lascia vuote entrambe le date per conservare tutto. Orari in UTC.</value></data>
+  <data name="HoldPeriodStart" xml:space="preserve"><value>Inizio periodo (UTC)</value></data>
+  <data name="HoldPeriodEnd" xml:space="preserve"><value>Fine periodo (UTC)</value></data>
+  <data name="HoldReason" xml:space="preserve"><value>Base del blocco</value></data>
+  <data name="HoldReasonLitigation" xml:space="preserve"><value>Contenzioso</value></data>
+  <data name="HoldReasonInvestigation" xml:space="preserve"><value>Indagine</value></data>
+  <data name="HoldReasonRecordsRequest" xml:space="preserve"><value>Richiesta di accesso agli atti</value></data>
+  <data name="HoldReasonOther" xml:space="preserve"><value>Altro</value></data>
+  <data name="HoldReference" xml:space="preserve"><value>Autorità o riferimento del caso</value></data>
+  <data name="HoldNotes" xml:space="preserve"><value>Istruzioni di conservazione e motivazione</value></data>
+  <data name="HoldAllMatching" xml:space="preserve"><value>Tutti i registri corrispondenti</value></data>
+  <data name="HoldAnyStart" xml:space="preserve"><value>Qualsiasi inizio</value></data>
+  <data name="HoldAnyEnd" xml:space="preserve"><value>Qualsiasi fine</value></data>
+  <data name="HoldPlacedBy" xml:space="preserve"><value>Applicato da</value></data>
+  <data name="HoldReleasedBy" xml:space="preserve"><value>Rilasciato da</value></data>
+  <data name="Reason" xml:space="preserve"><value>Motivo</value></data>
+  <data name="NoRowsHelp" xml:space="preserve"><value>Non c'è ancora nulla. Usa i pulsanti sopra per creare il primo.</value></data>
+  <data name="PreviousPage" xml:space="preserve"><value>Pagina precedente</value></data>
+  <data name="NextPage" xml:space="preserve"><value>Pagina successiva</value></data>
+  <data name="ReturnToReport" xml:space="preserve"><value>Torna al report</value></data>
+  <data name="EvidenceManifestIntro" xml:space="preserve"><value>Un manifesto acquisito conserva i fatti di origine selezionati e il loro checksum. Le acquisizioni in bozza entrano nella revisione firmata e le correzioni mantengono le prove precedenti nello storico.</value></data>
+  <data name="EvidenceWithheld" xml:space="preserve"><value>Prove riservate non mostrate</value></data>
+  <data name="EvidenceCurrent" xml:space="preserve"><value>Corrente</value></data>
+  <data name="EvidenceDraft" xml:space="preserve"><value>Acquisizione in bozza</value></data>
+  <data name="EvidenceSignedRevision" xml:space="preserve"><value>Revisione firmata</value></data>
+  <data name="EvidenceSourceVersion" xml:space="preserve"><value>Versione di origine</value></data>
+  <data name="EvidenceDownloadManifest" xml:space="preserve"><value>Scarica il manifesto verificato</value></data>
+  <data name="EvidenceLoadSource" xml:space="preserve"><value>Carica origine</value></data>
+  <data name="EvidenceLoadMessages" xml:space="preserve"><value>Carica messaggi</value></data>
+  <data name="EvidenceChannel" xml:space="preserve"><value>Canale dell'intervento</value></data>
+  <data name="EvidenceChooseChannel" xml:space="preserve"><value>Scegli un canale</value></data>
+  <data name="EvidenceRestricted" xml:space="preserve"><value>richiede accesso riservato</value></data>
+  <data name="EvidenceUnavailableNotice" xml:space="preserve"><value>Non verrà registrata alcuna prova per un'origine non disponibile.</value></data>
+  <data name="EvidenceCoverageStart" xml:space="preserve"><value>Inizio della copertura (UTC)</value></data>
+  <data name="EvidenceCoverageEnd" xml:space="preserve"><value>Fine della copertura (UTC)</value></data>
+  <data name="EvidenceValidityTime" xml:space="preserve"><value>Orario dell'intervento per la validità (UTC)</value></data>
+  <data name="EvidencePersonnel" xml:space="preserve"><value>Personale</value></data>
+  <data name="EvidenceMessages" xml:space="preserve"><value>Messaggi</value></data>
+  <data name="EvidenceNoChoices" xml:space="preserve"><value>Nessun elemento accessibile in questa pagina.</value></data>
+  <data name="EvidenceEdited" xml:space="preserve"><value>modificato</value></data>
+  <data name="EvidencePageWarning" xml:space="preserve"><value>Le selezioni non acquisite in questa pagina verranno azzerate.</value></data>
+  <data name="EvidenceTrackingHelp" xml:space="preserve"><value>Scegli al massimo 20 mezzi e una finestra di 24 ore. Vengono campionate fino a 24 posizioni per mezzo; acquisisci separatamente le altre finestre.</value></data>
+  <data name="EvidenceCertificationHelp" xml:space="preserve"><value>Scegli il personale il cui stato di qualifica riguarda questo report. Numeri di certificato e file restano nelle Certificazioni.</value></data>
+  <data name="EvidenceRunCardHelp" xml:space="preserve"><value>Acquisisce le decisioni di invio registrate dalle Run Card per l'intervento di questo report. Una decisione mai registrata non è ricostruibile.</value></data>
+  <data name="EvidenceInventoryHelp" xml:space="preserve"><value>Aggiorna le prove per ogni consumo di magazzino registrato. Non consuma nuovamente le scorte.</value></data>
+  <data name="EvidenceChatHelp" xml:space="preserve"><value>Seleziona i messaggi da conservare; le risposte del thread sono incluse. Ogni pagina è un'acquisizione separata, quindi acquisisci questa prima di proseguire. I corpi sono mostrati come testo.</value></data>
+  <data name="SubmissionRecoveryHeader" xml:space="preserve"><value>Storico invii e recupero</value></data>
+  <data name="SubmissionRecoveryIntro" xml:space="preserve"><value>Ogni tentativo di consegna e risposta della destinazione per questo deposito, con gli strumenti per riconciliarne uno errato.</value></data>
+  <data name="SubmissionNoIdentifier" xml:space="preserve"><value>Nessun identificatore registrato</value></data>
+  <data name="SubmissionLatestIssue" xml:space="preserve"><value>Ultimo problema</value></data>
+  <data name="SubmissionExchangeHeader" xml:space="preserve"><value>Storico consegne e risposte</value></data>
+  <data name="SubmissionExchangeIntro" xml:space="preserve"><value>Orari in UTC. Le risposte precedenti restano disponibili dopo un rifiuto, un nuovo tentativo e una correzione.</value></data>
+  <data name="SubmissionNoExchanges" xml:space="preserve"><value>Per questo invio legacy non è stato registrato alcuno storico di scambio.</value></data>
+  <data name="SubmissionOperation" xml:space="preserve"><value>Operazione e fase</value></data>
+  <data name="SubmissionResponse" xml:space="preserve"><value>Risposta della destinazione</value></data>
+  <data name="SubmissionLastResponseHeader" xml:space="preserve"><value>Ultima risposta della destinazione salvata</value></data>
+  <data name="SubmissionBindHeader" xml:space="preserve"><value>Collega un invio non spedito</value></data>
+  <data name="SubmissionBindIntro" xml:space="preserve"><value>Verifica l'entità NERIS e la destinazione correnti del reparto. Il collegamento mette in coda l'invio.</value></data>
+  <data name="SubmissionBindAction" xml:space="preserve"><value>Collega e accoda</value></data>
+  <data name="SubmissionVerifyHeader" xml:space="preserve"><value>Verifica un deposito esistente alla destinazione</value></data>
+  <data name="SubmissionVerifyIntro" xml:space="preserve"><value>Individua il deposito nella destinazione originale. Il suo identificatore viene confrontato con il report in coda prima di riprendere il polling.</value></data>
+  <data name="SubmissionVerifyAction" xml:space="preserve"><value>Verifica ricezione</value></data>
+  <data name="SubmissionAbsenceHeader" xml:space="preserve"><value>Registra l'assenza verificata di un deposito</value></data>
+  <data name="SubmissionAbsenceIntro" xml:space="preserve"><value>Usalo solo dopo che la destinazione o il suo supporto conferma che il deposito non è mai stato creato; un risultato di ricerca vuoto non basta. Registra la verifica e sblocca il recupero. Non invia nulla e non pianifica ritentativi.</value></data>
+  <data name="SubmissionVerificationReference" xml:space="preserve"><value>Riferimento di verifica o supporto della destinazione</value></data>
+  <data name="SubmissionAbsenceReason" xml:space="preserve"><value>Cosa è stato verificato e da chi</value></data>
+  <data name="SubmissionAbsenceConfirm" xml:space="preserve"><value>Ho verificato che la destinazione originale non ha creato questo deposito.</value></data>
+  <data name="SubmissionAbsenceAction" xml:space="preserve"><value>Registra la verifica senza inviare</value></data>
+  <data name="SubmissionStateQueued" xml:space="preserve"><value>In coda</value></data>
+  <data name="SubmissionStateInFlight" xml:space="preserve"><value>In transito</value></data>
+  <data name="SubmissionStateAccepted" xml:space="preserve"><value>Accettato</value></data>
+  <data name="SubmissionStateRejected" xml:space="preserve"><value>Respinto</value></data>
+  <data name="SubmissionStateFailed" xml:space="preserve"><value>Non riuscito</value></data>
+  <data name="SubmissionStateSuperseded" xml:space="preserve"><value>Sostituito da una revisione più recente</value></data>
+  <data name="SubmissionStateAwaitingDestination" xml:space="preserve"><value>In attesa della revisione della destinazione</value></data>
+  <data name="NewRunCallHeader" xml:space="preserve"><value>Crea un intervento per questa uscita</value></data>
+  <data name="NewRunCallIntro" xml:space="preserve"><value>Registra un intervento passato e collegalo a questa uscita. L'intervento viene creato chiuso e non invia nessuno.</value></data>
+  <data name="NewRunCallName" xml:space="preserve"><value>Nome dell'intervento</value></data>
+  <data name="NewRunCallOccurredOn" xml:space="preserve"><value>Avvenuto il (ora locale del reparto)</value></data>
+  <data name="NewRunCallAddress" xml:space="preserve"><value>Indirizzo</value></data>
+  <data name="NewRunCallNature" xml:space="preserve"><value>Natura dell'intervento</value></data>
+  <data name="NewRunCallAction" xml:space="preserve"><value>Crea e collega l'intervento</value></data>
+  <data name="DiffRevisionRange" xml:space="preserve"><value>Revisione {0} confrontata con la revisione {1}</value></data>
+  <data name="DiffPrint" xml:space="preserve"><value>Stampa il confronto in PDF</value></data>
+  <data name="CustomFieldsHeader" xml:space="preserve"><value>Campi personalizzati del reparto</value></data>
+  <data name="NewRunCallSaveFirst" xml:space="preserve"><value>Salva la bozza per creare e collegare un intervento storico.</value></data>
+  <data name="ParticipantInclude" xml:space="preserve"><value>Includi</value></data>
+  <data name="ParticipantChoose" xml:space="preserve"><value>Scegli un partecipante</value></data>
+  <data name="ParticipantLabel" xml:space="preserve"><value>Partecipante</value></data>
+  <data name="ParticipantRoleLabel" xml:space="preserve"><value>Ruolo del partecipante</value></data>
+  <data name="ParticipantUnitLabel" xml:space="preserve"><value>Mezzo assegnato</value></data>
+  <data name="ParticipantNoUnit" xml:space="preserve"><value>Nessun mezzo assegnato</value></data>
+  <data name="ParticipantPreviousUnit" xml:space="preserve"><value>Mezzo assegnato in precedenza</value></data>
+  <data name="ParticipantAdd" xml:space="preserve"><value>Aggiungi partecipante</value></data>
+  <data name="ParticipantRoleFor" xml:space="preserve"><value>Ruolo di {0}</value></data>
+  <data name="FileClassification" xml:space="preserve"><value>Classificazione del file</value></data>
+  <data name="FileClassificationHelp" xml:space="preserve"><value>Si applica anche a nomi e descrizioni dei file, non solo al file.</value></data>
+  <data name="ClassificationRestricted" xml:space="preserve"><value>Riservato</value></data>
+  <data name="ClassificationUnrestricted" xml:space="preserve"><value>Contenuto operativo non riservato</value></data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Records/Records.pl.resx
+++ b/Core/Resgrid.Localization/Areas/User/Records/Records.pl.resx
@@ -1992,4 +1992,116 @@
   <data name="ReadinessUnits" xml:space="preserve"><value>Tablica gotowości jednostek</value></data>
   <data name="ReadinessUnknownCosts" xml:space="preserve"><value>Pozycje bez ceny</value></data>
   <data name="ReadinessWorkOrders" xml:space="preserve"><value>Zlecenia pracy</value></data>
+  <data name="LegalHoldsHeader" xml:space="preserve"><value>Blokady zachowania rejestrów</value></data>
+  <data name="LegalHoldsIntro" xml:space="preserve"><value>Użyj blokady zachowania przy sporze, dochodzeniu lub wniosku o dokumenty. Blokada chroni też analizę i dowody; zwolnienie ujawnienia jej nie znosi.</value></data>
+  <data name="PlaceHold" xml:space="preserve"><value>Nałóż blokadę zachowania</value></data>
+  <data name="ReleaseHold" xml:space="preserve"><value>Zwolnij blokadę</value></data>
+  <data name="ReleaseHoldReason" xml:space="preserve"><value>Podstawa i powód zwolnienia zachowania</value></data>
+  <data name="NoHolds" xml:space="preserve"><value>Nie nałożono żadnych blokad zachowania.</value></data>
+  <data name="HoldActive" xml:space="preserve"><value>Blokada obowiązuje</value></data>
+  <data name="HoldScope" xml:space="preserve"><value>Zakres</value></data>
+  <data name="HoldPeriod" xml:space="preserve"><value>Zachowany okres</value></data>
+  <data name="HoldRecordId" xml:space="preserve"><value>Identyfikator konkretnego wpisu</value></data>
+  <data name="HoldRecordIdHelp" xml:space="preserve"><value>Pozostaw puste, aby objąć wszystko pasujące do definicji i zakresu dat.</value></data>
+  <data name="HoldDefinition" xml:space="preserve"><value>Zakres definicji</value></data>
+  <data name="HoldNerisScope" xml:space="preserve"><value>Zdarzenie i analiza NERIS</value></data>
+  <data name="HoldScopeHelp" xml:space="preserve"><value>Dla zakresu definicji pozostaw obie daty puste, aby zachować wszystkie. Czas w UTC.</value></data>
+  <data name="HoldPeriodStart" xml:space="preserve"><value>Początek okresu (UTC)</value></data>
+  <data name="HoldPeriodEnd" xml:space="preserve"><value>Koniec okresu (UTC)</value></data>
+  <data name="HoldReason" xml:space="preserve"><value>Podstawa blokady</value></data>
+  <data name="HoldReasonLitigation" xml:space="preserve"><value>Spór sądowy</value></data>
+  <data name="HoldReasonInvestigation" xml:space="preserve"><value>Dochodzenie</value></data>
+  <data name="HoldReasonRecordsRequest" xml:space="preserve"><value>Wniosek o informację publiczną</value></data>
+  <data name="HoldReasonOther" xml:space="preserve"><value>Inne</value></data>
+  <data name="HoldReference" xml:space="preserve"><value>Podstawa lub sygnatura sprawy</value></data>
+  <data name="HoldNotes" xml:space="preserve"><value>Instrukcje zachowania i podstawa</value></data>
+  <data name="HoldAllMatching" xml:space="preserve"><value>Wszystkie pasujące wpisy</value></data>
+  <data name="HoldAnyStart" xml:space="preserve"><value>Dowolny początek</value></data>
+  <data name="HoldAnyEnd" xml:space="preserve"><value>Dowolny koniec</value></data>
+  <data name="HoldPlacedBy" xml:space="preserve"><value>Nałożona przez</value></data>
+  <data name="HoldReleasedBy" xml:space="preserve"><value>Zwolniona przez</value></data>
+  <data name="Reason" xml:space="preserve"><value>Powód</value></data>
+  <data name="NoRowsHelp" xml:space="preserve"><value>Jeszcze nic tu nie ma. Użyj przycisków powyżej, aby utworzyć pierwszy wpis.</value></data>
+  <data name="PreviousPage" xml:space="preserve"><value>Poprzednia strona</value></data>
+  <data name="NextPage" xml:space="preserve"><value>Następna strona</value></data>
+  <data name="ReturnToReport" xml:space="preserve"><value>Wróć do raportu</value></data>
+  <data name="EvidenceManifestIntro" xml:space="preserve"><value>Zapisany manifest zachowuje wybrane fakty źródłowe i ich sumę kontrolną. Przechwycenia robocze wchodzą do podpisanej wersji, a korekty pozostawiają wcześniejsze dowody w historii.</value></data>
+  <data name="EvidenceWithheld" xml:space="preserve"><value>Wstrzymano dowody o ograniczonym dostępie</value></data>
+  <data name="EvidenceCurrent" xml:space="preserve"><value>Aktualne</value></data>
+  <data name="EvidenceDraft" xml:space="preserve"><value>Przechwycenie robocze</value></data>
+  <data name="EvidenceSignedRevision" xml:space="preserve"><value>Podpisana wersja</value></data>
+  <data name="EvidenceSourceVersion" xml:space="preserve"><value>Wersja źródła</value></data>
+  <data name="EvidenceDownloadManifest" xml:space="preserve"><value>Pobierz zweryfikowany manifest</value></data>
+  <data name="EvidenceLoadSource" xml:space="preserve"><value>Wczytaj źródło</value></data>
+  <data name="EvidenceLoadMessages" xml:space="preserve"><value>Wczytaj wiadomości</value></data>
+  <data name="EvidenceChannel" xml:space="preserve"><value>Kanał zdarzenia</value></data>
+  <data name="EvidenceChooseChannel" xml:space="preserve"><value>Wybierz kanał</value></data>
+  <data name="EvidenceRestricted" xml:space="preserve"><value>wymaga dostępu ograniczonego</value></data>
+  <data name="EvidenceUnavailableNotice" xml:space="preserve"><value>Dla niedostępnego źródła nie zostaną zapisane żadne dowody.</value></data>
+  <data name="EvidenceCoverageStart" xml:space="preserve"><value>Początek zakresu (UTC)</value></data>
+  <data name="EvidenceCoverageEnd" xml:space="preserve"><value>Koniec zakresu (UTC)</value></data>
+  <data name="EvidenceValidityTime" xml:space="preserve"><value>Czas zdarzenia dla ważności (UTC)</value></data>
+  <data name="EvidencePersonnel" xml:space="preserve"><value>Personel</value></data>
+  <data name="EvidenceMessages" xml:space="preserve"><value>Wiadomości</value></data>
+  <data name="EvidenceNoChoices" xml:space="preserve"><value>Brak dostępnych elementów na tej stronie.</value></data>
+  <data name="EvidenceEdited" xml:space="preserve"><value>edytowano</value></data>
+  <data name="EvidencePageWarning" xml:space="preserve"><value>Nieprzechwycone zaznaczenia na tej stronie zostaną wyczyszczone.</value></data>
+  <data name="EvidenceTrackingHelp" xml:space="preserve"><value>Wybierz maksymalnie 20 pojazdów i okno do 24 godzin. Próbkowane są do 24 pozycji na pojazd; kolejne okna przechwyć osobno.</value></data>
+  <data name="EvidenceCertificationHelp" xml:space="preserve"><value>Wybierz personel, którego status kwalifikacji należy do tego raportu. Numery certyfikatów i pliki pozostają w Certyfikatach.</value></data>
+  <data name="EvidenceRunCardHelp" xml:space="preserve"><value>Przechwytuje decyzje dysponowania zapisane przez Run Cards dla zdarzenia z tego raportu. Decyzji nigdy niezapisanej nie da się odtworzyć.</value></data>
+  <data name="EvidenceInventoryHelp" xml:space="preserve"><value>Odświeża dowody dla każdego zapisanego zużycia zapasów. Nie zużywa stanu ponownie.</value></data>
+  <data name="EvidenceChatHelp" xml:space="preserve"><value>Wybierz wiadomości do zachowania; odpowiedzi w wątku są uwzględnione. Każda strona to osobne przechwycenie, więc przechwyć tę przed przejściem dalej. Treści pokazywane są jako tekst.</value></data>
+  <data name="SubmissionRecoveryHeader" xml:space="preserve"><value>Historia wysyłki i odzyskiwanie</value></data>
+  <data name="SubmissionRecoveryIntro" xml:space="preserve"><value>Każda próba dostarczenia i odpowiedź celu dla tego zgłoszenia oraz narzędzia do uzgodnienia nieudanej.</value></data>
+  <data name="SubmissionNoIdentifier" xml:space="preserve"><value>Nie zapisano identyfikatora</value></data>
+  <data name="SubmissionLatestIssue" xml:space="preserve"><value>Ostatni problem</value></data>
+  <data name="SubmissionExchangeHeader" xml:space="preserve"><value>Historia dostarczeń i odpowiedzi</value></data>
+  <data name="SubmissionExchangeIntro" xml:space="preserve"><value>Czas w UTC. Wcześniejsze odpowiedzi pozostają dostępne po odrzuceniu, ponowieniu i korekcie.</value></data>
+  <data name="SubmissionNoExchanges" xml:space="preserve"><value>Dla tej starszej wysyłki nie zapisano historii wymiany.</value></data>
+  <data name="SubmissionOperation" xml:space="preserve"><value>Operacja i etap</value></data>
+  <data name="SubmissionResponse" xml:space="preserve"><value>Odpowiedź celu</value></data>
+  <data name="SubmissionLastResponseHeader" xml:space="preserve"><value>Ostatnia zapisana odpowiedź celu</value></data>
+  <data name="SubmissionBindHeader" xml:space="preserve"><value>Powiąż niewysłaną wysyłkę</value></data>
+  <data name="SubmissionBindIntro" xml:space="preserve"><value>Sprawdź bieżącą jednostkę NERIS i cel jednostki. Powiązanie kolejkuje tę wysyłkę do dostarczenia.</value></data>
+  <data name="SubmissionBindAction" xml:space="preserve"><value>Powiąż i zakolejkuj</value></data>
+  <data name="SubmissionVerifyHeader" xml:space="preserve"><value>Zweryfikuj istniejące zgłoszenie u celu</value></data>
+  <data name="SubmissionVerifyIntro" xml:space="preserve"><value>Odszukaj zgłoszenie w pierwotnym celu. Jego identyfikator jest porównywany z raportem w kolejce przed wznowieniem odpytywania.</value></data>
+  <data name="SubmissionVerifyAction" xml:space="preserve"><value>Potwierdź odbiór</value></data>
+  <data name="SubmissionAbsenceHeader" xml:space="preserve"><value>Zapisz zweryfikowany brak zgłoszenia</value></data>
+  <data name="SubmissionAbsenceIntro" xml:space="preserve"><value>Użyj dopiero po potwierdzeniu przez cel lub jego wsparcie, że zgłoszenie nigdy nie powstało; pusty wynik wyszukiwania nie wystarczy. Zapisuje weryfikację i zdejmuje blokadę. Nic nie wysyła ani nie planuje ponowień.</value></data>
+  <data name="SubmissionVerificationReference" xml:space="preserve"><value>Numer weryfikacji lub zgłoszenia wsparcia celu</value></data>
+  <data name="SubmissionAbsenceReason" xml:space="preserve"><value>Co zweryfikowano i przez kogo</value></data>
+  <data name="SubmissionAbsenceConfirm" xml:space="preserve"><value>Zweryfikowałem, że pierwotny cel nie utworzył tego zgłoszenia.</value></data>
+  <data name="SubmissionAbsenceAction" xml:space="preserve"><value>Zapisz weryfikację bez wysyłania</value></data>
+  <data name="SubmissionStateQueued" xml:space="preserve"><value>W kolejce</value></data>
+  <data name="SubmissionStateInFlight" xml:space="preserve"><value>W trakcie wysyłki</value></data>
+  <data name="SubmissionStateAccepted" xml:space="preserve"><value>Zaakceptowano</value></data>
+  <data name="SubmissionStateRejected" xml:space="preserve"><value>Odrzucono</value></data>
+  <data name="SubmissionStateFailed" xml:space="preserve"><value>Niepowodzenie</value></data>
+  <data name="SubmissionStateSuperseded" xml:space="preserve"><value>Zastąpiono nowszą wersją</value></data>
+  <data name="SubmissionStateAwaitingDestination" xml:space="preserve"><value>Oczekuje na przegląd celu</value></data>
+  <data name="NewRunCallHeader" xml:space="preserve"><value>Utwórz zdarzenie dla tego wyjazdu</value></data>
+  <data name="NewRunCallIntro" xml:space="preserve"><value>Zapisz minione zdarzenie i powiąż je z tym wyjazdem. Zdarzenie powstaje jako zamknięte i nikogo nie dysponuje.</value></data>
+  <data name="NewRunCallName" xml:space="preserve"><value>Nazwa zdarzenia</value></data>
+  <data name="NewRunCallOccurredOn" xml:space="preserve"><value>Wystąpiło (czas lokalny jednostki)</value></data>
+  <data name="NewRunCallAddress" xml:space="preserve"><value>Adres</value></data>
+  <data name="NewRunCallNature" xml:space="preserve"><value>Charakter zdarzenia</value></data>
+  <data name="NewRunCallAction" xml:space="preserve"><value>Utwórz i powiąż zdarzenie</value></data>
+  <data name="DiffRevisionRange" xml:space="preserve"><value>Wersja {0} w porównaniu z wersją {1}</value></data>
+  <data name="DiffPrint" xml:space="preserve"><value>Wydrukuj porównanie do PDF</value></data>
+  <data name="CustomFieldsHeader" xml:space="preserve"><value>Pola własne jednostki</value></data>
+  <data name="NewRunCallSaveFirst" xml:space="preserve"><value>Zapisz wersję roboczą, aby utworzyć i powiązać zdarzenie historyczne.</value></data>
+  <data name="ParticipantInclude" xml:space="preserve"><value>Uwzględnij</value></data>
+  <data name="ParticipantChoose" xml:space="preserve"><value>Wybierz uczestnika</value></data>
+  <data name="ParticipantLabel" xml:space="preserve"><value>Uczestnik</value></data>
+  <data name="ParticipantRoleLabel" xml:space="preserve"><value>Rola uczestnika</value></data>
+  <data name="ParticipantUnitLabel" xml:space="preserve"><value>Przypisany pojazd</value></data>
+  <data name="ParticipantNoUnit" xml:space="preserve"><value>Brak przypisanego pojazdu</value></data>
+  <data name="ParticipantPreviousUnit" xml:space="preserve"><value>Wcześniej przypisany pojazd</value></data>
+  <data name="ParticipantAdd" xml:space="preserve"><value>Dodaj uczestnika</value></data>
+  <data name="ParticipantRoleFor" xml:space="preserve"><value>Rola dla {0}</value></data>
+  <data name="FileClassification" xml:space="preserve"><value>Klasyfikacja pliku</value></data>
+  <data name="FileClassificationHelp" xml:space="preserve"><value>Dotyczy także nazw i opisów plików, nie tylko samego pliku.</value></data>
+  <data name="ClassificationRestricted" xml:space="preserve"><value>Ograniczone</value></data>
+  <data name="ClassificationUnrestricted" xml:space="preserve"><value>Treść operacyjna bez ograniczeń</value></data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Records/Records.pl.resx
+++ b/Core/Resgrid.Localization/Areas/User/Records/Records.pl.resx
@@ -2104,4 +2104,9 @@
   <data name="FileClassificationHelp" xml:space="preserve"><value>Dotyczy także nazw i opisów plików, nie tylko samego pliku.</value></data>
   <data name="ClassificationRestricted" xml:space="preserve"><value>Ograniczone</value></data>
   <data name="ClassificationUnrestricted" xml:space="preserve"><value>Treść operacyjna bez ograniczeń</value></data>
+  <data name="ReportsMenu" xml:space="preserve"><value>Raporty</value></data>
+  <data name="ManageMenu" xml:space="preserve"><value>Zarządzaj</value></data>
+  <data name="ExportListHeader" xml:space="preserve"><value>Eksportuj tę listę</value></data>
+  <data name="MoreMenu" xml:space="preserve"><value>Więcej</value></data>
+  <data name="InventoryUsage" xml:space="preserve"><value>Zużycie zapasów</value></data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Records/Records.sv.resx
+++ b/Core/Resgrid.Localization/Areas/User/Records/Records.sv.resx
@@ -1992,4 +1992,116 @@
   <data name="ReadinessUnits" xml:space="preserve"><value>Beredskapstavla för enheter</value></data>
   <data name="ReadinessUnknownCosts" xml:space="preserve"><value>Oprissatta rader</value></data>
   <data name="ReadinessWorkOrders" xml:space="preserve"><value>Arbetsorder</value></data>
+  <data name="LegalHoldsHeader" xml:space="preserve"><value>Bevarandespärrar för journaler</value></data>
+  <data name="LegalHoldsIntro" xml:space="preserve"><value>Använd en bevarandespärr vid tvist, utredning eller begäran om handlingar. Spärren skyddar även analys och bevis; att släppa ett utlämnande upphäver den inte.</value></data>
+  <data name="PlaceHold" xml:space="preserve"><value>Lägg bevarandespärr</value></data>
+  <data name="ReleaseHold" xml:space="preserve"><value>Släpp spärren</value></data>
+  <data name="ReleaseHoldReason" xml:space="preserve"><value>Behörighet och skäl för att häva bevarandet</value></data>
+  <data name="NoHolds" xml:space="preserve"><value>Inga bevarandespärrar har lagts.</value></data>
+  <data name="HoldActive" xml:space="preserve"><value>Spärr gäller</value></data>
+  <data name="HoldScope" xml:space="preserve"><value>Omfattning</value></data>
+  <data name="HoldPeriod" xml:space="preserve"><value>Bevarad period</value></data>
+  <data name="HoldRecordId" xml:space="preserve"><value>Specifik journalidentifierare</value></data>
+  <data name="HoldRecordIdHelp" xml:space="preserve"><value>Lämna tomt för att i stället spärra allt som matchar en definition och ett datumintervall.</value></data>
+  <data name="HoldDefinition" xml:space="preserve"><value>Definitionsomfattning</value></data>
+  <data name="HoldNerisScope" xml:space="preserve"><value>NERIS-händelse och analys</value></data>
+  <data name="HoldScopeHelp" xml:space="preserve"><value>För en definitionsomfattning, lämna båda datumen tomma för att bevara alla. Tider i UTC.</value></data>
+  <data name="HoldPeriodStart" xml:space="preserve"><value>Periodens start (UTC)</value></data>
+  <data name="HoldPeriodEnd" xml:space="preserve"><value>Periodens slut (UTC)</value></data>
+  <data name="HoldReason" xml:space="preserve"><value>Grund för spärren</value></data>
+  <data name="HoldReasonLitigation" xml:space="preserve"><value>Rättstvist</value></data>
+  <data name="HoldReasonInvestigation" xml:space="preserve"><value>Utredning</value></data>
+  <data name="HoldReasonRecordsRequest" xml:space="preserve"><value>Begäran om allmän handling</value></data>
+  <data name="HoldReasonOther" xml:space="preserve"><value>Annat</value></data>
+  <data name="HoldReference" xml:space="preserve"><value>Behörighet eller ärendereferens</value></data>
+  <data name="HoldNotes" xml:space="preserve"><value>Bevarandeinstruktioner och grund</value></data>
+  <data name="HoldAllMatching" xml:space="preserve"><value>Alla matchande journaler</value></data>
+  <data name="HoldAnyStart" xml:space="preserve"><value>Valfri start</value></data>
+  <data name="HoldAnyEnd" xml:space="preserve"><value>Valfritt slut</value></data>
+  <data name="HoldPlacedBy" xml:space="preserve"><value>Lagd av</value></data>
+  <data name="HoldReleasedBy" xml:space="preserve"><value>Släppt av</value></data>
+  <data name="Reason" xml:space="preserve"><value>Skäl</value></data>
+  <data name="NoRowsHelp" xml:space="preserve"><value>Inget här ännu. Använd knapparna ovan för att skapa den första.</value></data>
+  <data name="PreviousPage" xml:space="preserve"><value>Föregående sida</value></data>
+  <data name="NextPage" xml:space="preserve"><value>Nästa sida</value></data>
+  <data name="ReturnToReport" xml:space="preserve"><value>Tillbaka till rapporten</value></data>
+  <data name="EvidenceManifestIntro" xml:space="preserve"><value>Ett sparat manifest bevarar de valda källuppgifterna och deras kontrollsumma. Utkastsinsamlingar blir del av den signerade revisionen, och rättelser behåller tidigare bevis i historiken.</value></data>
+  <data name="EvidenceWithheld" xml:space="preserve"><value>Begränsade bevis undanhålls</value></data>
+  <data name="EvidenceCurrent" xml:space="preserve"><value>Aktuell</value></data>
+  <data name="EvidenceDraft" xml:space="preserve"><value>Utkastsinsamling</value></data>
+  <data name="EvidenceSignedRevision" xml:space="preserve"><value>Signerad revision</value></data>
+  <data name="EvidenceSourceVersion" xml:space="preserve"><value>Källversion</value></data>
+  <data name="EvidenceDownloadManifest" xml:space="preserve"><value>Ladda ner verifierat manifest</value></data>
+  <data name="EvidenceLoadSource" xml:space="preserve"><value>Läs in källa</value></data>
+  <data name="EvidenceLoadMessages" xml:space="preserve"><value>Läs in meddelanden</value></data>
+  <data name="EvidenceChannel" xml:space="preserve"><value>Händelsekanal</value></data>
+  <data name="EvidenceChooseChannel" xml:space="preserve"><value>Välj en kanal</value></data>
+  <data name="EvidenceRestricted" xml:space="preserve"><value>kräver begränsad behörighet</value></data>
+  <data name="EvidenceUnavailableNotice" xml:space="preserve"><value>Inga bevis registreras för en otillgänglig källa.</value></data>
+  <data name="EvidenceCoverageStart" xml:space="preserve"><value>Täckningens start (UTC)</value></data>
+  <data name="EvidenceCoverageEnd" xml:space="preserve"><value>Täckningens slut (UTC)</value></data>
+  <data name="EvidenceValidityTime" xml:space="preserve"><value>Händelsetid för giltighet (UTC)</value></data>
+  <data name="EvidencePersonnel" xml:space="preserve"><value>Personal</value></data>
+  <data name="EvidenceMessages" xml:space="preserve"><value>Meddelanden</value></data>
+  <data name="EvidenceNoChoices" xml:space="preserve"><value>Inga åtkomliga poster på den här sidan.</value></data>
+  <data name="EvidenceEdited" xml:space="preserve"><value>redigerad</value></data>
+  <data name="EvidencePageWarning" xml:space="preserve"><value>Ej insamlade val på den här sidan rensas.</value></data>
+  <data name="EvidenceTrackingHelp" xml:space="preserve"><value>Välj högst 20 fordon och ett fönster på högst 24 timmar. Upp till 24 positioner per fordon samlas in; fånga ytterligare fönster separat.</value></data>
+  <data name="EvidenceCertificationHelp" xml:space="preserve"><value>Välj den personal vars behörighetsstatus hör till den här rapporten. Certifikatnummer och filer stannar i Certifieringar.</value></data>
+  <data name="EvidenceRunCardHelp" xml:space="preserve"><value>Fångar de larmbeslut som Run Cards registrerade för rapportens larm. Ett beslut som aldrig registrerades kan inte återskapas.</value></data>
+  <data name="EvidenceInventoryHelp" xml:space="preserve"><value>Uppdaterar bevisen för varje registrerad lagerförbrukning. Inget lager förbrukas på nytt.</value></data>
+  <data name="EvidenceChatHelp" xml:space="preserve"><value>Välj meddelandena som ska bevaras; trådsvar ingår. Varje sida är en egen insamling, så samla in den här sidan innan du går vidare. Meddelandetexter visas som text.</value></data>
+  <data name="SubmissionRecoveryHeader" xml:space="preserve"><value>Inlämningshistorik och återställning</value></data>
+  <data name="SubmissionRecoveryIntro" xml:space="preserve"><value>Varje leveransförsök och svar från destinationen för den här inlämningen, samt verktygen för att reda ut ett som gick fel.</value></data>
+  <data name="SubmissionNoIdentifier" xml:space="preserve"><value>Ingen identifierare registrerad</value></data>
+  <data name="SubmissionLatestIssue" xml:space="preserve"><value>Senaste problemet</value></data>
+  <data name="SubmissionExchangeHeader" xml:space="preserve"><value>Leverans- och svarshistorik</value></data>
+  <data name="SubmissionExchangeIntro" xml:space="preserve"><value>Tider i UTC. Tidigare svar finns kvar efter avslag, nytt försök och rättelse.</value></data>
+  <data name="SubmissionNoExchanges" xml:space="preserve"><value>Ingen utbyteshistorik registrerades för den här äldre inlämningen.</value></data>
+  <data name="SubmissionOperation" xml:space="preserve"><value>Åtgärd och steg</value></data>
+  <data name="SubmissionResponse" xml:space="preserve"><value>Destinationens svar</value></data>
+  <data name="SubmissionLastResponseHeader" xml:space="preserve"><value>Senast sparade svar från destinationen</value></data>
+  <data name="SubmissionBindHeader" xml:space="preserve"><value>Koppla en icke skickad inlämning</value></data>
+  <data name="SubmissionBindIntro" xml:space="preserve"><value>Granska organisationens aktuella NERIS-enhet och destination. Kopplingen köar inlämningen för leverans.</value></data>
+  <data name="SubmissionBindAction" xml:space="preserve"><value>Koppla och köa</value></data>
+  <data name="SubmissionVerifyHeader" xml:space="preserve"><value>Verifiera en befintlig inlämning hos destinationen</value></data>
+  <data name="SubmissionVerifyIntro" xml:space="preserve"><value>Leta upp inlämningen hos den ursprungliga destinationen. Identifieraren kontrolleras mot den köade rapporten innan avfrågningen återupptas.</value></data>
+  <data name="SubmissionVerifyAction" xml:space="preserve"><value>Bekräfta mottagande</value></data>
+  <data name="SubmissionAbsenceHeader" xml:space="preserve"><value>Registrera verifierad avsaknad av inlämning</value></data>
+  <data name="SubmissionAbsenceIntro" xml:space="preserve"><value>Använd först efter att destinationen eller dess support bekräftat att inlämningen aldrig skapades; ett tomt sökresultat räcker inte. Det registrerar din verifiering och häver spärren. Inget skickas och inget nytt försök schemaläggs.</value></data>
+  <data name="SubmissionVerificationReference" xml:space="preserve"><value>Destinationens verifierings- eller supportreferens</value></data>
+  <data name="SubmissionAbsenceReason" xml:space="preserve"><value>Vad som verifierades och av vem</value></data>
+  <data name="SubmissionAbsenceConfirm" xml:space="preserve"><value>Jag har verifierat att den ursprungliga destinationen inte skapade den här inlämningen.</value></data>
+  <data name="SubmissionAbsenceAction" xml:space="preserve"><value>Registrera verifiering utan att skicka</value></data>
+  <data name="SubmissionStateQueued" xml:space="preserve"><value>I kö</value></data>
+  <data name="SubmissionStateInFlight" xml:space="preserve"><value>Under leverans</value></data>
+  <data name="SubmissionStateAccepted" xml:space="preserve"><value>Godkänd</value></data>
+  <data name="SubmissionStateRejected" xml:space="preserve"><value>Avvisad</value></data>
+  <data name="SubmissionStateFailed" xml:space="preserve"><value>Misslyckad</value></data>
+  <data name="SubmissionStateSuperseded" xml:space="preserve"><value>Ersatt av en nyare revision</value></data>
+  <data name="SubmissionStateAwaitingDestination" xml:space="preserve"><value>Väntar på destinationens granskning</value></data>
+  <data name="NewRunCallHeader" xml:space="preserve"><value>Skapa ett larm för den här insatsen</value></data>
+  <data name="NewRunCallIntro" xml:space="preserve"><value>Registrera en tidigare händelse och koppla den till insatsen. Larmet skapas stängt och larmar ingen.</value></data>
+  <data name="NewRunCallName" xml:space="preserve"><value>Larmets namn</value></data>
+  <data name="NewRunCallOccurredOn" xml:space="preserve"><value>Inträffade (organisationens lokala tid)</value></data>
+  <data name="NewRunCallAddress" xml:space="preserve"><value>Adress</value></data>
+  <data name="NewRunCallNature" xml:space="preserve"><value>Larmets art</value></data>
+  <data name="NewRunCallAction" xml:space="preserve"><value>Skapa och koppla larmet</value></data>
+  <data name="DiffRevisionRange" xml:space="preserve"><value>Revision {0} jämförd med revision {1}</value></data>
+  <data name="DiffPrint" xml:space="preserve"><value>Skriv ut jämförelsen som PDF</value></data>
+  <data name="CustomFieldsHeader" xml:space="preserve"><value>Organisationens egna fält</value></data>
+  <data name="NewRunCallSaveFirst" xml:space="preserve"><value>Spara utkastet för att skapa och koppla ett historiskt larm.</value></data>
+  <data name="ParticipantInclude" xml:space="preserve"><value>Inkludera</value></data>
+  <data name="ParticipantChoose" xml:space="preserve"><value>Välj en deltagare</value></data>
+  <data name="ParticipantLabel" xml:space="preserve"><value>Deltagare</value></data>
+  <data name="ParticipantRoleLabel" xml:space="preserve"><value>Deltagarens roll</value></data>
+  <data name="ParticipantUnitLabel" xml:space="preserve"><value>Tilldelat fordon</value></data>
+  <data name="ParticipantNoUnit" xml:space="preserve"><value>Inget tilldelat fordon</value></data>
+  <data name="ParticipantPreviousUnit" xml:space="preserve"><value>Tidigare tilldelat fordon</value></data>
+  <data name="ParticipantAdd" xml:space="preserve"><value>Lägg till deltagare</value></data>
+  <data name="ParticipantRoleFor" xml:space="preserve"><value>Roll för {0}</value></data>
+  <data name="FileClassification" xml:space="preserve"><value>Filens klassificering</value></data>
+  <data name="FileClassificationHelp" xml:space="preserve"><value>Gäller även filnamn och beskrivningar, inte bara själva filen.</value></data>
+  <data name="ClassificationRestricted" xml:space="preserve"><value>Begränsad</value></data>
+  <data name="ClassificationUnrestricted" xml:space="preserve"><value>Obegränsat operativt innehåll</value></data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Records/Records.sv.resx
+++ b/Core/Resgrid.Localization/Areas/User/Records/Records.sv.resx
@@ -2104,4 +2104,9 @@
   <data name="FileClassificationHelp" xml:space="preserve"><value>Gäller även filnamn och beskrivningar, inte bara själva filen.</value></data>
   <data name="ClassificationRestricted" xml:space="preserve"><value>Begränsad</value></data>
   <data name="ClassificationUnrestricted" xml:space="preserve"><value>Obegränsat operativt innehåll</value></data>
+  <data name="ReportsMenu" xml:space="preserve"><value>Rapporter</value></data>
+  <data name="ManageMenu" xml:space="preserve"><value>Hantera</value></data>
+  <data name="ExportListHeader" xml:space="preserve"><value>Exportera den här listan</value></data>
+  <data name="MoreMenu" xml:space="preserve"><value>Mer</value></data>
+  <data name="InventoryUsage" xml:space="preserve"><value>Lagerförbrukning</value></data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Records/Records.uk.resx
+++ b/Core/Resgrid.Localization/Areas/User/Records/Records.uk.resx
@@ -1992,4 +1992,116 @@
   <data name="ReadinessUnits" xml:space="preserve"><value>Табло готовності підрозділів</value></data>
   <data name="ReadinessUnknownCosts" xml:space="preserve"><value>Рядки без ціни</value></data>
   <data name="ReadinessWorkOrders" xml:space="preserve"><value>Наряди на роботи</value></data>
+  <data name="LegalHoldsHeader" xml:space="preserve"><value>Утримання записів для збереження</value></data>
+  <data name="LegalHoldsIntro" xml:space="preserve"><value>Використовуйте утримання для судового спору, розслідування чи запиту на документи. Воно захищає також аналіз і докази; зняття розкриття його не скасовує.</value></data>
+  <data name="PlaceHold" xml:space="preserve"><value>Накласти утримання</value></data>
+  <data name="ReleaseHold" xml:space="preserve"><value>Зняти утримання</value></data>
+  <data name="ReleaseHoldReason" xml:space="preserve"><value>Повноваження та причина зняття збереження</value></data>
+  <data name="NoHolds" xml:space="preserve"><value>Утримань для збереження не накладено.</value></data>
+  <data name="HoldActive" xml:space="preserve"><value>Утримання діє</value></data>
+  <data name="HoldScope" xml:space="preserve"><value>Обсяг</value></data>
+  <data name="HoldPeriod" xml:space="preserve"><value>Період збереження</value></data>
+  <data name="HoldRecordId" xml:space="preserve"><value>Ідентифікатор конкретного запису</value></data>
+  <data name="HoldRecordIdHelp" xml:space="preserve"><value>Залиште порожнім, щоб утримати все, що відповідає визначенню та діапазону дат.</value></data>
+  <data name="HoldDefinition" xml:space="preserve"><value>Обсяг за визначенням</value></data>
+  <data name="HoldNerisScope" xml:space="preserve"><value>Подія та аналіз NERIS</value></data>
+  <data name="HoldScopeHelp" xml:space="preserve"><value>Для обсягу за визначенням залиште обидві дати порожніми, щоб зберегти всі. Час у UTC.</value></data>
+  <data name="HoldPeriodStart" xml:space="preserve"><value>Початок періоду (UTC)</value></data>
+  <data name="HoldPeriodEnd" xml:space="preserve"><value>Кінець періоду (UTC)</value></data>
+  <data name="HoldReason" xml:space="preserve"><value>Підстава утримання</value></data>
+  <data name="HoldReasonLitigation" xml:space="preserve"><value>Судовий спір</value></data>
+  <data name="HoldReasonInvestigation" xml:space="preserve"><value>Розслідування</value></data>
+  <data name="HoldReasonRecordsRequest" xml:space="preserve"><value>Запит на публічну інформацію</value></data>
+  <data name="HoldReasonOther" xml:space="preserve"><value>Інше</value></data>
+  <data name="HoldReference" xml:space="preserve"><value>Повноваження або номер справи</value></data>
+  <data name="HoldNotes" xml:space="preserve"><value>Інструкції зі збереження та підстава</value></data>
+  <data name="HoldAllMatching" xml:space="preserve"><value>Усі відповідні записи</value></data>
+  <data name="HoldAnyStart" xml:space="preserve"><value>Будь-який початок</value></data>
+  <data name="HoldAnyEnd" xml:space="preserve"><value>Будь-який кінець</value></data>
+  <data name="HoldPlacedBy" xml:space="preserve"><value>Накладено</value></data>
+  <data name="HoldReleasedBy" xml:space="preserve"><value>Знято</value></data>
+  <data name="Reason" xml:space="preserve"><value>Причина</value></data>
+  <data name="NoRowsHelp" xml:space="preserve"><value>Тут ще нічого немає. Скористайтеся кнопками вище, щоб створити перший запис.</value></data>
+  <data name="PreviousPage" xml:space="preserve"><value>Попередня сторінка</value></data>
+  <data name="NextPage" xml:space="preserve"><value>Наступна сторінка</value></data>
+  <data name="ReturnToReport" xml:space="preserve"><value>Повернутися до звіту</value></data>
+  <data name="EvidenceManifestIntro" xml:space="preserve"><value>Збережений маніфест зберігає обрані вихідні дані та їхню контрольну суму. Чернеткові збори входять до підписаної редакції, а виправлення залишають попередні докази в історії.</value></data>
+  <data name="EvidenceWithheld" xml:space="preserve"><value>Обмежені докази приховано</value></data>
+  <data name="EvidenceCurrent" xml:space="preserve"><value>Поточне</value></data>
+  <data name="EvidenceDraft" xml:space="preserve"><value>Чернетковий збір</value></data>
+  <data name="EvidenceSignedRevision" xml:space="preserve"><value>Підписана редакція</value></data>
+  <data name="EvidenceSourceVersion" xml:space="preserve"><value>Версія джерела</value></data>
+  <data name="EvidenceDownloadManifest" xml:space="preserve"><value>Завантажити перевірений маніфест</value></data>
+  <data name="EvidenceLoadSource" xml:space="preserve"><value>Завантажити джерело</value></data>
+  <data name="EvidenceLoadMessages" xml:space="preserve"><value>Завантажити повідомлення</value></data>
+  <data name="EvidenceChannel" xml:space="preserve"><value>Канал події</value></data>
+  <data name="EvidenceChooseChannel" xml:space="preserve"><value>Оберіть канал</value></data>
+  <data name="EvidenceRestricted" xml:space="preserve"><value>потрібен обмежений доступ</value></data>
+  <data name="EvidenceUnavailableNotice" xml:space="preserve"><value>Для недоступного джерела докази не записуються.</value></data>
+  <data name="EvidenceCoverageStart" xml:space="preserve"><value>Початок охоплення (UTC)</value></data>
+  <data name="EvidenceCoverageEnd" xml:space="preserve"><value>Кінець охоплення (UTC)</value></data>
+  <data name="EvidenceValidityTime" xml:space="preserve"><value>Час події для чинності (UTC)</value></data>
+  <data name="EvidencePersonnel" xml:space="preserve"><value>Особовий склад</value></data>
+  <data name="EvidenceMessages" xml:space="preserve"><value>Повідомлення</value></data>
+  <data name="EvidenceNoChoices" xml:space="preserve"><value>На цій сторінці немає доступних елементів.</value></data>
+  <data name="EvidenceEdited" xml:space="preserve"><value>відредаговано</value></data>
+  <data name="EvidencePageWarning" xml:space="preserve"><value>Незібрані позначки на цій сторінці буде скинуто.</value></data>
+  <data name="EvidenceTrackingHelp" xml:space="preserve"><value>Оберіть щонайбільше 20 одиниць техніки та вікно до 24 годин. Вибирається до 24 позицій на одиницю; інші вікна фіксуйте окремо.</value></data>
+  <data name="EvidenceCertificationHelp" xml:space="preserve"><value>Оберіть осіб, чий статус кваліфікації належить до цього звіту. Номери сертифікатів і файли лишаються в Сертифікаціях.</value></data>
+  <data name="EvidenceRunCardHelp" xml:space="preserve"><value>Фіксує рішення про висилку, записані Run Cards для виклику цього звіту. Незаписане рішення відновити неможливо.</value></data>
+  <data name="EvidenceInventoryHelp" xml:space="preserve"><value>Оновлює докази для кожного зафіксованого використання запасів. Запас повторно не списується.</value></data>
+  <data name="EvidenceChatHelp" xml:space="preserve"><value>Оберіть повідомлення для збереження; відповіді в гілці включено. Кожна сторінка — окремий збір, тож зафіксуйте цю перед переходом далі. Тексти показано як текст.</value></data>
+  <data name="SubmissionRecoveryHeader" xml:space="preserve"><value>Історія надсилання та відновлення</value></data>
+  <data name="SubmissionRecoveryIntro" xml:space="preserve"><value>Кожна спроба доставки та відповідь призначення для цього подання, а також інструменти для узгодження невдалої.</value></data>
+  <data name="SubmissionNoIdentifier" xml:space="preserve"><value>Ідентифікатор не записано</value></data>
+  <data name="SubmissionLatestIssue" xml:space="preserve"><value>Остання проблема</value></data>
+  <data name="SubmissionExchangeHeader" xml:space="preserve"><value>Історія доставки та відповідей</value></data>
+  <data name="SubmissionExchangeIntro" xml:space="preserve"><value>Час у UTC. Попередні відповіді залишаються доступними після відмови, повтору та виправлення.</value></data>
+  <data name="SubmissionNoExchanges" xml:space="preserve"><value>Для цього застарілого подання історію обміну не записано.</value></data>
+  <data name="SubmissionOperation" xml:space="preserve"><value>Операція та етап</value></data>
+  <data name="SubmissionResponse" xml:space="preserve"><value>Відповідь призначення</value></data>
+  <data name="SubmissionLastResponseHeader" xml:space="preserve"><value>Остання збережена відповідь призначення</value></data>
+  <data name="SubmissionBindHeader" xml:space="preserve"><value>Прив'язати ненадіслане подання</value></data>
+  <data name="SubmissionBindIntro" xml:space="preserve"><value>Перевірте поточну сутність NERIS і призначення підрозділу. Прив'язка ставить подання в чергу на доставку.</value></data>
+  <data name="SubmissionBindAction" xml:space="preserve"><value>Прив'язати та поставити в чергу</value></data>
+  <data name="SubmissionVerifyHeader" xml:space="preserve"><value>Перевірити наявне подання в призначенні</value></data>
+  <data name="SubmissionVerifyIntro" xml:space="preserve"><value>Знайдіть подання в початковому призначенні. Його ідентифікатор звіряється зі звітом у черзі перед відновленням опитування.</value></data>
+  <data name="SubmissionVerifyAction" xml:space="preserve"><value>Підтвердити отримання</value></data>
+  <data name="SubmissionAbsenceHeader" xml:space="preserve"><value>Зафіксувати підтверджену відсутність подання</value></data>
+  <data name="SubmissionAbsenceIntro" xml:space="preserve"><value>Використовуйте лише після підтвердження призначенням або його підтримкою, що подання ніколи не створювалося; порожній результат пошуку недостатній. Це фіксує вашу перевірку та знімає блок. Нічого не надсилає й не планує повторів.</value></data>
+  <data name="SubmissionVerificationReference" xml:space="preserve"><value>Номер перевірки або звернення до підтримки призначення</value></data>
+  <data name="SubmissionAbsenceReason" xml:space="preserve"><value>Що перевірено і ким</value></data>
+  <data name="SubmissionAbsenceConfirm" xml:space="preserve"><value>Я перевірив, що початкове призначення не створювало цього подання.</value></data>
+  <data name="SubmissionAbsenceAction" xml:space="preserve"><value>Зафіксувати перевірку без надсилання</value></data>
+  <data name="SubmissionStateQueued" xml:space="preserve"><value>У черзі</value></data>
+  <data name="SubmissionStateInFlight" xml:space="preserve"><value>У дорозі</value></data>
+  <data name="SubmissionStateAccepted" xml:space="preserve"><value>Прийнято</value></data>
+  <data name="SubmissionStateRejected" xml:space="preserve"><value>Відхилено</value></data>
+  <data name="SubmissionStateFailed" xml:space="preserve"><value>Помилка</value></data>
+  <data name="SubmissionStateSuperseded" xml:space="preserve"><value>Замінено новішою редакцією</value></data>
+  <data name="SubmissionStateAwaitingDestination" xml:space="preserve"><value>Очікує розгляду призначенням</value></data>
+  <data name="NewRunCallHeader" xml:space="preserve"><value>Створити виклик для цього виїзду</value></data>
+  <data name="NewRunCallIntro" xml:space="preserve"><value>Зафіксуйте минулу подію та прив'яжіть її до цього виїзду. Виклик створюється закритим і нікого не висилає.</value></data>
+  <data name="NewRunCallName" xml:space="preserve"><value>Назва виклику</value></data>
+  <data name="NewRunCallOccurredOn" xml:space="preserve"><value>Сталося (місцевий час підрозділу)</value></data>
+  <data name="NewRunCallAddress" xml:space="preserve"><value>Адреса</value></data>
+  <data name="NewRunCallNature" xml:space="preserve"><value>Характер виклику</value></data>
+  <data name="NewRunCallAction" xml:space="preserve"><value>Створити та прив'язати виклик</value></data>
+  <data name="DiffRevisionRange" xml:space="preserve"><value>Редакція {0} у порівнянні з редакцією {1}</value></data>
+  <data name="DiffPrint" xml:space="preserve"><value>Друкувати порівняння як PDF</value></data>
+  <data name="CustomFieldsHeader" xml:space="preserve"><value>Власні поля підрозділу</value></data>
+  <data name="NewRunCallSaveFirst" xml:space="preserve"><value>Збережіть чернетку, щоб створити та прив'язати минулий виклик.</value></data>
+  <data name="ParticipantInclude" xml:space="preserve"><value>Включити</value></data>
+  <data name="ParticipantChoose" xml:space="preserve"><value>Оберіть учасника</value></data>
+  <data name="ParticipantLabel" xml:space="preserve"><value>Учасник</value></data>
+  <data name="ParticipantRoleLabel" xml:space="preserve"><value>Роль учасника</value></data>
+  <data name="ParticipantUnitLabel" xml:space="preserve"><value>Призначена техніка</value></data>
+  <data name="ParticipantNoUnit" xml:space="preserve"><value>Техніку не призначено</value></data>
+  <data name="ParticipantPreviousUnit" xml:space="preserve"><value>Раніше призначена техніка</value></data>
+  <data name="ParticipantAdd" xml:space="preserve"><value>Додати учасника</value></data>
+  <data name="ParticipantRoleFor" xml:space="preserve"><value>Роль для {0}</value></data>
+  <data name="FileClassification" xml:space="preserve"><value>Класифікація файлу</value></data>
+  <data name="FileClassificationHelp" xml:space="preserve"><value>Стосується також назв і описів файлів, а не лише самого файлу.</value></data>
+  <data name="ClassificationRestricted" xml:space="preserve"><value>Обмежено</value></data>
+  <data name="ClassificationUnrestricted" xml:space="preserve"><value>Необмежений оперативний вміст</value></data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/Records/Records.uk.resx
+++ b/Core/Resgrid.Localization/Areas/User/Records/Records.uk.resx
@@ -2104,4 +2104,9 @@
   <data name="FileClassificationHelp" xml:space="preserve"><value>Стосується також назв і описів файлів, а не лише самого файлу.</value></data>
   <data name="ClassificationRestricted" xml:space="preserve"><value>Обмежено</value></data>
   <data name="ClassificationUnrestricted" xml:space="preserve"><value>Необмежений оперативний вміст</value></data>
+  <data name="ReportsMenu" xml:space="preserve"><value>Звіти</value></data>
+  <data name="ManageMenu" xml:space="preserve"><value>Керування</value></data>
+  <data name="ExportListHeader" xml:space="preserve"><value>Експортувати цей список</value></data>
+  <data name="MoreMenu" xml:space="preserve"><value>Більше</value></data>
+  <data name="InventoryUsage" xml:space="preserve"><value>Використання запасів</value></data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/WorkOrders/WorkOrders.ar.resx
+++ b/Core/Resgrid.Localization/Areas/User/WorkOrders/WorkOrders.ar.resx
@@ -376,4 +376,25 @@
 <data name="WorkOrderPolicyChanged" xml:space="preserve"><value>تغيرت سياسة عمليات أوامر العمل</value></data>
 <data name="ResponseDueOn" xml:space="preserve"><value>الموعد النهائي للاستجابة (UTC)</value></data>
 <data name="RepairDueOn" xml:space="preserve"><value>الموعد النهائي للإصلاح (UTC)</value></data>
+  <data name="WorkOrdersIntro" xml:space="preserve"><value>أنشئ أوامر الإصلاح وتابع من ينفّذها واطّلع على تكلفة الصيانة.</value></data>
+  <data name="Close" xml:space="preserve"><value>إغلاق</value></data>
+  <data name="Continue" xml:space="preserve"><value>متابعة</value></data>
+  <data name="Review" xml:space="preserve"><value>مراجعة</value></data>
+  <data name="ReviewHint" xml:space="preserve"><value>راجع الإجابات أدناه ثم احفظ.</value></data>
+  <data name="RequiredFieldsMissing" xml:space="preserve"><value>املأ الحقول المميزة قبل المتابعة.</value></data>
+  <data name="NoRowsHelp" xml:space="preserve"><value>لا يوجد شيء هنا بعد. استخدم الأزرار أعلاه لإنشاء أول واحد.</value></data>
+  <data name="HelpWorkOrders" xml:space="preserve"><value>أمر العمل هو إصلاح أو فحص واحد، من الطلب حتى الإصلاح المُتحقّق منه.</value></data>
+  <data name="StepOrderDescribe" xml:space="preserve"><value>وصف العمل</value></data>
+  <data name="StepOrderDescribeHint" xml:space="preserve"><value>ما المطلوب عمله، ومدى إلحاحه، وموعد الحاجة إليه.</value></data>
+  <data name="StepOrderTarget" xml:space="preserve"><value>موضوع العمل</value></data>
+  <data name="StepOrderTargetHint" xml:space="preserve"><value>المركبة أو المحطة أو الأصل المعني بالعمل، وأين يوجد.</value></data>
+  <data name="StepOrderCost" xml:space="preserve"><value>التكلفة والمورّد</value></data>
+  <data name="StepOrderCostHint" xml:space="preserve"><value>التكلفة المتوقعة، وأي ميزانية تتحمّلها، ومن ينفّذ العمل.</value></data>
+  <data name="StepOrderSafety" xml:space="preserve"><value>السلامة والإجراء</value></data>
+  <data name="StepOrderSafetyHint" xml:space="preserve"><value>التصاريح وعمليات العزل والمؤهلات التي يتطلبها العمل، والخطوات الواجب اتباعها.</value></data>
+  <data name="StepRecurrenceScheduleHint" xml:space="preserve"><value>عدد مرات تكرار العمل، والنافذة الزمنية التي يمكن لأطقمك تنفيذه خلالها.</value></data>
+  <data name="StepRecurrenceUsageHint" xml:space="preserve"><value>محفّزات اختيارية للعدّاد أو الحالة تُنشئ العمل مبكرًا وفق الاستخدام.</value></data>
+  <data name="StepRecurrenceAssignmentHint" xml:space="preserve"><value>إلى من يذهب أمر العمل المُنشأ، وإلى من يُصعَّد إن لم يتولّه أحد.</value></data>
+  <data name="HelpFieldDueOn" xml:space="preserve"><value>يحدّد وسم التأخر وعدّاد مستوى الخدمة.</value></data>
+  <data name="HelpFieldSteps" xml:space="preserve"><value>الخطوات التي ينفّذها الفني. بعض تغييرات الحالة تتطلب إتمامها جميعًا.</value></data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/WorkOrders/WorkOrders.de.resx
+++ b/Core/Resgrid.Localization/Areas/User/WorkOrders/WorkOrders.de.resx
@@ -376,4 +376,25 @@
 <data name="WorkOrderPolicyChanged" xml:space="preserve"><value>Vorgangsrichtlinie für Arbeitsaufträge geändert</value></data>
 <data name="ResponseDueOn" xml:space="preserve"><value>Reaktionsfrist (UTC)</value></data>
 <data name="RepairDueOn" xml:space="preserve"><value>Reparaturfrist (UTC)</value></data>
+  <data name="WorkOrdersIntro" xml:space="preserve"><value>Reparaturen anlegen, Zuständigkeiten verfolgen und die Wartungskosten sehen.</value></data>
+  <data name="Close" xml:space="preserve"><value>Schließen</value></data>
+  <data name="Continue" xml:space="preserve"><value>Weiter</value></data>
+  <data name="Review" xml:space="preserve"><value>Prüfen</value></data>
+  <data name="ReviewHint" xml:space="preserve"><value>Prüfen Sie die Angaben unten und speichern Sie dann.</value></data>
+  <data name="RequiredFieldsMissing" xml:space="preserve"><value>Füllen Sie die hervorgehobenen Felder aus, bevor Sie fortfahren.</value></data>
+  <data name="NoRowsHelp" xml:space="preserve"><value>Hier ist noch nichts. Legen Sie über die Schaltflächen oben den ersten Eintrag an.</value></data>
+  <data name="HelpWorkOrders" xml:space="preserve"><value>Ein Arbeitsauftrag ist eine Reparatur oder Prüfung, von der Anforderung bis zur geprüften Behebung.</value></data>
+  <data name="StepOrderDescribe" xml:space="preserve"><value>Arbeit beschreiben</value></data>
+  <data name="StepOrderDescribeHint" xml:space="preserve"><value>Was zu tun ist, wie dringend es ist und bis wann es benötigt wird.</value></data>
+  <data name="StepOrderTarget" xml:space="preserve"><value>Wofür es gilt</value></data>
+  <data name="StepOrderTargetHint" xml:space="preserve"><value>Fahrzeug, Wache oder Asset, für das die Arbeit gilt, und wo es zu finden ist.</value></data>
+  <data name="StepOrderCost" xml:space="preserve"><value>Kosten und Lieferant</value></data>
+  <data name="StepOrderCostHint" xml:space="preserve"><value>Welche Kosten erwartet werden, welches Budget belastet wird und wer die Arbeit ausführt.</value></data>
+  <data name="StepOrderSafety" xml:space="preserve"><value>Sicherheit und Verfahren</value></data>
+  <data name="StepOrderSafetyHint" xml:space="preserve"><value>Erforderliche Freigaben, Freischaltungen und Qualifikationen sowie die einzuhaltenden Schritte.</value></data>
+  <data name="StepRecurrenceScheduleHint" xml:space="preserve"><value>Wie oft die Arbeit ansteht und in welchem Zeitfenster sie erledigt werden kann.</value></data>
+  <data name="StepRecurrenceUsageHint" xml:space="preserve"><value>Optionale Zähler- oder Zustandsauslöser, die die Arbeit bei entsprechender Nutzung früher anlegen.</value></data>
+  <data name="StepRecurrenceAssignmentHint" xml:space="preserve"><value>An wen der erzeugte Arbeitsauftrag geht und an wen eskaliert wird, wenn ihn niemand übernimmt.</value></data>
+  <data name="HelpFieldDueOn" xml:space="preserve"><value>Steuert die Überfälligkeitsmarkierung und die Service-Level-Uhr.</value></data>
+  <data name="HelpFieldSteps" xml:space="preserve"><value>Die Schritte, die der Techniker abarbeitet. Manche Statuswechsel setzen voraus, dass alle erledigt sind.</value></data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/WorkOrders/WorkOrders.el.resx
+++ b/Core/Resgrid.Localization/Areas/User/WorkOrders/WorkOrders.el.resx
@@ -376,4 +376,25 @@
 <data name="WorkOrderPolicyChanged" xml:space="preserve"><value>Αλλαγή πολιτικής λειτουργιών εντολών εργασίας</value></data>
 <data name="ResponseDueOn" xml:space="preserve"><value>Προθεσμία απόκρισης (UTC)</value></data>
 <data name="RepairDueOn" xml:space="preserve"><value>Προθεσμία επισκευής (UTC)</value></data>
+  <data name="WorkOrdersIntro" xml:space="preserve"><value>Δημιουργήστε επισκευές, παρακολουθήστε ποιος τις εκτελεί και δείτε το κόστος συντήρησης.</value></data>
+  <data name="Close" xml:space="preserve"><value>Κλείσιμο</value></data>
+  <data name="Continue" xml:space="preserve"><value>Συνέχεια</value></data>
+  <data name="Review" xml:space="preserve"><value>Έλεγχος</value></data>
+  <data name="ReviewHint" xml:space="preserve"><value>Ελέγξτε τις απαντήσεις παρακάτω και αποθηκεύστε.</value></data>
+  <data name="RequiredFieldsMissing" xml:space="preserve"><value>Συμπληρώστε τα επισημασμένα πεδία πριν συνεχίσετε.</value></data>
+  <data name="NoRowsHelp" xml:space="preserve"><value>Δεν υπάρχει τίποτα ακόμη. Χρησιμοποιήστε τα κουμπιά παραπάνω για να δημιουργήσετε το πρώτο.</value></data>
+  <data name="HelpWorkOrders" xml:space="preserve"><value>Μια εντολή εργασίας είναι μία επισκευή ή επιθεώρηση, από το αίτημα έως την επαληθευμένη αποκατάσταση.</value></data>
+  <data name="StepOrderDescribe" xml:space="preserve"><value>Περιγράψτε την εργασία</value></data>
+  <data name="StepOrderDescribeHint" xml:space="preserve"><value>Τι πρέπει να γίνει, πόσο επείγον είναι και μέχρι πότε χρειάζεται.</value></data>
+  <data name="StepOrderTarget" xml:space="preserve"><value>Σε τι αφορά</value></data>
+  <data name="StepOrderTargetHint" xml:space="preserve"><value>Το όχημα, ο σταθμός ή το πάγιο που αφορά η εργασία, και πού βρίσκεται.</value></data>
+  <data name="StepOrderCost" xml:space="preserve"><value>Κόστος και προμηθευτής</value></data>
+  <data name="StepOrderCostHint" xml:space="preserve"><value>Πόσο αναμένεται να κοστίσει, σε ποιον προϋπολογισμό βαρύνει και ποιος το εκτελεί.</value></data>
+  <data name="StepOrderSafety" xml:space="preserve"><value>Ασφάλεια και διαδικασία</value></data>
+  <data name="StepOrderSafetyHint" xml:space="preserve"><value>Οι άδειες, οι απομονώσεις και τα προσόντα που απαιτεί η εργασία, και τα βήματα.</value></data>
+  <data name="StepRecurrenceScheduleHint" xml:space="preserve"><value>Πόσο συχνά επανέρχεται η εργασία και σε ποιο παράθυρο μπορεί να γίνει.</value></data>
+  <data name="StepRecurrenceUsageHint" xml:space="preserve"><value>Προαιρετικοί μετρητές ή συνθήκες που ενεργοποιούν νωρίτερα την εργασία ανάλογα με τη χρήση.</value></data>
+  <data name="StepRecurrenceAssignmentHint" xml:space="preserve"><value>Σε ποιον πηγαίνει η εντολή που δημιουργείται και σε ποιον κλιμακώνεται αν δεν την αναλάβει κανείς.</value></data>
+  <data name="HelpFieldDueOn" xml:space="preserve"><value>Καθορίζει την ένδειξη καθυστέρησης και το χρονόμετρο επιπέδου υπηρεσίας.</value></data>
+  <data name="HelpFieldSteps" xml:space="preserve"><value>Τα βήματα που ακολουθεί ο τεχνικός. Ορισμένες μεταβάσεις απαιτούν να ολοκληρωθούν όλα.</value></data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/WorkOrders/WorkOrders.en.resx
+++ b/Core/Resgrid.Localization/Areas/User/WorkOrders/WorkOrders.en.resx
@@ -376,4 +376,25 @@
 <data name="WorkOrderPolicyChanged" xml:space="preserve"><value>Work order operations policy changed</value></data>
 <data name="ResponseDueOn" xml:space="preserve"><value>Response deadline (UTC)</value></data>
 <data name="RepairDueOn" xml:space="preserve"><value>Repair deadline (UTC)</value></data>
+  <data name="WorkOrdersIntro" xml:space="preserve"><value>Raise repairs, track who is doing them, and see what maintenance has cost.</value></data>
+  <data name="Close" xml:space="preserve"><value>Close</value></data>
+  <data name="Continue" xml:space="preserve"><value>Continue</value></data>
+  <data name="Review" xml:space="preserve"><value>Review</value></data>
+  <data name="ReviewHint" xml:space="preserve"><value>Check the answers below, then save.</value></data>
+  <data name="RequiredFieldsMissing" xml:space="preserve"><value>Fill in the highlighted fields before continuing.</value></data>
+  <data name="NoRowsHelp" xml:space="preserve"><value>Nothing here yet. Use the buttons above to create the first one.</value></data>
+  <data name="HelpWorkOrders" xml:space="preserve"><value>A work order is one repair or inspection, from the request through to the verified fix.</value></data>
+  <data name="StepOrderDescribe" xml:space="preserve"><value>Describe the work</value></data>
+  <data name="StepOrderDescribeHint" xml:space="preserve"><value>What needs doing, how urgent it is, and when it is needed by.</value></data>
+  <data name="StepOrderTarget" xml:space="preserve"><value>What it is for</value></data>
+  <data name="StepOrderTargetHint" xml:space="preserve"><value>The apparatus, station or asset the work is against, and where to find it.</value></data>
+  <data name="StepOrderCost" xml:space="preserve"><value>Cost and vendor</value></data>
+  <data name="StepOrderCostHint" xml:space="preserve"><value>What the work is expected to cost, which budget it lands on, and who is doing it.</value></data>
+  <data name="StepOrderSafety" xml:space="preserve"><value>Safety and procedure</value></data>
+  <data name="StepOrderSafetyHint" xml:space="preserve"><value>The permits, isolations and qualifications the work needs, and the steps to follow.</value></data>
+  <data name="StepRecurrenceScheduleHint" xml:space="preserve"><value>How often the work comes around, and the window your crews can do it in.</value></data>
+  <data name="StepRecurrenceUsageHint" xml:space="preserve"><value>Optional meter or condition triggers that raise the work early when usage says so.</value></data>
+  <data name="StepRecurrenceAssignmentHint" xml:space="preserve"><value>Who the generated work order goes to, and who it escalates to if nobody picks it up.</value></data>
+  <data name="HelpFieldDueOn" xml:space="preserve"><value>Drives the overdue flag and the service level clock.</value></data>
+  <data name="HelpFieldSteps" xml:space="preserve"><value>The checks the technician works down. Some transitions require them all to be done.</value></data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/WorkOrders/WorkOrders.es.resx
+++ b/Core/Resgrid.Localization/Areas/User/WorkOrders/WorkOrders.es.resx
@@ -376,4 +376,25 @@
 <data name="WorkOrderPolicyChanged" xml:space="preserve"><value>Política de operaciones de órdenes de trabajo modificada</value></data>
 <data name="ResponseDueOn" xml:space="preserve"><value>Fecha límite de respuesta (UTC)</value></data>
 <data name="RepairDueOn" xml:space="preserve"><value>Fecha límite de reparación (UTC)</value></data>
+  <data name="WorkOrdersIntro" xml:space="preserve"><value>Cree reparaciones, controle quién las realiza y vea el coste del mantenimiento.</value></data>
+  <data name="Close" xml:space="preserve"><value>Cerrar</value></data>
+  <data name="Continue" xml:space="preserve"><value>Continuar</value></data>
+  <data name="Review" xml:space="preserve"><value>Revisar</value></data>
+  <data name="ReviewHint" xml:space="preserve"><value>Revise las respuestas de abajo y guarde.</value></data>
+  <data name="RequiredFieldsMissing" xml:space="preserve"><value>Complete los campos resaltados antes de continuar.</value></data>
+  <data name="NoRowsHelp" xml:space="preserve"><value>Aquí todavía no hay nada. Use los botones de arriba para crear el primero.</value></data>
+  <data name="HelpWorkOrders" xml:space="preserve"><value>Una orden de trabajo es una reparación o inspección, desde la solicitud hasta la corrección verificada.</value></data>
+  <data name="StepOrderDescribe" xml:space="preserve"><value>Describa el trabajo</value></data>
+  <data name="StepOrderDescribeHint" xml:space="preserve"><value>Qué hay que hacer, con qué urgencia y para cuándo.</value></data>
+  <data name="StepOrderTarget" xml:space="preserve"><value>A qué se refiere</value></data>
+  <data name="StepOrderTargetHint" xml:space="preserve"><value>El vehículo, parque o activo al que corresponde el trabajo, y dónde encontrarlo.</value></data>
+  <data name="StepOrderCost" xml:space="preserve"><value>Coste y proveedor</value></data>
+  <data name="StepOrderCostHint" xml:space="preserve"><value>Cuánto se espera que cueste, a qué presupuesto se imputa y quién lo hace.</value></data>
+  <data name="StepOrderSafety" xml:space="preserve"><value>Seguridad y procedimiento</value></data>
+  <data name="StepOrderSafetyHint" xml:space="preserve"><value>Los permisos, bloqueos y cualificaciones que requiere el trabajo, y los pasos a seguir.</value></data>
+  <data name="StepRecurrenceScheduleHint" xml:space="preserve"><value>Con qué frecuencia se repite el trabajo y en qué ventana puede hacerse.</value></data>
+  <data name="StepRecurrenceUsageHint" xml:space="preserve"><value>Disparadores opcionales de contador o condición que adelantan el trabajo según el uso.</value></data>
+  <data name="StepRecurrenceAssignmentHint" xml:space="preserve"><value>A quién va la orden generada y a quién se escala si nadie la asume.</value></data>
+  <data name="HelpFieldDueOn" xml:space="preserve"><value>Determina el indicador de retraso y el reloj del nivel de servicio.</value></data>
+  <data name="HelpFieldSteps" xml:space="preserve"><value>Los pasos que sigue el técnico. Algunas transiciones exigen que estén todos hechos.</value></data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/WorkOrders/WorkOrders.fr.resx
+++ b/Core/Resgrid.Localization/Areas/User/WorkOrders/WorkOrders.fr.resx
@@ -376,4 +376,25 @@
 <data name="WorkOrderPolicyChanged" xml:space="preserve"><value>Politique des opérations des ordres de travail modifiée</value></data>
 <data name="ResponseDueOn" xml:space="preserve"><value>Échéance de réponse (UTC)</value></data>
 <data name="RepairDueOn" xml:space="preserve"><value>Échéance de réparation (UTC)</value></data>
+  <data name="WorkOrdersIntro" xml:space="preserve"><value>Créez des réparations, suivez qui les réalise et consultez le coût de la maintenance.</value></data>
+  <data name="Close" xml:space="preserve"><value>Fermer</value></data>
+  <data name="Continue" xml:space="preserve"><value>Continuer</value></data>
+  <data name="Review" xml:space="preserve"><value>Vérifier</value></data>
+  <data name="ReviewHint" xml:space="preserve"><value>Vérifiez les réponses ci-dessous, puis enregistrez.</value></data>
+  <data name="RequiredFieldsMissing" xml:space="preserve"><value>Renseignez les champs en surbrillance avant de continuer.</value></data>
+  <data name="NoRowsHelp" xml:space="preserve"><value>Rien pour l'instant. Utilisez les boutons ci-dessus pour créer le premier.</value></data>
+  <data name="HelpWorkOrders" xml:space="preserve"><value>Un ordre de travail correspond à une réparation ou une inspection, de la demande jusqu'à la correction vérifiée.</value></data>
+  <data name="StepOrderDescribe" xml:space="preserve"><value>Décrire les travaux</value></data>
+  <data name="StepOrderDescribeHint" xml:space="preserve"><value>Ce qu'il faut faire, son urgence et la date à laquelle c'est attendu.</value></data>
+  <data name="StepOrderTarget" xml:space="preserve"><value>Objet concerné</value></data>
+  <data name="StepOrderTargetHint" xml:space="preserve"><value>L'engin, la caserne ou l'actif concerné, et où le trouver.</value></data>
+  <data name="StepOrderCost" xml:space="preserve"><value>Coût et fournisseur</value></data>
+  <data name="StepOrderCostHint" xml:space="preserve"><value>Le coût attendu, le budget concerné et qui réalise les travaux.</value></data>
+  <data name="StepOrderSafety" xml:space="preserve"><value>Sécurité et procédure</value></data>
+  <data name="StepOrderSafetyHint" xml:space="preserve"><value>Les permis, consignations et qualifications requis, et les étapes à suivre.</value></data>
+  <data name="StepRecurrenceScheduleHint" xml:space="preserve"><value>À quelle fréquence les travaux reviennent et dans quelle plage ils peuvent être faits.</value></data>
+  <data name="StepRecurrenceUsageHint" xml:space="preserve"><value>Déclencheurs facultatifs de compteur ou d'état qui avancent les travaux selon l'usage.</value></data>
+  <data name="StepRecurrenceAssignmentHint" xml:space="preserve"><value>À qui va l'ordre de travail généré, et vers qui il remonte si personne ne le prend.</value></data>
+  <data name="HelpFieldDueOn" xml:space="preserve"><value>Détermine l'indicateur de retard et le compteur de niveau de service.</value></data>
+  <data name="HelpFieldSteps" xml:space="preserve"><value>Les étapes que suit le technicien. Certaines transitions exigent qu'elles soient toutes faites.</value></data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/WorkOrders/WorkOrders.it.resx
+++ b/Core/Resgrid.Localization/Areas/User/WorkOrders/WorkOrders.it.resx
@@ -376,4 +376,25 @@
 <data name="WorkOrderPolicyChanged" xml:space="preserve"><value>Regole operative degli ordini di lavoro modificate</value></data>
 <data name="ResponseDueOn" xml:space="preserve"><value>Scadenza di risposta (UTC)</value></data>
 <data name="RepairDueOn" xml:space="preserve"><value>Scadenza di riparazione (UTC)</value></data>
+  <data name="WorkOrdersIntro" xml:space="preserve"><value>Apri riparazioni, controlla chi le esegue e verifica quanto è costata la manutenzione.</value></data>
+  <data name="Close" xml:space="preserve"><value>Chiudi</value></data>
+  <data name="Continue" xml:space="preserve"><value>Continua</value></data>
+  <data name="Review" xml:space="preserve"><value>Verifica</value></data>
+  <data name="ReviewHint" xml:space="preserve"><value>Controlla le risposte qui sotto, poi salva.</value></data>
+  <data name="RequiredFieldsMissing" xml:space="preserve"><value>Compila i campi evidenziati prima di continuare.</value></data>
+  <data name="NoRowsHelp" xml:space="preserve"><value>Non c'è ancora nulla. Usa i pulsanti sopra per creare il primo.</value></data>
+  <data name="HelpWorkOrders" xml:space="preserve"><value>Un ordine di lavoro è una riparazione o un'ispezione, dalla richiesta fino alla correzione verificata.</value></data>
+  <data name="StepOrderDescribe" xml:space="preserve"><value>Descrivi il lavoro</value></data>
+  <data name="StepOrderDescribeHint" xml:space="preserve"><value>Cosa serve fare, con quale urgenza ed entro quando.</value></data>
+  <data name="StepOrderTarget" xml:space="preserve"><value>A cosa si riferisce</value></data>
+  <data name="StepOrderTargetHint" xml:space="preserve"><value>Il mezzo, la sede o il cespite a cui si riferisce il lavoro, e dove trovarlo.</value></data>
+  <data name="StepOrderCost" xml:space="preserve"><value>Costo e fornitore</value></data>
+  <data name="StepOrderCostHint" xml:space="preserve"><value>Quanto ci si attende che costi, su quale budget ricade e chi lo esegue.</value></data>
+  <data name="StepOrderSafety" xml:space="preserve"><value>Sicurezza e procedura</value></data>
+  <data name="StepOrderSafetyHint" xml:space="preserve"><value>Permessi, sezionamenti e qualifiche necessari, e i passi da seguire.</value></data>
+  <data name="StepRecurrenceScheduleHint" xml:space="preserve"><value>Ogni quanto torna il lavoro e in quale finestra le squadre possono eseguirlo.</value></data>
+  <data name="StepRecurrenceUsageHint" xml:space="preserve"><value>Trigger facoltativi di contatore o condizione che anticipano il lavoro in base all'uso.</value></data>
+  <data name="StepRecurrenceAssignmentHint" xml:space="preserve"><value>A chi va l'ordine generato e a chi viene inoltrato se nessuno lo prende in carico.</value></data>
+  <data name="HelpFieldDueOn" xml:space="preserve"><value>Determina l'indicatore di ritardo e il conteggio del livello di servizio.</value></data>
+  <data name="HelpFieldSteps" xml:space="preserve"><value>I passi che il tecnico esegue. Alcune transizioni richiedono che siano tutti completati.</value></data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/WorkOrders/WorkOrders.pl.resx
+++ b/Core/Resgrid.Localization/Areas/User/WorkOrders/WorkOrders.pl.resx
@@ -376,4 +376,25 @@
 <data name="WorkOrderPolicyChanged" xml:space="preserve"><value>Zmieniono zasady operacyjne zleceń pracy</value></data>
 <data name="ResponseDueOn" xml:space="preserve"><value>Termin reakcji (UTC)</value></data>
 <data name="RepairDueOn" xml:space="preserve"><value>Termin naprawy (UTC)</value></data>
+  <data name="WorkOrdersIntro" xml:space="preserve"><value>Zgłaszaj naprawy, śledź wykonawców i sprawdzaj koszty utrzymania.</value></data>
+  <data name="Close" xml:space="preserve"><value>Zamknij</value></data>
+  <data name="Continue" xml:space="preserve"><value>Dalej</value></data>
+  <data name="Review" xml:space="preserve"><value>Podsumowanie</value></data>
+  <data name="ReviewHint" xml:space="preserve"><value>Sprawdź poniższe odpowiedzi, a następnie zapisz.</value></data>
+  <data name="RequiredFieldsMissing" xml:space="preserve"><value>Wypełnij podświetlone pola przed przejściem dalej.</value></data>
+  <data name="NoRowsHelp" xml:space="preserve"><value>Jeszcze nic tu nie ma. Użyj przycisków powyżej, aby utworzyć pierwszy wpis.</value></data>
+  <data name="HelpWorkOrders" xml:space="preserve"><value>Zlecenie pracy to jedna naprawa lub przegląd, od zgłoszenia po zweryfikowaną naprawę.</value></data>
+  <data name="StepOrderDescribe" xml:space="preserve"><value>Opisz pracę</value></data>
+  <data name="StepOrderDescribeHint" xml:space="preserve"><value>Co trzeba zrobić, jak pilne to jest i na kiedy.</value></data>
+  <data name="StepOrderTarget" xml:space="preserve"><value>Czego dotyczy</value></data>
+  <data name="StepOrderTargetHint" xml:space="preserve"><value>Pojazd, remiza lub zasób, którego dotyczy praca, oraz gdzie go znaleźć.</value></data>
+  <data name="StepOrderCost" xml:space="preserve"><value>Koszt i dostawca</value></data>
+  <data name="StepOrderCostHint" xml:space="preserve"><value>Ile ma kosztować, na który budżet trafia i kto wykonuje pracę.</value></data>
+  <data name="StepOrderSafety" xml:space="preserve"><value>Bezpieczeństwo i procedura</value></data>
+  <data name="StepOrderSafetyHint" xml:space="preserve"><value>Wymagane zezwolenia, blokady i kwalifikacje oraz kroki do wykonania.</value></data>
+  <data name="StepRecurrenceScheduleHint" xml:space="preserve"><value>Jak często praca się powtarza i w jakim oknie można ją wykonać.</value></data>
+  <data name="StepRecurrenceUsageHint" xml:space="preserve"><value>Opcjonalne wyzwalacze licznika lub stanu, które przyspieszają pracę zależnie od użycia.</value></data>
+  <data name="StepRecurrenceAssignmentHint" xml:space="preserve"><value>Do kogo trafia wygenerowane zlecenie i do kogo jest eskalowane, gdy nikt go nie podejmie.</value></data>
+  <data name="HelpFieldDueOn" xml:space="preserve"><value>Steruje oznaczeniem opóźnienia i zegarem poziomu usług.</value></data>
+  <data name="HelpFieldSteps" xml:space="preserve"><value>Kroki, które wykonuje technik. Niektóre zmiany statusu wymagają ukończenia wszystkich.</value></data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/WorkOrders/WorkOrders.resx
+++ b/Core/Resgrid.Localization/Areas/User/WorkOrders/WorkOrders.resx
@@ -376,4 +376,25 @@
 <data name="WorkOrderPolicyChanged" xml:space="preserve"><value>Work order operations policy changed</value></data>
 <data name="ResponseDueOn" xml:space="preserve"><value>Response deadline (UTC)</value></data>
 <data name="RepairDueOn" xml:space="preserve"><value>Repair deadline (UTC)</value></data>
+  <data name="WorkOrdersIntro" xml:space="preserve"><value>Raise repairs, track who is doing them, and see what maintenance has cost.</value></data>
+  <data name="Close" xml:space="preserve"><value>Close</value></data>
+  <data name="Continue" xml:space="preserve"><value>Continue</value></data>
+  <data name="Review" xml:space="preserve"><value>Review</value></data>
+  <data name="ReviewHint" xml:space="preserve"><value>Check the answers below, then save.</value></data>
+  <data name="RequiredFieldsMissing" xml:space="preserve"><value>Fill in the highlighted fields before continuing.</value></data>
+  <data name="NoRowsHelp" xml:space="preserve"><value>Nothing here yet. Use the buttons above to create the first one.</value></data>
+  <data name="HelpWorkOrders" xml:space="preserve"><value>A work order is one repair or inspection, from the request through to the verified fix.</value></data>
+  <data name="StepOrderDescribe" xml:space="preserve"><value>Describe the work</value></data>
+  <data name="StepOrderDescribeHint" xml:space="preserve"><value>What needs doing, how urgent it is, and when it is needed by.</value></data>
+  <data name="StepOrderTarget" xml:space="preserve"><value>What it is for</value></data>
+  <data name="StepOrderTargetHint" xml:space="preserve"><value>The apparatus, station or asset the work is against, and where to find it.</value></data>
+  <data name="StepOrderCost" xml:space="preserve"><value>Cost and vendor</value></data>
+  <data name="StepOrderCostHint" xml:space="preserve"><value>What the work is expected to cost, which budget it lands on, and who is doing it.</value></data>
+  <data name="StepOrderSafety" xml:space="preserve"><value>Safety and procedure</value></data>
+  <data name="StepOrderSafetyHint" xml:space="preserve"><value>The permits, isolations and qualifications the work needs, and the steps to follow.</value></data>
+  <data name="StepRecurrenceScheduleHint" xml:space="preserve"><value>How often the work comes around, and the window your crews can do it in.</value></data>
+  <data name="StepRecurrenceUsageHint" xml:space="preserve"><value>Optional meter or condition triggers that raise the work early when usage says so.</value></data>
+  <data name="StepRecurrenceAssignmentHint" xml:space="preserve"><value>Who the generated work order goes to, and who it escalates to if nobody picks it up.</value></data>
+  <data name="HelpFieldDueOn" xml:space="preserve"><value>Drives the overdue flag and the service level clock.</value></data>
+  <data name="HelpFieldSteps" xml:space="preserve"><value>The checks the technician works down. Some transitions require them all to be done.</value></data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/WorkOrders/WorkOrders.sv.resx
+++ b/Core/Resgrid.Localization/Areas/User/WorkOrders/WorkOrders.sv.resx
@@ -376,4 +376,25 @@
 <data name="WorkOrderPolicyChanged" xml:space="preserve"><value>Reglerna för arbetsorder ändrade</value></data>
 <data name="ResponseDueOn" xml:space="preserve"><value>Sista svarstid (UTC)</value></data>
 <data name="RepairDueOn" xml:space="preserve"><value>Sista reparationstid (UTC)</value></data>
+  <data name="WorkOrdersIntro" xml:space="preserve"><value>Skapa reparationer, följ vem som utför dem och se vad underhållet kostat.</value></data>
+  <data name="Close" xml:space="preserve"><value>Stäng</value></data>
+  <data name="Continue" xml:space="preserve"><value>Fortsätt</value></data>
+  <data name="Review" xml:space="preserve"><value>Granska</value></data>
+  <data name="ReviewHint" xml:space="preserve"><value>Kontrollera uppgifterna nedan och spara sedan.</value></data>
+  <data name="RequiredFieldsMissing" xml:space="preserve"><value>Fyll i de markerade fälten innan du fortsätter.</value></data>
+  <data name="NoRowsHelp" xml:space="preserve"><value>Inget här ännu. Använd knapparna ovan för att skapa den första.</value></data>
+  <data name="HelpWorkOrders" xml:space="preserve"><value>En arbetsorder är en reparation eller inspektion, från begäran till verifierad åtgärd.</value></data>
+  <data name="StepOrderDescribe" xml:space="preserve"><value>Beskriv arbetet</value></data>
+  <data name="StepOrderDescribeHint" xml:space="preserve"><value>Vad som behöver göras, hur brådskande det är och när det behövs.</value></data>
+  <data name="StepOrderTarget" xml:space="preserve"><value>Vad det gäller</value></data>
+  <data name="StepOrderTargetHint" xml:space="preserve"><value>Fordonet, stationen eller tillgången arbetet gäller, och var den finns.</value></data>
+  <data name="StepOrderCost" xml:space="preserve"><value>Kostnad och leverantör</value></data>
+  <data name="StepOrderCostHint" xml:space="preserve"><value>Vad arbetet väntas kosta, vilken budget det belastar och vem som utför det.</value></data>
+  <data name="StepOrderSafety" xml:space="preserve"><value>Säkerhet och rutin</value></data>
+  <data name="StepOrderSafetyHint" xml:space="preserve"><value>De tillstånd, frånskiljningar och kvalifikationer arbetet kräver, och stegen att följa.</value></data>
+  <data name="StepRecurrenceScheduleHint" xml:space="preserve"><value>Hur ofta arbetet återkommer och inom vilket fönster besättningarna kan utföra det.</value></data>
+  <data name="StepRecurrenceUsageHint" xml:space="preserve"><value>Valfria mätar- eller tillståndsutlösare som tidigarelägger arbetet när användningen kräver.</value></data>
+  <data name="StepRecurrenceAssignmentHint" xml:space="preserve"><value>Vem den skapade arbetsordern går till, och vem den eskaleras till om ingen tar den.</value></data>
+  <data name="HelpFieldDueOn" xml:space="preserve"><value>Styr förseningsmarkeringen och servicenivåklockan.</value></data>
+  <data name="HelpFieldSteps" xml:space="preserve"><value>Stegen teknikern arbetar igenom. Vissa statusbyten kräver att alla är klara.</value></data>
 </root>

--- a/Core/Resgrid.Localization/Areas/User/WorkOrders/WorkOrders.uk.resx
+++ b/Core/Resgrid.Localization/Areas/User/WorkOrders/WorkOrders.uk.resx
@@ -376,4 +376,25 @@
 <data name="WorkOrderPolicyChanged" xml:space="preserve"><value>Правила операцій нарядів змінено</value></data>
 <data name="ResponseDueOn" xml:space="preserve"><value>Кінцевий термін реагування (UTC)</value></data>
 <data name="RepairDueOn" xml:space="preserve"><value>Кінцевий термін ремонту (UTC)</value></data>
+  <data name="WorkOrdersIntro" xml:space="preserve"><value>Створюйте ремонти, стежте за виконавцями та дивіться вартість обслуговування.</value></data>
+  <data name="Close" xml:space="preserve"><value>Закрити</value></data>
+  <data name="Continue" xml:space="preserve"><value>Продовжити</value></data>
+  <data name="Review" xml:space="preserve"><value>Перевірка</value></data>
+  <data name="ReviewHint" xml:space="preserve"><value>Перевірте відповіді нижче та збережіть.</value></data>
+  <data name="RequiredFieldsMissing" xml:space="preserve"><value>Заповніть підсвічені поля, перш ніж продовжити.</value></data>
+  <data name="NoRowsHelp" xml:space="preserve"><value>Тут ще нічого немає. Скористайтеся кнопками вище, щоб створити перший запис.</value></data>
+  <data name="HelpWorkOrders" xml:space="preserve"><value>Наряд — це один ремонт або огляд, від заявки до перевіреного усунення.</value></data>
+  <data name="StepOrderDescribe" xml:space="preserve"><value>Опишіть роботу</value></data>
+  <data name="StepOrderDescribeHint" xml:space="preserve"><value>Що потрібно зробити, наскільки терміново і до якого часу.</value></data>
+  <data name="StepOrderTarget" xml:space="preserve"><value>Чого це стосується</value></data>
+  <data name="StepOrderTargetHint" xml:space="preserve"><value>Техніка, частина або актив, якого стосується робота, і де його знайти.</value></data>
+  <data name="StepOrderCost" xml:space="preserve"><value>Вартість і постачальник</value></data>
+  <data name="StepOrderCostHint" xml:space="preserve"><value>Скільки очікувано коштуватиме, на який бюджет лягає і хто виконує.</value></data>
+  <data name="StepOrderSafety" xml:space="preserve"><value>Безпека та процедура</value></data>
+  <data name="StepOrderSafetyHint" xml:space="preserve"><value>Потрібні дозволи, від'єднання та кваліфікації, а також кроки виконання.</value></data>
+  <data name="StepRecurrenceScheduleHint" xml:space="preserve"><value>Як часто повторюється робота і в якому вікні її можна виконати.</value></data>
+  <data name="StepRecurrenceUsageHint" xml:space="preserve"><value>Необов'язкові тригери лічильника чи стану, що створюють роботу раніше за показниками.</value></data>
+  <data name="StepRecurrenceAssignmentHint" xml:space="preserve"><value>Кому надходить створений наряд і кому ескалюється, якщо ніхто його не взяв.</value></data>
+  <data name="HelpFieldDueOn" xml:space="preserve"><value>Визначає позначку прострочення та відлік рівня обслуговування.</value></data>
+  <data name="HelpFieldSteps" xml:space="preserve"><value>Кроки, які виконує технік. Деякі переходи вимагають завершення всіх.</value></data>
 </root>

--- a/Core/Resgrid.Localization/Common.ar.resx
+++ b/Core/Resgrid.Localization/Common.ar.resx
@@ -297,4 +297,5 @@
     <value>ملف القسم</value>
   </data>
   <data name="RecordsLegalHoldsModule" xml:space="preserve"><value>حالات حفظ السجلات</value></data>
+  <data name="RecordsAllModule" xml:space="preserve"><value>كل السجلات</value></data>
 </root>

--- a/Core/Resgrid.Localization/Common.de.resx
+++ b/Core/Resgrid.Localization/Common.de.resx
@@ -730,4 +730,5 @@
     <value>Abteilungsprofil</value>
   </data>
   <data name="RecordsLegalHoldsModule" xml:space="preserve"><value>Aufbewahrungssperren für Akten</value></data>
+  <data name="RecordsAllModule" xml:space="preserve"><value>Alle Akten</value></data>
 </root>

--- a/Core/Resgrid.Localization/Common.el.resx
+++ b/Core/Resgrid.Localization/Common.el.resx
@@ -782,4 +782,5 @@
     <value>Προφίλ υπηρεσίας</value>
   </data>
   <data name="RecordsLegalHoldsModule" xml:space="preserve"><value>Δεσμεύσεις διατήρησης αρχείων</value></data>
+  <data name="RecordsAllModule" xml:space="preserve"><value>Όλα τα αρχεία</value></data>
 </root>

--- a/Core/Resgrid.Localization/Common.en.resx
+++ b/Core/Resgrid.Localization/Common.en.resx
@@ -782,4 +782,5 @@
     <value>Department Profile</value>
   </data>
   <data name="RecordsLegalHoldsModule" xml:space="preserve"><value>Records preservation holds</value></data>
+  <data name="RecordsAllModule" xml:space="preserve"><value>All records</value></data>
 </root>

--- a/Core/Resgrid.Localization/Common.es.resx
+++ b/Core/Resgrid.Localization/Common.es.resx
@@ -770,4 +770,5 @@
     <value>Perfil del departamento</value>
   </data>
   <data name="RecordsLegalHoldsModule" xml:space="preserve"><value>Retenciones de conservación de registros</value></data>
+  <data name="RecordsAllModule" xml:space="preserve"><value>Todos los registros</value></data>
 </root>

--- a/Core/Resgrid.Localization/Common.fr.resx
+++ b/Core/Resgrid.Localization/Common.fr.resx
@@ -730,4 +730,5 @@
     <value>Profil du service</value>
   </data>
   <data name="RecordsLegalHoldsModule" xml:space="preserve"><value>Conservations légales des dossiers</value></data>
+  <data name="RecordsAllModule" xml:space="preserve"><value>Tous les dossiers</value></data>
 </root>

--- a/Core/Resgrid.Localization/Common.it.resx
+++ b/Core/Resgrid.Localization/Common.it.resx
@@ -730,4 +730,5 @@
     <value>Profilo del dipartimento</value>
   </data>
   <data name="RecordsLegalHoldsModule" xml:space="preserve"><value>Blocchi di conservazione dei registri</value></data>
+  <data name="RecordsAllModule" xml:space="preserve"><value>Tutti i registri</value></data>
 </root>

--- a/Core/Resgrid.Localization/Common.pl.resx
+++ b/Core/Resgrid.Localization/Common.pl.resx
@@ -730,4 +730,5 @@
     <value>Profil wydziału</value>
   </data>
   <data name="RecordsLegalHoldsModule" xml:space="preserve"><value>Blokady zachowania rejestrów</value></data>
+  <data name="RecordsAllModule" xml:space="preserve"><value>Wszystkie rejestry</value></data>
 </root>

--- a/Core/Resgrid.Localization/Common.sv.resx
+++ b/Core/Resgrid.Localization/Common.sv.resx
@@ -730,4 +730,5 @@
     <value>Avdelningsprofil</value>
   </data>
   <data name="RecordsLegalHoldsModule" xml:space="preserve"><value>Bevarandespärrar för journaler</value></data>
+  <data name="RecordsAllModule" xml:space="preserve"><value>Alla journaler</value></data>
 </root>

--- a/Core/Resgrid.Localization/Common.uk.resx
+++ b/Core/Resgrid.Localization/Common.uk.resx
@@ -730,4 +730,5 @@
     <value>Профіль підрозділу</value>
   </data>
   <data name="RecordsLegalHoldsModule" xml:space="preserve"><value>Утримання записів для збереження</value></data>
+  <data name="RecordsAllModule" xml:space="preserve"><value>Усі записи</value></data>
 </root>

--- a/Core/Resgrid.Model/Records/RecordsContracts.cs
+++ b/Core/Resgrid.Model/Records/RecordsContracts.cs
@@ -1,26 +1,36 @@
 using System;
 using System.Collections.Generic;
+using ProtoBuf;
 
 namespace Resgrid.Model
 {
 	/// <summary>Records module state for one department (flag plus append-only cutover fact).</summary>
+	/// <remarks>Cached through ICacheProvider (RmsModuleState_{departmentId}), so it must be a protobuf contract.</remarks>
+	[ProtoContract]
 	public class RecordsModuleState
 	{
+		[ProtoMember(1)]
 		public int DepartmentId { get; set; }
 
 		/// <summary>Records.System evaluates on for this department.</summary>
+		[ProtoMember(2)]
 		public bool FlagEnabled { get; set; }
 
 		/// <summary>An RmsDepartmentCutover row exists.</summary>
+		[ProtoMember(3)]
 		public bool Activated { get; set; }
 
+		[ProtoMember(4)]
 		public DateTime? ActivatedOn { get; set; }
 
+		[ProtoMember(5)]
 		public int? CutoverId { get; set; }
 
+		[ProtoMember(6)]
 		public RmsDepartmentCutoverState? CutoverState { get; set; }
 
 		/// <summary>True when every legacy Log/UnitLog mutation must be denied (cutover active).</summary>
+		[ProtoMember(7)]
 		public bool LegacyWritesBlocked { get; set; }
 
 		/// <summary>Records routes are usable: flag on and cutover active.</summary>

--- a/Core/Resgrid.Model/Records/RmsAuditEnums.cs
+++ b/Core/Resgrid.Model/Records/RmsAuditEnums.cs
@@ -50,5 +50,20 @@ namespace Resgrid.Model
 	{
 		public const string Records = "Records";
 		public const string RecordsAggregate = "RmsOperationalRecord";
+		public const string IncidentReportAggregate = "RmsIncidentReport";
+		public const string IncidentAnalysisAggregate = "RmsIncidentAnalysis";
+		public const string LegalHoldAggregate = "RmsRecordLegalHold";
+
+		/// <summary>
+		/// The aggregate types whose AggregateId is a Record (operational record, incident report or incident analysis).
+		/// Only these are subject to the live-content guard when an outbox row is written: the guard locks the
+		/// owning Record row and refuses to write against a missing or purged Record. Every other Records-subsystem
+		/// aggregate (definitions, disclosures, export templates, inspections, permits, scope-only legal holds …) is
+		/// keyed by its own id and must not be looked up in the Record tables.
+		/// </summary>
+		public static bool IsRecordContentAggregate(string aggregateType) =>
+			string.Equals(aggregateType, RecordsAggregate, System.StringComparison.OrdinalIgnoreCase) ||
+			string.Equals(aggregateType, IncidentReportAggregate, System.StringComparison.OrdinalIgnoreCase) ||
+			string.Equals(aggregateType, IncidentAnalysisAggregate, System.StringComparison.OrdinalIgnoreCase);
 	}
 }

--- a/Core/Resgrid.Services/Records/DomainEventOutboxService.cs
+++ b/Core/Resgrid.Services/Records/DomainEventOutboxService.cs
@@ -49,6 +49,9 @@ namespace Resgrid.Services.Records
 			if (envelope == null) throw new ArgumentNullException(nameof(envelope));
 			if (string.IsNullOrWhiteSpace(envelope.EventName)) throw new ArgumentException("EventName is required.", nameof(envelope));
 			if (string.IsNullOrWhiteSpace(envelope.AggregateId)) throw new ArgumentException("AggregateId is required.", nameof(envelope));
+			// The Records outbox repository decides whether to apply the live-content guard from the aggregate type, so a
+			// Records-subsystem event must always say what kind of aggregate its id names.
+			if (producerSubsystem == DomainEventProducers.Records && string.IsNullOrWhiteSpace(envelope.AggregateType)) throw new ArgumentException("AggregateType is required for Records events.", nameof(envelope));
 
 			var now = DateTime.UtcNow;
 			var entry = new DomainEventOutboxEntry

--- a/Core/Resgrid.Services/Records/IncidentAnalysisService.cs
+++ b/Core/Resgrid.Services/Records/IncidentAnalysisService.cs
@@ -26,7 +26,7 @@ namespace Resgrid.Services.Records
 	/// </summary>
 	public class IncidentAnalysisService : IIncidentAnalysisService
 	{
-		public const string AnalysisAggregate = "RmsIncidentAnalysis";
+		public const string AnalysisAggregate = DomainEventProducers.IncidentAnalysisAggregate;
 
 		private readonly IRmsIncidentAnalysesRepository _analyses;
 		private readonly IRmsIncidentReportsRepository _reports;

--- a/Core/Resgrid.Services/Records/IncidentReportsService.cs
+++ b/Core/Resgrid.Services/Records/IncidentReportsService.cs
@@ -27,7 +27,7 @@ namespace Resgrid.Services.Records
 	public class IncidentReportsService : IIncidentReportsService
 	{
 		public const string AttestationStatementVersion = "1";
-		public const string IncidentAggregate = "RmsIncidentReport";
+		public const string IncidentAggregate = DomainEventProducers.IncidentReportAggregate;
 		public const string DispatchCommentFactPrefix = "dispatch.comment.";
 		public const string NumberPrefix = "INC";
 

--- a/Core/Resgrid.Services/Records/RecordsLegalHoldService.cs
+++ b/Core/Resgrid.Services/Records/RecordsLegalHoldService.cs
@@ -106,7 +106,9 @@ namespace Resgrid.Services.Records
 		private async Task<long> EnqueueAsync(RmsRecordLegalHold hold, WorkflowTriggerEventType trigger, CancellationToken cancellationToken)
 		{
 			object recordBlock = new { id = hold.RecordId, kind = (string)null, department_id = hold.DepartmentId };
-			var aggregateType = DomainEventProducers.RecordsAggregate;
+			// A scope-only hold (definition/date scope, no record) is its own aggregate: the outbox guard must not look its
+			// id up as a Record. Holds on a specific record keep the record as the aggregate so purge protection applies.
+			var aggregateType = hold.RecordId != null ? DomainEventProducers.RecordsAggregate : DomainEventProducers.LegalHoldAggregate;
 			if (hold.RecordId != null)
 			{
 				var record = await _records.GetByIdForDepartmentAsync(hold.DepartmentId, hold.RecordId);

--- a/Repositories/Resgrid.Repositories.DataRepository/RmsPreventionRepositories.cs
+++ b/Repositories/Resgrid.Repositories.DataRepository/RmsPreventionRepositories.cs
@@ -332,10 +332,10 @@ namespace Resgrid.Repositories.DataRepository
 		{
 			var ids = InListValue(occupancyIds);
 			if (ids.Length == 0) return new Dictionary<string, int>(StringComparer.Ordinal);
-			var rows = await QueryAsync<(string OccupancyId, int Open)>(
-				$"SELECT {Col("RmsOccupancyId")} AS OccupancyId, COUNT(1) AS Open FROM {Tbl("RmsViolations")} WHERE {Col("DepartmentId")} = {P}DepartmentId AND {InList("RmsOccupancyId", "Ids")} AND {OpenStates} AND {Col("DeletedOn")} IS NULL GROUP BY {Col("RmsOccupancyId")}",
+			var rows = await QueryAsync<(string OccupancyId, int OpenCount)>(
+				$"SELECT {Col("RmsOccupancyId")} AS OccupancyId, COUNT(1) AS OpenCount FROM {Tbl("RmsViolations")} WHERE {Col("DepartmentId")} = {P}DepartmentId AND {InList("RmsOccupancyId", "Ids")} AND {OpenStates} AND {Col("DeletedOn")} IS NULL GROUP BY {Col("RmsOccupancyId")}",
 				new { DepartmentId = departmentId, Ids = ids });
-			return rows.ToDictionary(r => r.OccupancyId, r => r.Open, StringComparer.Ordinal);
+			return rows.ToDictionary(r => r.OccupancyId, r => r.OpenCount, StringComparer.Ordinal);
 		}
 
 		public Task<IEnumerable<RmsViolation>> GetForRangeAsync(int departmentId, DateTime startUtc, DateTime endUtc, int take)

--- a/Repositories/Resgrid.Repositories.DataRepository/RmsRepositories.cs
+++ b/Repositories/Resgrid.Repositories.DataRepository/RmsRepositories.cs
@@ -695,7 +695,11 @@ AND NOT EXISTS (SELECT 1 FROM {Tbl("RmsRecordLegalHoldMembers")} m WHERE m.{Col(
 
 		public override async Task<DomainEventOutboxEntry> InsertAsync(DomainEventOutboxEntry entity, CancellationToken cancellationToken, bool firstLevelOnly = false)
 		{
-			if (entity?.ProducerSubsystem != DomainEventProducers.Records) return await base.InsertAsync(entity, cancellationToken, firstLevelOnly);
+			// The live-content guard only makes sense when AggregateId names a Record. Records-subsystem events about
+			// definitions, disclosures, export templates, inspections, permits or scope-only legal holds carry their own
+			// aggregate id, which has no row in the Record tables and must not be reported as "missing or purged".
+			if (entity?.ProducerSubsystem != DomainEventProducers.Records || !DomainEventProducers.IsRecordContentAggregate(entity.AggregateType))
+				return await base.InsertAsync(entity, cancellationToken, firstLevelOnly);
 			var owns = UnitOfWork.Transaction == null;
 			UnitOfWork.CreateOrGetConnection();
 			try

--- a/Tests/Resgrid.Tests/Rms/FakeRmsStore.cs
+++ b/Tests/Resgrid.Tests/Rms/FakeRmsStore.cs
@@ -60,6 +60,9 @@ namespace Resgrid.Tests.Rms
 
 		private long _outboxSeed;
 
+		/// <summary>Enable the outbox live-content guard of the real repository (off by default so existing harnesses are unaffected).</summary>
+		public bool LiveContentGuard { get; set; }
+
 		public FakeRmsStore()
 		{
 			UnitOfWork.Setup(u => u.CommitChanges()).Callback(() => Commits++);
@@ -185,9 +188,17 @@ namespace Resgrid.Tests.Rms
 			AuditsRepo.Setup(r => r.InsertAsync(It.IsAny<RmsAccessAudit>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()))
 				.ReturnsAsync((RmsAccessAudit e, CancellationToken c, bool f) => { Audits.Add(e); return e; });
 
-			// Outbox
+			// Outbox. When LiveContentGuard is on, the fake mirrors DomainEventOutboxRepository.InsertAsync: a Records event whose
+			// aggregate type names a Record must point at a live operational record in this store, exactly like the real
+			// repository locks the Record row and refuses a missing or purged one. Non-record aggregates pass straight through.
 			OutboxRepo.Setup(r => r.InsertAsync(It.IsAny<DomainEventOutboxEntry>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()))
-				.ReturnsAsync((DomainEventOutboxEntry e, CancellationToken c, bool f) => { e.DomainEventOutboxId = ++_outboxSeed; Outbox.Add(e); return e; });
+				.ReturnsAsync((DomainEventOutboxEntry e, CancellationToken c, bool f) =>
+				{
+					if (LiveContentGuard && e.ProducerSubsystem == DomainEventProducers.Records && DomainEventProducers.IsRecordContentAggregate(e.AggregateType)
+						&& !Records.Any(x => x.DepartmentId == e.DepartmentId && x.RmsOperationalRecordId == e.AggregateId && x.PurgedOn == null && x.DeletedOn == null))
+						throw new InvalidOperationException("Content cannot be written to a missing or purged RMS record.");
+					e.DomainEventOutboxId = ++_outboxSeed; Outbox.Add(e); return e;
+				});
 			OutboxRepo.Setup(r => r.GetNextSequenceAsync(It.IsAny<int>(), It.IsAny<string>()))
 				.ReturnsAsync((int d, string a) => Outbox.Where(x => x.DepartmentId == d && x.AggregateId == a).Select(x => x.Sequence).DefaultIfEmpty(0).Max() + 1);
 			OutboxRepo.Setup(r => r.ClaimByIdAsync(It.IsAny<long>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))

--- a/Tests/Resgrid.Tests/Rms/RecordDefinitionsServiceTests.cs
+++ b/Tests/Resgrid.Tests/Rms/RecordDefinitionsServiceTests.cs
@@ -155,6 +155,56 @@ namespace Resgrid.Tests.Rms
 			await stale.Should().ThrowAsync<RecordConcurrencyException>();
 		}
 
+		/// <summary>
+		/// Regression: publishing a department definition created from a template failed with "Content cannot be written
+		/// to a missing or purged RMS record" because the Records outbox repository applied the live-content guard to every
+		/// Records event, including definition events whose aggregate id is the definition, not a Record. The harness
+		/// runs the same guard, so this test fails without the aggregate-type discrimination in DomainEventOutboxRepository.
+		/// </summary>
+		[Test]
+		public async Task Publish_and_retire_of_a_template_created_definition_pass_the_outbox_live_content_guard()
+		{
+			var aggregate = await _h.Definitions.CreateAsync(Dept, Admin, new RecordDefinitionCreateInput
+			{
+				DefinitionKey = "ops.security-patrol", Name = "Security Patrol Log", Category = "Security", TemplateKey = "template.security-patrol", JurisdictionProfileKey = "us"
+			});
+			aggregate.Draft.Should().NotBeNull();
+			(await _h.Definitions.ValidateAsync(Dept, RecordDefinitionsService.ToDraftInput(aggregate.Draft, aggregate.Definition))).IsValid.Should().BeTrue();
+
+			var published = await _h.PublishAsync("ops.security-patrol");
+			published.IsPublished.Should().BeTrue();
+			published.DefinitionKey.Should().Be("ops.security-patrol");
+			_h.Defs.Definitions.Single().CurrentPublishedVersion.Should().Be(1);
+			var publishedEvent = _h.Events(WorkflowTriggerEventType.RecordDefinitionPublished).Should().ContainSingle().Which;
+			publishedEvent.AggregateType.Should().Be(RecordDefinitionsService.DefinitionAggregate);
+			publishedEvent.AggregateId.Should().Be(aggregate.Definition.RmsRecordDefinitionId, "the definition, not a Record, is the aggregate");
+			DomainEventProducers.IsRecordContentAggregate(publishedEvent.AggregateType).Should().BeFalse();
+			_h.Published.Should().ContainSingle(e => e.EventName == WorkflowTriggerEventType.RecordDefinitionPublished.ToString());
+
+			var definition = _h.Defs.Definitions.Single();
+			var retired = await _h.Definitions.RetireAsync(Dept, Admin, "ops.security-patrol", definition.RowVersion, "Superseded by the v2 patrol log");
+			retired.IsRetired.Should().BeTrue();
+			_h.Events(WorkflowTriggerEventType.RecordDefinitionRetired).Should().ContainSingle().Which.AggregateType.Should().Be(RecordDefinitionsService.DefinitionAggregate);
+		}
+
+		[Test]
+		public async Task Outbox_guard_still_refuses_record_events_for_a_missing_record()
+		{
+			// The guard the definition test relies on is live in this harness: a Records event that names a Record which
+			// does not exist is refused, exactly as the repository does for a missing or purged row.
+			Func<Task> missing = () => _h.Outbox.EnqueueAsync(Dept, DomainEventProducers.Records, new DomainEventEnvelope
+			{
+				EventName = WorkflowTriggerEventType.RecordFinalized.ToString(), SchemaVersion = 1, AggregateType = DomainEventProducers.RecordsAggregate, AggregateId = "no-such-record", AggregateVersion = 1
+			});
+			(await missing.Should().ThrowAsync<InvalidOperationException>()).Which.Message.Should().Contain("missing or purged");
+
+			Func<Task> untyped = () => _h.Outbox.EnqueueAsync(Dept, DomainEventProducers.Records, new DomainEventEnvelope
+			{
+				EventName = WorkflowTriggerEventType.RecordDefinitionPublished.ToString(), SchemaVersion = 1, AggregateId = "def-1", AggregateVersion = 1
+			});
+			(await untyped.Should().ThrowAsync<ArgumentException>()).Which.Message.Should().Contain("AggregateType");
+		}
+
 		[Test]
 		public async Task Retire_marks_definition_and_versions_enqueues_114_and_blocks_new_drafts()
 		{

--- a/Tests/Resgrid.Tests/Rms/RmsDefinitionHarness.cs
+++ b/Tests/Resgrid.Tests/Rms/RmsDefinitionHarness.cs
@@ -88,6 +88,8 @@ namespace Resgrid.Tests.Rms
 
 			var aggregator = new Mock<IEventAggregator>();
 			aggregator.Setup(a => a.SendMessage(It.IsAny<DomainEventDispatchedEvent>())).Callback<DomainEventDispatchedEvent>(e => Published.Add(e));
+			// Definition, record and report events all go through the same outbox as production, guard included.
+			Store.LiveContentGuard = true;
 			Outbox = new DomainEventOutboxService(Store.OutboxRepo.Object, aggregator.Object);
 
 			Templates = new RecordTemplatePacksService(Defs.PacksRepo.Object, Defs.ProfilesRepo.Object);

--- a/Tests/Resgrid.Tests/Rms/RmsRetentionDatabaseTests.cs
+++ b/Tests/Resgrid.Tests/Rms/RmsRetentionDatabaseTests.cs
@@ -530,7 +530,7 @@ INSERT WorkflowRunLogs (WorkflowRunLogId,WorkflowRunId,RenderedOutput,ActionResu
 			var connections = Connections(); using var unit = new UnitOfWork(connections);
 			var events = new DomainEventOutboxRepository(connections, new SqlServerConfiguration(), unit, WriteQueries());
 			var dispatched = await events.InsertAsync(new DomainEventOutboxEntry { DepartmentId = 11, ProducerSubsystem = DomainEventProducers.Records,
-				EventId = Guid.NewGuid().ToString(), EventName = "test.analysis", AggregateType = "IncidentAnalysis", AggregateId = analysis, Sequence = 1,
+				EventId = Guid.NewGuid().ToString(), EventName = "test.analysis", AggregateType = DomainEventProducers.IncidentAnalysisAggregate, AggregateId = analysis, Sequence = 1,
 				SchemaVersion = 1, PayloadJson = "private outbox content", OccurredOn = old, CreatedOn = old }, CancellationToken.None, true);
 			await events.MarkDispatchedAsync(dispatched.DomainEventOutboxId, old);
 			foreach (var recordId in new[] { id, analysis })
@@ -663,6 +663,30 @@ INSERT RmsRecordAttachments (RmsRecordAttachmentId,DepartmentId,ProtectionId,Rec
 			await transaction.CommitAsync();
 			(await attempt).Held.Should().BeTrue();
 			(await holder.ExecuteScalarAsync<DateTime?>("SELECT PurgedOn FROM RmsOperationalRecords WHERE RmsOperationalRecordId=@Id", new { Id = id })).Should().BeNull();
+		}
+
+		[Test]
+		public async Task Outbox_live_content_guard_applies_only_to_record_aggregates()
+		{
+			// A definition publish/retire event (or any other Records-subsystem aggregate that is not a Record) is keyed by
+			// its own id; the guard must not look that id up in the Record tables and report it as missing or purged.
+			var connections = Connections(); using var unit = new UnitOfWork(connections);
+			var events = new DomainEventOutboxRepository(connections, new SqlServerConfiguration(), unit, WriteQueries());
+			DomainEventOutboxEntry Entry(string aggregateType, string aggregateId) => new DomainEventOutboxEntry
+			{
+				DepartmentId = 11, ProducerSubsystem = DomainEventProducers.Records, EventId = Guid.NewGuid().ToString(), EventName = "test.aggregate",
+				AggregateType = aggregateType, AggregateId = aggregateId, Sequence = 1, SchemaVersion = 1, PayloadJson = "{}", OccurredOn = DateTime.UtcNow, CreatedOn = DateTime.UtcNow
+			};
+			foreach (var aggregateType in new[] { "RmsRecordDefinition", "RmsDisclosureRequest", "RmsExportTemplate", "RmsInspection", "RmsPermit", DomainEventProducers.LegalHoldAggregate })
+			{
+				var stored = await events.InsertAsync(Entry(aggregateType, Guid.NewGuid().ToString()), CancellationToken.None, true);
+				stored.DomainEventOutboxId.Should().BeGreaterThan(0, aggregateType + " is not a Record and must not be guarded");
+			}
+			foreach (var aggregateType in new[] { DomainEventProducers.RecordsAggregate, DomainEventProducers.IncidentReportAggregate, DomainEventProducers.IncidentAnalysisAggregate })
+			{
+				Func<Task> missing = () => events.InsertAsync(Entry(aggregateType, Guid.NewGuid().ToString()), CancellationToken.None, true);
+				(await missing.Should().ThrowAsync<InvalidOperationException>(aggregateType + " names a Record that does not exist")).Which.Message.Should().Contain("missing or purged");
+			}
 		}
 	}
 }

--- a/Tests/Resgrid.Tests/Services/ChecklistPr504BoundaryTests.cs
+++ b/Tests/Resgrid.Tests/Services/ChecklistPr504BoundaryTests.cs
@@ -106,9 +106,11 @@ namespace Resgrid.Tests.Services
 				var html = await response.Content.ReadAsStringAsync(); response.StatusCode.Should().Be(HttpStatusCode.OK, html);
 				html.Should().NotContain("<script>").And.NotContain("<a onmouseover=").And.Contain("&lt;script&gt;");
 				var links = Regex.Matches(html, "href=\"([^\"]+)\"").Select(m => WebUtility.HtmlDecode(m.Groups[1].Value)).ToList();
-				links.Should().HaveCount(canEdit ? 5 : 3, "each edit/navigation link must remain one attribute");
+				// No href anywhere on the page may break out of its attribute, including the
+				// module chrome (breadcrumb and tab strip) that carries no untrusted input.
 				links.Should().OnlyContain(link => !link.Contains("<") && !link.Contains("\""));
-				links.Select(Uri.UnescapeDataString).Should().OnlyContain(link => link.Contains(attack));
+				var untrusted = links.Where(link => Uri.UnescapeDataString(link).Contains(attack)).ToList();
+				untrusted.Should().HaveCount(canEdit ? 5 : 3, "each edit/navigation link must remain one attribute");
 			}
 			finally { await app.StopAsync(); ClaimsAuthorizationHelper._httpContextAccessor = previous; }
 		}

--- a/Tests/Resgrid.Tests/Web/side-navigation.test.cjs
+++ b/Tests/Resgrid.Tests/Web/side-navigation.test.cjs
@@ -1,0 +1,110 @@
+// Sidebar module list (_Navigation.cshtml + metisMenu, initialised in site.js).
+//
+// Records owns a dozen screens, so its links sit in a collapsible group instead of a dozen
+// top level entries. These cases pin the behaviour the markup depends on: the group is open
+// when the user is already on a records page, the header toggles it, and following a child
+// link is not treated as a toggle.
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const { chromium } = require('./browser-launch.cjs').playwright();
+
+const root = path.resolve(__dirname, '../../..');
+const wwwroot = path.join(root, 'Web/Resgrid.Web/wwwroot');
+
+// A trimmed copy of the sidebar: two flat modules either side of the Records group. The
+// classes are exactly what the Razor partial emits.
+function menu(recordsOpen) {
+    return `
+<ul class="nav" id="side-menu">
+    <li id="flat-home"><a href="/User/Home/Dashboard"><i class="fa fa-home"></i> <span class="nav-label">Home</span></a></li>
+    <li id="records" class="${recordsOpen ? 'active mm-active' : ''}">
+        <a href="#" id="records-header" aria-expanded="${recordsOpen ? 'true' : 'false'}">
+            <i class="fa fa-file"></i>
+            <span class="nav-label">Records</span>
+            <span class="fa arrow"></span>
+        </a>
+        <ul class="nav nav-second-level" id="records-menu">
+            <li id="records-all" class="${recordsOpen ? 'active' : ''}"><a href="/User/Records">All records</a></li>
+            <li id="records-holds"><a href="/User/RecordLegalHolds">Records preservation holds</a></li>
+            <li id="records-analytics"><a href="/User/RecordsAnalytics">Analytics</a></li>
+        </ul>
+    </li>
+    <li id="flat-inventory"><a href="/User/Inventory"><i class="fa fa-barcode"></i> <span class="nav-label">Inventory</span></a></li>
+</ul>`;
+}
+
+async function build(browser, recordsOpen) {
+    const page = await browser.newPage();
+    await page.setContent(menu(recordsOpen));
+    await page.addScriptTag({ path: path.join(wwwroot, 'lib/jquery/dist/jquery.min.js') });
+    await page.addScriptTag({ path: path.join(wwwroot, 'lib/metisMenu/dist/metisMenu.min.js') });
+    await page.addStyleTag({ path: path.join(wwwroot, 'lib/metisMenu/dist/metisMenu.min.css') });
+    // The same call site.js makes on every page.
+    await page.evaluate(() => window.jQuery('#side-menu').metisMenu());
+    return page;
+}
+
+const visible = (page, selector) => page.evaluate((s) => {
+    const element = document.querySelector(s);
+    return !!element && element.getBoundingClientRect().height > 0;
+}, selector);
+
+(async () => {
+    const browser = await chromium.launch(require('./browser-launch.cjs').launchOptions());
+    try {
+        // A records page: the group is open, and its links are reachable without a click.
+        let page = await build(browser, true);
+        assert.equal(await page.$eval('#records-menu', (el) => el.classList.contains('mm-show')), true,
+            'The Records group did not open on a records page.');
+        assert.equal(await visible(page, '#records-holds'), true, 'Records children were hidden while the group was open.');
+        assert.equal(await page.$eval('#records-header', (el) => el.getAttribute('aria-expanded')), 'true',
+            'The open group did not report itself as expanded.');
+
+        // Collapsing hides the children and flips the arrow state.
+        await page.click('#records-header');
+        await page.waitForFunction(() => { const menu = document.querySelector('#records-menu'); return menu.classList.contains('mm-collapse') && !menu.classList.contains('mm-collapsing') && !menu.classList.contains('mm-show'); });
+        assert.equal(await visible(page, '#records-holds'), false, 'Collapsing the group left its children on screen.');
+        assert.equal(await page.$eval('#records', (el) => el.classList.contains('mm-active')), false,
+            'The collapsed group still reported itself as expanded.');
+        assert.equal(await page.$eval('#records', (el) => el.classList.contains('active')), true,
+            'Collapsing the group dropped the highlight for the page the user is on.');
+
+        // And expanding again brings them back.
+        await page.click('#records-header');
+        await page.waitForFunction(() => document.querySelector('#records-menu').classList.contains('mm-show') && document.querySelector('#records-menu').getBoundingClientRect().height > 0);
+        assert.equal(await visible(page, '#records-holds'), true, 'Re-expanding the group did not restore its children.');
+        await page.close();
+
+        // Anywhere else: the group is closed, so the sidebar shows one Records entry, not a dozen.
+        page = await build(browser, false);
+        assert.equal(await visible(page, '#records-holds'), false, 'The Records group was open on an unrelated page.');
+        assert.equal(await visible(page, '#flat-home'), true, 'The flat modules disappeared.');
+        assert.equal(await visible(page, '#flat-inventory'), true, 'The flat modules disappeared.');
+
+        await page.click('#records-header');
+        await page.waitForFunction(() => document.querySelector('#records-menu').classList.contains('mm-show') && document.querySelector('#records-menu').getBoundingClientRect().height > 0);
+        assert.equal(await visible(page, '#records-analytics'), true, 'Opening the group did not reveal its children.');
+
+        // A child link navigates; it must not be swallowed as a toggle.
+        const target = await page.$eval('#records-analytics a', (el) => el.getAttribute('href'));
+        assert.equal(target, '/User/RecordsAnalytics');
+        await page.evaluate(() => {
+            window.__navigated = null;
+            document.querySelector('#records-analytics a').addEventListener('click', (event) => {
+                window.__navigated = { href: event.currentTarget.getAttribute('href'), prevented: event.defaultPrevented };
+                event.preventDefault();
+            });
+        });
+        await page.click('#records-analytics a');
+        const followed = await page.evaluate(() => window.__navigated);
+        assert.deepEqual(followed, { href: '/User/RecordsAnalytics', prevented: false },
+            'A child link was cancelled instead of navigating.');
+        assert.equal(await page.$eval('#records-menu', (el) => el.classList.contains('mm-show')), true,
+            'Following a child link collapsed the group.');
+        await page.close();
+
+        console.log('Sidebar Records group expand, collapse and child navigation passed.');
+    } finally {
+        await browser.close();
+    }
+})().catch((error) => { console.error(error); process.exit(1); });

--- a/Tests/Resgrid.Tests/Web/workspace-wizard.test.cjs
+++ b/Tests/Resgrid.Tests/Web/workspace-wizard.test.cjs
@@ -1,0 +1,146 @@
+// Shared workspace step wizard (js/app/common/workspace/resgrid.common.workspace.js).
+//
+// The wizard turns native validation off, because a browser refuses to report a required
+// field that sits on a hidden step. These cases pin the behaviour that replaces it: a step
+// cannot be left while it is incomplete, and a submit from the last step jumps back to the
+// step that is actually missing an answer instead of posting a half-filled command.
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { chromium } = require('./browser-launch.cjs').playwright();
+
+const root = path.resolve(__dirname, '../../..');
+const script = fs.readFileSync(path.join(root, 'Web/Resgrid.Web/wwwroot/js/app/common/workspace/resgrid.common.workspace.js'), 'utf8');
+
+const markup = `
+<script id="workspace-settings" type="application/json">{"required":"Fill in the highlighted fields.","nothingEntered":"Nothing entered","yes":"Yes","no":"No"}</script>
+<form id="wizard" class="rgw-wizard" method="post">
+    <input type="hidden" name="RequestId" value="abc" />
+    <ol class="rgw-steps"></ol>
+    <div class="rgw-step" data-title="What">
+        <h4>What</h4>
+        <div class="rgw-grid">
+            <div class="form-group">
+                <label for="item">Item</label>
+                <select class="form-control" id="item" name="ItemId" required>
+                    <option value="">&mdash;</option>
+                    <option value="item-a">Bandages</option>
+                </select>
+            </div>
+        </div>
+    </div>
+    <div class="rgw-step" data-title="How much">
+        <h4>How much</h4>
+        <div class="rgw-grid">
+            <div class="form-group">
+                <label for="qty">Amount</label>
+                <input class="form-control" id="qty" name="Quantity" type="number" required />
+            </div>
+            <div class="form-group">
+                <label for="note">Note</label>
+                <input class="form-control" id="note" name="Note" />
+            </div>
+            <div class="form-group">
+                <label>Days</label>
+                <div>
+                    <label class="checkbox-inline"><input type="checkbox" name="days" value="1" data-review-skip="true" checked /> Monday</label>
+                    <label class="checkbox-inline"><input type="checkbox" name="days" value="2" data-review-skip="true" /> Tuesday</label>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="rgw-step" data-title="Review">
+        <h4>Review</h4>
+        <dl class="rgw-review"></dl>
+    </div>
+    <div class="rgw-wizard-actions">
+        <button type="button" class="btn rgw-step-prev">Back</button>
+        <button type="button" class="btn rgw-step-next">Continue</button>
+        <button type="submit" class="btn rgw-step-submit">Save</button>
+    </div>
+</form>`;
+
+(async () => {
+    const browser = await chromium.launch(require('./browser-launch.cjs').launchOptions());
+    try {
+        const page = await browser.newPage();
+        await page.setContent(markup);
+        await page.addScriptTag({ content: script });
+
+        const result = await page.evaluate(() => {
+            function check(condition, message) { if (!condition) throw new Error(message); }
+
+            const form = document.getElementById('wizard');
+            const steps = Array.from(form.querySelectorAll('.rgw-step'));
+            const next = form.querySelector('.rgw-step-next');
+            const previous = form.querySelector('.rgw-step-prev');
+            const submit = form.querySelector('.rgw-step-submit');
+            const indicator = form.querySelector('.rgw-steps');
+
+            // The wizard, not the browser, decides when a step is complete.
+            check(form.hasAttribute('novalidate'), 'The wizard left native validation on, which cannot report hidden steps.');
+
+            check(!steps[0].hidden && steps[1].hidden && steps[2].hidden, 'The wizard did not open on its first step.');
+            check(previous.hidden && !next.hidden && submit.hidden, 'The first step offered Back or Save.');
+            check(indicator.children.length === 3, 'The step indicator did not list every step.');
+            check(indicator.children[0].className === 'current' && Array.from(indicator.children).map(li => li.textContent).join('|') === '1What|2How much|3Review',
+                'The step indicator did not label the steps in order.');
+
+            // An incomplete step keeps the user where they are and says which field is missing.
+            next.click();
+            check(!steps[0].hidden, 'An incomplete step let the user continue.');
+            check(form.querySelector('#item').closest('.form-group').classList.contains('rgw-invalid'), 'The missing field was not marked.');
+            check((steps[0].querySelector('.rgw-step-error') || {}).hidden === false, 'No message explained why the step would not advance.');
+
+            form.querySelector('#item').value = 'item-a';
+            next.click();
+            check(steps[0].hidden && !steps[1].hidden, 'A completed step did not advance.');
+            check(!previous.hidden, 'Back was still hidden on the second step.');
+
+            previous.click();
+            check(!steps[0].hidden && !form.querySelector('#item').closest('.form-group').classList.contains('rgw-invalid'),
+                'Going back did not restore the first step or left it marked invalid.');
+
+            next.click();
+            form.querySelector('#qty').value = '4';
+            form.querySelector('#note').value = 'restock';
+            next.click();
+            check(!steps[2].hidden && next.hidden && !submit.hidden, 'The last step did not swap Continue for Save.');
+
+            // The review step reads back what was answered, skipping empty and hidden fields.
+            const review = Array.from(form.querySelectorAll('.rgw-review-row')).map(row => row.textContent);
+            check(review.length === 3, 'The review step did not list every answered field: ' + review.join(' / '));
+            check(review[0] === 'ItemBandages', 'The review step showed the option value instead of its label: ' + review[0]);
+            check(review[1] === 'Amount4' && review[2] === 'Noterestock', 'The review step lost a later answer: ' + review.join(' / '));
+            check(!review.some(row => row.includes('abc')), 'The review step exposed a hidden field.');
+            // A repeated checkbox group would otherwise list one Yes/No row per box, all sharing
+            // the group's single label, so those boxes opt out of the review.
+            check(!review.some(row => row.startsWith('Days')), 'A checkbox marked data-review-skip reached the review step.');
+
+            // A late edit that empties a required field must not slip through the review step.
+            const posts = [];
+            form.addEventListener('submit', event => { posts.push(event.defaultPrevented); event.preventDefault(); });
+
+            form.querySelector('#qty').value = '';
+            submit.click();
+            check(posts.length === 1 && posts[0] === true, 'A submit with an incomplete step was not cancelled.');
+            check(!steps[1].hidden, 'The cancelled submit did not return to the incomplete step.');
+            check(form.querySelector('#qty').closest('.form-group').classList.contains('rgw-invalid'), 'The incomplete field was not marked after the submit.');
+
+            const quantity = form.querySelector('#qty');
+            quantity.value = '4';
+            quantity.dispatchEvent(new Event('input', { bubbles: true }));
+            check(!quantity.closest('.form-group').classList.contains('rgw-invalid'), 'Typing did not clear the invalid mark.');
+
+            next.click();
+            submit.click();
+            check(posts.length === 2 && posts[1] === false, 'A complete wizard did not submit.');
+            return 'ok';
+        });
+
+        assert.equal(result, 'ok');
+        console.log('Workspace wizard step navigation, review and submit guard passed.');
+    } finally {
+        await browser.close();
+    }
+})().catch((error) => { console.error(error); process.exit(1); });

--- a/Tools/Resgrid.Console/Commands/FeatureFlagsCommand.cs
+++ b/Tools/Resgrid.Console/Commands/FeatureFlagsCommand.cs
@@ -1,0 +1,558 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Resgrid.Config;
+using Resgrid.Console.Models;
+using Resgrid.Model;
+using Resgrid.Model.Services;
+
+namespace Resgrid.Console.Commands
+{
+	/// <summary>
+	///     Reads and sets feature toggles without going through the admin UI or the API.
+	///     <para>
+	///     Two write scopes, matching the two things an operator actually needs. With no --DepartmentId,
+	///     --On/--Off sets the flag's global default, which is what every department that has no override
+	///     of its own resolves to. With --DepartmentId, it writes that department's override, which wins
+	///     over the percentage rollout and any targeting rules. --Clear removes an override and drops the
+	///     department back onto the global answer.
+	///     </para>
+	///     <para>
+	///     --List shows the flags that exist in the database; --Keys shows the keys application code
+	///     actually gates on, which is the list to check when a toggle "does nothing" because no
+	///     migration ever seeded a row for it.
+	///     </para>
+	///     <para>
+	///     Writes go through <see cref="IFeatureToggleService" />, so they invalidate the shared flag cache
+	///     and emit the same audit event the admin API does; web, API and worker nodes pick the change up
+	///     on their next read rather than after the cache duration expires.
+	///     </para>
+	/// </summary>
+	public sealed class FeatureFlagsCommand(
+		ILogger<FeatureFlagsCommand> logger,
+		IFeatureToggleService featureToggleService,
+		IDepartmentsService departmentsService) : ICommandService
+	{
+		/// <summary>
+		///     Executes the main functionality of the application.
+		/// </summary>
+		/// <param name="args">An array of command-line arguments passed to the application.</param>
+		/// <param name="cancellationToken">A token that can be used to signal the operation should be canceled.</param>
+		/// <returns>Returns an <see cref="ExitCode" /> indicating the result of the execution.</returns>
+		public async Task<ExitCode> ExecuteMainAsync(string[] args, CancellationToken cancellationToken)
+		{
+			try
+			{
+				if (!FeatureFlagsConfig.FeatureFlagsEnabled)
+					logger.LogWarning(
+						"FeatureFlagsConfig.FeatureFlagsEnabled is false. The whole toggle subsystem is off for this install, so every flag reads as disabled no matter what is set here.");
+
+				var key = GetValue(args, "Key");
+				var userId = GetValue(args, "UserId");
+
+				if (!TryGetInt(args, "DepartmentId", out var departmentId))
+					return Fail("--DepartmentId must be a whole number.");
+
+				var on = HasSwitch(args, "On");
+				var off = HasSwitch(args, "Off");
+
+				if (on && off)
+					return Fail("--On and --Off cannot both be passed.");
+
+				if (HasSwitch(args, "Rollout"))
+					return await SetRolloutAsync(args, key, userId, cancellationToken);
+
+				if (HasSwitch(args, "Clear"))
+					return await ClearOverrideAsync(key, departmentId, userId, cancellationToken);
+
+				if (on || off)
+					return await SetAsync(args, key, departmentId, on, userId, cancellationToken);
+
+				if (HasSwitch(args, "Keys"))
+					return await ListKeysAsync();
+
+				if (HasSwitch(args, "Show"))
+					return await ShowAsync(key, departmentId);
+
+				return await ListAsync(args, departmentId);
+			}
+			catch (OperationCanceledException)
+			{
+				throw;
+			}
+			catch (Exception ex)
+			{
+				logger.LogError("There was an error working with the feature toggles, see the error output below:");
+				logger.LogError(ex.ToString());
+				return ExitCode.Failed;
+			}
+		}
+
+		#region Actions
+
+		/// <summary>
+		///     Lists every flag with its global default and, when a department is given, what that
+		///     department actually resolves to and which rule decided it.
+		/// </summary>
+		private async Task<ExitCode> ListAsync(string[] args, int? departmentId)
+		{
+			var includeArchived = HasSwitch(args, "IncludeArchived");
+			var filter = GetValue(args, "Filter");
+
+			var flags = await featureToggleService.GetAllFlagsAsync(includeArchived, bypassCache: true);
+
+			if (flags == null || flags.Count == 0)
+			{
+				logger.LogWarning("No feature flags are defined. Flags are seeded by migrations, so check that the database is up to date.");
+				return ExitCode.Success;
+			}
+
+			if (!string.IsNullOrWhiteSpace(filter))
+				flags = flags.Where(f => Contains(f.FlagKey, filter) || Contains(f.Name, filter) || Contains(f.Category, filter)).ToList();
+
+			if (flags.Count == 0)
+			{
+				logger.LogWarning("No feature flags matched the filter '{Filter}'.", filter);
+				return ExitCode.Success;
+			}
+
+			if (departmentId.HasValue)
+			{
+				var department = await GetDepartmentAsync(departmentId.Value);
+
+				if (department == null)
+					return Fail($"Department {departmentId.Value} was not found.");
+
+				Write($"Feature toggles as resolved for department {departmentId.Value} ({department.Name}):");
+			}
+			else
+			{
+				Write("Feature toggles (global defaults). Pass --DepartmentId=N to see what a department resolves to.");
+			}
+
+			Write("");
+
+			foreach (var flag in flags.OrderBy(f => f.FlagKey, StringComparer.OrdinalIgnoreCase))
+			{
+				var line = $"{flag.FlagKey.PadRight(44)} global={State(flag.IsEnabledGlobally)}{Rollout(flag)}{Archived(flag)}";
+
+				if (departmentId.HasValue)
+				{
+					var evaluation = await featureToggleService.EvaluateFreshAsync(flag.FlagKey, departmentId.Value);
+					line += $"  ->  department={State(evaluation.IsEnabled)} ({evaluation.Source})";
+				}
+
+				Write(line);
+			}
+
+			Write("");
+			Write($"{flags.Count} flag(s).");
+
+			return ExitCode.Success;
+		}
+
+		/// <summary>
+		///     Lists every flag key application code reads (the <see cref="FeatureFlagKeys" /> constants)
+		///     against the rows that exist, so a key that code gates on but no migration has seeded shows up
+		///     as unseeded rather than silently falling back to a code default. Flags in the database with no
+		///     matching constant are listed after, since those are client-only or retired keys.
+		/// </summary>
+		private async Task<ExitCode> ListKeysAsync()
+		{
+			var known = KnownKeys();
+			var flags = await featureToggleService.GetAllFlagsAsync(includeArchived: true, bypassCache: true) ?? new List<FeatureFlag>();
+
+			Write("Feature flag keys read by application code:");
+			Write("");
+
+			foreach (var key in known)
+			{
+				var flag = flags.FirstOrDefault(f => string.Equals(f.FlagKey, key, StringComparison.OrdinalIgnoreCase));
+
+				Write(flag == null
+					? $"{key.PadRight(44)} NOT SEEDED - no row exists, so code falls back to its own default"
+					: $"{key.PadRight(44)} global={State(flag.IsEnabledGlobally)}{Rollout(flag)}{Archived(flag)}");
+			}
+
+			var unlisted = flags
+				.Where(f => !known.Any(k => string.Equals(k, f.FlagKey, StringComparison.OrdinalIgnoreCase)))
+				.OrderBy(f => f.FlagKey, StringComparer.OrdinalIgnoreCase)
+				.ToList();
+
+			if (unlisted.Count > 0)
+			{
+				Write("");
+				Write("Flags in the database with no matching key constant (client-only or retired):");
+				Write("");
+
+				foreach (var flag in unlisted)
+					Write($"{flag.FlagKey.PadRight(44)} global={State(flag.IsEnabledGlobally)}{Rollout(flag)}{Archived(flag)}");
+			}
+
+			Write("");
+			Write($"{known.Count} key(s) in code, {flags.Count} flag(s) in the database.");
+
+			return ExitCode.Success;
+		}
+
+		/// <summary>Prints one flag in full: definition, overrides, targeting rules and prerequisites.</summary>
+		private async Task<ExitCode> ShowAsync(string key, int? departmentId)
+		{
+			if (string.IsNullOrWhiteSpace(key))
+				return Fail("--Show needs a flag key: --Show --Key=Chat.System");
+
+			var flag = await featureToggleService.GetFlagByKeyAsync(key, bypassCache: true);
+
+			if (flag == null)
+				return FlagNotFound(key);
+
+			Write($"{flag.FlagKey} - {flag.Name}");
+
+			if (!string.IsNullOrWhiteSpace(flag.Description))
+				Write($"  {flag.Description}");
+
+			Write($"  Global default:       {State(flag.IsEnabledGlobally)}");
+			Write($"  Rollout:              {(flag.RolloutPercentage.HasValue ? flag.RolloutPercentage.Value + "%" : "100% (no staged rollout)")}");
+			Write($"  Value type:           {(FeatureFlagValueTypes)flag.FlagType}");
+			Write($"  Category:             {flag.Category ?? "(none)"}");
+			Write($"  Archived:             {flag.IsArchived}");
+			Write($"  Permanent:            {flag.IsPermanent}");
+
+			if (flag.MinimumPlanType.HasValue)
+				Write($"  Minimum plan:         {flag.MinimumPlanType.Value}");
+
+			if (flag.EnableOn.HasValue || flag.DisableOn.HasValue)
+				Write($"  Schedule:             {Stamp(flag.EnableOn)} -> {Stamp(flag.DisableOn)}");
+
+			Write($"  Last evaluated:       {Stamp(flag.LastEvaluatedOn)}");
+
+			var prerequisites = await featureToggleService.GetPrerequisitesForFlagAsync(flag.FlagKey);
+
+			if (prerequisites != null && prerequisites.Count > 0)
+			{
+				Write("  Prerequisites (all must be satisfied before this flag can be on):");
+
+				foreach (var prerequisite in prerequisites)
+					Write($"    requires flag id {prerequisite.RequiredFeatureFlagId} = {prerequisite.RequiredValue ?? "true"}");
+			}
+
+			var rules = await featureToggleService.GetTargetingRulesForFlagAsync(flag.FlagKey);
+
+			if (rules != null && rules.Count > 0)
+				Write($"  Targeting rules:      {rules.Count} (managed from the admin UI)");
+
+			var overrides = await featureToggleService.GetOverridesForFlagAsync(flag.FlagKey);
+			Write($"  Department overrides: {(overrides == null ? 0 : overrides.Count)}");
+
+			if (overrides != null)
+			{
+				foreach (var item in overrides.OrderBy(o => o.DepartmentId))
+					Write($"    department {item.DepartmentId}: {State(item.IsEnabled)}{Expiry(item.ExpiresOn)}{Reason(item.Reason)}");
+			}
+
+			if (departmentId.HasValue)
+			{
+				var department = await GetDepartmentAsync(departmentId.Value);
+
+				if (department == null)
+					return Fail($"Department {departmentId.Value} was not found.");
+
+				Write("");
+				await WriteEvaluationAsync(flag.FlagKey, departmentId.Value, department.Name);
+			}
+
+			return ExitCode.Success;
+		}
+
+		/// <summary>Sets the global default (no --DepartmentId) or a single department's override.</summary>
+		private async Task<ExitCode> SetAsync(string[] args, string key, int? departmentId, bool enabled, string userId, CancellationToken cancellationToken)
+		{
+			if (string.IsNullOrWhiteSpace(key))
+				return Fail("--On/--Off needs a flag key: --On --Key=Chat.System");
+
+			if (!departmentId.HasValue)
+			{
+				var flag = await featureToggleService.SetGlobalEnabledAsync(key, enabled, userId, cancellationToken);
+
+				if (flag == null)
+					return FlagNotFound(key);
+
+				Write($"Global default for '{flag.FlagKey}' is now {State(flag.IsEnabledGlobally)}, for every department that has no override of its own.");
+
+				if (flag.IsEnabledGlobally && flag.RolloutPercentage.HasValue && flag.RolloutPercentage.Value < 100)
+					logger.LogWarning(
+						"The flag also has a {Percentage}% staged rollout, so it is only on for departments inside that bucket. Use --Rollout=100 to reach everyone.",
+						flag.RolloutPercentage.Value);
+
+				if (flag.IsEnabledGlobally && flag.IsArchived)
+					logger.LogWarning("The flag is archived, which short-circuits evaluation to off. Un-archive it from the admin UI before it will read as on.");
+
+				Write("Flag cache invalidated; web, API and worker nodes pick this up on their next read.");
+
+				return ExitCode.Success;
+			}
+
+			var department = await GetDepartmentAsync(departmentId.Value);
+
+			if (department == null)
+				return Fail($"Department {departmentId.Value} was not found.");
+
+			if (!TryGetExpiry(args, out var expiresOn, out var expiryError))
+				return Fail(expiryError);
+
+			var value = GetValue(args, "Value");
+			var reason = GetValue(args, "Reason") ?? "Set from the Resgrid Console";
+
+			try
+			{
+				await featureToggleService.SetDepartmentOverrideAsync(key, departmentId.Value, enabled, value, reason, expiresOn, userId, cancellationToken);
+			}
+			catch (InvalidOperationException)
+			{
+				return FlagNotFound(key);
+			}
+
+			Write($"Override for '{key}' on department {departmentId.Value} ({department.Name}) is now {State(enabled)}{Expiry(expiresOn)}.");
+			await WriteEvaluationAsync(key, departmentId.Value, department.Name);
+
+			return ExitCode.Success;
+		}
+
+		/// <summary>Removes a department's override so it falls back to the global default and rollout.</summary>
+		private async Task<ExitCode> ClearOverrideAsync(string key, int? departmentId, string userId, CancellationToken cancellationToken)
+		{
+			if (string.IsNullOrWhiteSpace(key))
+				return Fail("--Clear needs a flag key: --Clear --Key=Chat.System --DepartmentId=1");
+
+			if (!departmentId.HasValue)
+				return Fail("--Clear removes a department override, so it needs --DepartmentId=N. To turn a flag off everywhere use --Off with no --DepartmentId.");
+
+			var department = await GetDepartmentAsync(departmentId.Value);
+
+			if (department == null)
+				return Fail($"Department {departmentId.Value} was not found.");
+
+			var removed = await featureToggleService.RemoveDepartmentOverrideAsync(key, departmentId.Value, userId, cancellationToken);
+
+			if (!removed)
+			{
+				logger.LogWarning("Department {DepartmentId} has no override for '{Key}' (or the flag does not exist); nothing was changed.", departmentId.Value, key);
+				return ExitCode.Success;
+			}
+
+			Write($"Removed the '{key}' override on department {departmentId.Value} ({department.Name}); it now follows the global default.");
+			await WriteEvaluationAsync(key, departmentId.Value, department.Name);
+
+			return ExitCode.Success;
+		}
+
+		/// <summary>Sets the staged rollout percentage, which only applies to departments with no override.</summary>
+		private async Task<ExitCode> SetRolloutAsync(string[] args, string key, string userId, CancellationToken cancellationToken)
+		{
+			if (string.IsNullOrWhiteSpace(key))
+				return Fail("--Rollout needs a flag key: --Rollout=25 --Key=Chat.System");
+
+			var raw = GetValue(args, "Rollout") ?? GetValue(args, "Percentage");
+
+			if (!int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var percentage) || percentage < 0 || percentage > 100)
+				return Fail("--Rollout needs a percentage between 0 and 100, as --Rollout=25 or --Rollout --Percentage=25.");
+
+			var flag = await featureToggleService.SetRolloutPercentageAsync(key, percentage, userId, cancellationToken);
+
+			if (flag == null)
+				return FlagNotFound(key);
+
+			Write($"Rollout for '{flag.FlagKey}' is now {flag.RolloutPercentage}%, on top of a global default of {State(flag.IsEnabledGlobally)}.");
+
+			if (!flag.IsEnabledGlobally)
+				logger.LogWarning("The global default is off, so the rollout has no effect until the flag is turned on with --On.");
+
+			return ExitCode.Success;
+		}
+
+		#endregion
+
+		#region Output helpers
+
+		private async Task WriteEvaluationAsync(string key, int departmentId, string departmentName)
+		{
+			var evaluation = await featureToggleService.EvaluateFreshAsync(key, departmentId);
+
+			Write($"Department {departmentId} ({departmentName}) now resolves '{key}' to {State(evaluation.IsEnabled)}, decided by {evaluation.Source}" +
+				  (evaluation.MatchedRuleId.HasValue ? $" (targeting rule {evaluation.MatchedRuleId.Value})." : "."));
+
+			if (evaluation.ValueType != FeatureFlagValueTypes.Boolean)
+				Write($"Resolved value: {evaluation.Value ?? "(null)"}");
+		}
+
+		/// <summary>
+		///     Reports an unknown key along with the keys application code actually reads, since a key with
+		///     no seeded row is the usual reason a toggle appears to do nothing.
+		/// </summary>
+		private ExitCode FlagNotFound(string key)
+		{
+			logger.LogError("No feature flag exists with the key '{Key}'. Flags are seeded by migrations, not created here.", key);
+
+			var known = KnownKeys();
+
+			if (known.Count > 0)
+			{
+				Write("Keys read by application code (--Keys shows which of these are seeded):");
+
+				foreach (var item in known)
+					Write($"  {item}");
+			}
+
+			return ExitCode.Failed;
+		}
+
+		/// <summary>The flag keys declared in <see cref="FeatureFlagKeys" />, which is what code gates on.</summary>
+		private static List<string> KnownKeys() =>
+			typeof(FeatureFlagKeys)
+				.GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)
+				.Where(f => f.IsLiteral && !f.IsInitOnly && f.FieldType == typeof(string))
+				.Select(f => (string)f.GetRawConstantValue())
+				.OrderBy(k => k, StringComparer.OrdinalIgnoreCase)
+				.ToList();
+
+		private ExitCode Fail(string message)
+		{
+			logger.LogError("{Line}", message);
+			return ExitCode.Failed;
+		}
+
+		/// <summary>Writes a line as-is, so a value containing braces is never read as a log template.</summary>
+		private void Write(string line) => logger.LogInformation("{Line}", line);
+
+		private static string State(bool enabled) => enabled ? "ON" : "OFF";
+
+		private static string Stamp(DateTime? value) => value.HasValue ? value.Value.ToString("u", CultureInfo.InvariantCulture) : "(none)";
+
+		private static string Rollout(FeatureFlag flag) =>
+			flag.RolloutPercentage.HasValue && flag.RolloutPercentage.Value < 100 ? $"  rollout={flag.RolloutPercentage.Value}%" : string.Empty;
+
+		private static string Archived(FeatureFlag flag) => flag.IsArchived ? "  [archived]" : string.Empty;
+
+		private static string Expiry(DateTime? expiresOn) => expiresOn.HasValue ? $", expiring {Stamp(expiresOn)}" : string.Empty;
+
+		private static string Reason(string reason) => string.IsNullOrWhiteSpace(reason) ? string.Empty : $" - {reason}";
+
+		private static bool Contains(string value, string filter) =>
+			!string.IsNullOrWhiteSpace(value) && value.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0;
+
+		#endregion
+
+		#region Lookups and argument parsing
+
+		private async Task<Department> GetDepartmentAsync(int departmentId)
+		{
+			var department = await departmentsService.GetDepartmentByIdAsync(departmentId);
+
+			// A cached blank entity deserializes to a non-null Department with a zero id, so the id is what
+			// is checked here and not just the reference.
+			return department == null || department.DepartmentId <= 0 ? null : department;
+		}
+
+		private static bool TryGetExpiry(string[] args, out DateTime? expiresOn, out string error)
+		{
+			expiresOn = null;
+			error = null;
+
+			var raw = GetValue(args, "ExpiresOn");
+
+			if (string.IsNullOrWhiteSpace(raw))
+				return true;
+
+			// Anything without an offset is read as UTC, which is what the override column stores.
+			if (!DateTime.TryParse(raw, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal, out var parsed))
+			{
+				error = $"--ExpiresOn '{raw}' is not a date. Use an ISO form such as --ExpiresOn=2026-12-31 or --ExpiresOn=2026-12-31T18:00:00Z (UTC).";
+				return false;
+			}
+
+			expiresOn = parsed;
+			return true;
+		}
+
+		private static bool TryGetInt(string[] args, string name, out int? value)
+		{
+			value = null;
+
+			var raw = GetValue(args, name);
+
+			if (string.IsNullOrWhiteSpace(raw))
+				return true;
+
+			if (!int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed))
+				return false;
+
+			value = parsed;
+			return true;
+		}
+
+		/// <summary>Reads "--Name=value" or "--Name value" out of the raw argument list.</summary>
+		private static string GetValue(string[] args, string name)
+		{
+			for (var i = 0; i < args.Length; i++)
+			{
+				var arg = args[i];
+
+				if (!arg.StartsWith("--", StringComparison.Ordinal))
+					continue;
+
+				var token = arg.Substring(2);
+				var separator = token.IndexOf('=');
+
+				if (separator >= 0)
+				{
+					if (string.Equals(token.Substring(0, separator), name, StringComparison.OrdinalIgnoreCase))
+						return Unquote(token.Substring(separator + 1));
+
+					continue;
+				}
+
+				if (string.Equals(token, name, StringComparison.OrdinalIgnoreCase) &&
+					i + 1 < args.Length && !args[i + 1].StartsWith("-", StringComparison.Ordinal))
+					return Unquote(args[i + 1]);
+			}
+
+			return null;
+		}
+
+		/// <summary>True when "--Name" is present, unless it was explicitly passed as "--Name=false".</summary>
+		private static bool HasSwitch(string[] args, string name)
+		{
+			foreach (var arg in args)
+			{
+				if (!arg.StartsWith("--", StringComparison.Ordinal))
+					continue;
+
+				var token = arg.Substring(2);
+				var separator = token.IndexOf('=');
+				var switchName = separator >= 0 ? token.Substring(0, separator) : token;
+
+				if (!string.Equals(switchName, name, StringComparison.OrdinalIgnoreCase))
+					continue;
+
+				return separator < 0 || !string.Equals(token.Substring(separator + 1), "false", StringComparison.OrdinalIgnoreCase);
+			}
+
+			return false;
+		}
+
+		private static string Unquote(string value)
+		{
+			if (value != null && value.Length > 1 && value.StartsWith("\"", StringComparison.Ordinal) && value.EndsWith("\"", StringComparison.Ordinal))
+				return value.Substring(1, value.Length - 2);
+
+			return value;
+		}
+
+		#endregion
+	}
+}

--- a/Tools/Resgrid.Console/Commands/HelpCommand.cs
+++ b/Tools/Resgrid.Console/Commands/HelpCommand.cs
@@ -23,6 +23,15 @@ namespace Resgrid.Console.Commands
 			logger.LogInformation("--AddHosts :: Adds a host to the Resgrid Console");
 			logger.LogInformation("--ClearCache -- --DepartmentId=1 :: Clears the cache for a department");
 			logger.LogInformation("--DbUpdate || --UpdateDb :: Updates the Resgrid Database");
+			logger.LogInformation("--FeatureFlags :: Reads and sets feature toggles. Sub commands:");
+			logger.LogInformation("    --FeatureFlags --List [--DepartmentId=1] [--IncludeArchived] [--Filter=text] :: Lists every flag in the database, and what a department resolves it to");
+			logger.LogInformation("    --FeatureFlags --Keys :: Lists every flag key application code reads and whether a flag row has been seeded for it");
+			logger.LogInformation("    --FeatureFlags --Show --Key=Chat.System [--DepartmentId=1] :: Shows one flag with its overrides, rules and prerequisites");
+			logger.LogInformation("    --FeatureFlags --On|--Off --Key=Chat.System :: Sets the global default, which applies to EVERY department without an override");
+			logger.LogInformation("    --FeatureFlags --On|--Off --Key=Chat.System --DepartmentId=1 [--Reason=\"text\"] [--ExpiresOn=2026-12-31] :: Sets one department's override");
+			logger.LogInformation("    --FeatureFlags --Clear --Key=Chat.System --DepartmentId=1 :: Removes a department override so it follows the global default");
+			logger.LogInformation("    --FeatureFlags --Rollout=25 --Key=Chat.System :: Sets the staged rollout percentage across departments");
+			logger.LogInformation("    Add --UserId=[GUID] to any write to attribute it in the audit log");
 			logger.LogInformation("--GenOidcCerts :: Generates the OIDC Certificates");
 			logger.LogInformation("--MigrateDocsDb :: Migrates the Resgrid Docs Database");
 			logger.LogInformation("--NormalizePhoneNumbers [--Apply] [--DepartmentId=1] :: Rewrites stored profile phone numbers to E.164. Dry run unless --Apply is passed");

--- a/Tools/Resgrid.Console/Program.cs
+++ b/Tools/Resgrid.Console/Program.cs
@@ -111,6 +111,7 @@ namespace Resgrid.Console
 					services.AddKeyedTransient<ICommandService, NormalizePhoneNumbersCommand>("NormalizePhoneNumbersCommand");
 					services.AddKeyedTransient<ICommandService, OidcUpdateCommand>("OidcUpdateCommand");
 					services.AddKeyedTransient<ICommandService, SecurityRefreshCommand>("SecurityRefreshCommand");
+					services.AddKeyedTransient<ICommandService, FeatureFlagsCommand>("FeatureFlagsCommand");
 					services.AddKeyedTransient<ICommandService, HelpCommand>("HelpCommand");
 
 					services.AddHostedService<ApplicationHostedService>();

--- a/Tools/Resgrid.Console/Services/ApplicationHostedService.cs
+++ b/Tools/Resgrid.Console/Services/ApplicationHostedService.cs
@@ -34,6 +34,7 @@ public sealed class ApplicationHostedService : IHostedService, IDisposable
     private ICommandService _normalizePhoneNumbersCommand;
     private ICommandService _oidcUpdateCommand;
     private ICommandService _securityRefreshCommand;
+    private ICommandService _featureFlagsCommand;
     private ICommandService _helpCommand;
 
     // Cancellation token source used to submit a cancellation request.
@@ -61,6 +62,7 @@ public sealed class ApplicationHostedService : IHostedService, IDisposable
         [FromKeyedServices("NormalizePhoneNumbersCommand")] ICommandService normalizePhoneNumbersCommand,
         [FromKeyedServices("OidcUpdateCommand")] ICommandService oidcUpdateCommand,
         [FromKeyedServices("SecurityRefreshCommand")] ICommandService securityRefreshCommand,
+        [FromKeyedServices("FeatureFlagsCommand")] ICommandService featureFlagsCommand,
         [FromKeyedServices("HelpCommand")] ICommandService helpCommand)
     {
         _hostApplicationLifetime = hostApplicationLifetime;
@@ -75,6 +77,7 @@ public sealed class ApplicationHostedService : IHostedService, IDisposable
         _normalizePhoneNumbersCommand = normalizePhoneNumbersCommand;
         _oidcUpdateCommand = oidcUpdateCommand;
         _securityRefreshCommand = securityRefreshCommand;
+        _featureFlagsCommand = featureFlagsCommand;
         _helpCommand = helpCommand;
     }
 
@@ -206,6 +209,8 @@ public sealed class ApplicationHostedService : IHostedService, IDisposable
 		        return await _oidcUpdateCommand.ExecuteMainAsync(args, cancellationToken).ConfigureAwait(false);
 	        else if (args.Contains("--SecurityRefresh"))
 		        return await _securityRefreshCommand.ExecuteMainAsync(args, cancellationToken).ConfigureAwait(false);
+	        else if (args.Contains("--FeatureFlags") || args.Contains("--FeatureToggles") || args.Contains("--Toggles"))
+		        return await _featureFlagsCommand.ExecuteMainAsync(args, cancellationToken).ConfigureAwait(false);
 	        else
 	        {
 		        return await _helpCommand.ExecuteMainAsync(args, cancellationToken).ConfigureAwait(false);

--- a/Web/Resgrid.Web/Areas/User/Views/Checklists/CompletionDetail.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Checklists/CompletionDetail.cshtml
@@ -2,57 +2,178 @@
 @using Resgrid.Model.Checklists
 @using System.Linq
 @inject IStringLocalizer<Resgrid.Localization.Areas.User.Checklists.Checklists> localizer
-@{ ViewBag.Title = "Resgrid | " + Model.Form.Name; var run = Model.Completion; }
-<div class="wrapper wrapper-content"><div class="ibox"><div class="ibox-content">
-    <h2>@Model.Form.Name</h2><p>@Model.Target.Name</p>
-    @await Html.PartialAsync("_Protection")
-    <dl class="dl-horizontal">
-        <dt>@localizer["State"]</dt><dd>@localizer[((ChecklistRunState)run.State).ToString()]</dd>
-        <dt>@localizer["Score"]</dt><dd>@(run.Score.HasValue ? run.Score + "%" : localizer["NoScore"].Value)</dd>
-        <dt>@localizer["Result"]</dt><dd>@(run.SubmittedOn.HasValue ? run.Passed.HasValue ? run.Passed.Value ? localizer["Passed"] : localizer["Failed"] : "—" : localizer["Incomplete"])</dd>
-        <dt>@localizer["Author"]</dt><dd>@run.CreatedBy</dd><dt>@localizer["Submitted"] (UTC)</dt><dd>@run.SubmittedOn?.ToString("u")</dd>
-        <dt>@localizer["Version"]</dt><dd>@Model.VersionNumber</dd>
-        @if (run.WitnessedOn.HasValue) { <dt>@localizer["WitnessLabel"]</dt><dd>@run.WitnessUserId · @run.WitnessedOn.Value.ToString("u")</dd><dt>@localizer["Attestation"]</dt><dd>@Model.WitnessAttestation</dd> }
-    </dl>
-    @if (Model.Form.Sections.SelectMany(s => s.Items).Any(i => i.CreateWorkOrderOnFail)) { <a class="btn btn-default" asp-controller="WorkOrders" asp-action="Index" asp-route-checklistCompletionId="@run.Id">@localizer["RelatedWorkOrders"]</a> }
-    @foreach (var checklistSection in Model.Form.Sections)
+@functions {
+    string RunPill(ChecklistRunState state) => state switch
     {
-        <h3>@checklistSection.Name</h3>
-        <table class="table table-bordered"><thead><tr><th>@localizer["Item"]</th><th>@localizer["Answer"]</th><th>@localizer["Note"]</th><th>@localizer["Evidence"]</th></tr></thead><tbody>
-        @foreach (var item in checklistSection.Items)
-        {
-            var answer = Model.Input.Answers.FirstOrDefault(a => a.ItemId == item.Id);
-            var displayAnswer = answer?.Status == ChecklistAnswerStatus.NotApplicable ? localizer["N/A"].Value + ": " + answer.NotApplicableReason : localizer["Unanswered"].Value;
-            if (answer?.Status == ChecklistAnswerStatus.Answered)
+        ChecklistRunState.InProgress => "label-warning",
+        ChecklistRunState.AwaitingWitness => "label-info",
+        _ => "label-success"
+    };
+}
+@{
+    ViewBag.Title = "Resgrid | " + Model.Form.Name;
+    var run = Model.Completion;
+    var state = (ChecklistRunState)run.State;
+    ViewData["Tab"] = "Index";
+    ViewData["Title"] = Model.Form.Name;
+    ViewData["ParentText"] = localizer["History"].Value;
+    ViewData["ParentAction"] = "Detail";
+    ViewData["ParentId"] = run.ParentId;
+    ViewData["Subtitle"] = Model.Target.Name;
+}
+
+@await Html.PartialAsync("_Shell")
+
+<div class="wrapper wrapper-content">
+    <div class="ibox float-e-margins">
+        <div class="ibox-title"><h5>@Model.Form.Name</h5></div>
+        <div class="ibox-content">
+            @await Html.PartialAsync("_Protection")
+
+            <div class="rgw-toolbar">
+                <a class="btn btn-default btn-sm" asp-action="Detail" asp-route-id="@run.ParentId"><i class="fa fa-arrow-left"></i> @localizer["History"]</a>
+                <div class="rgw-toolbar-spacer"></div>
+                @if (Model.Form.Sections.SelectMany(s => s.Items).Any(i => i.CreateWorkOrderOnFail))
+                {
+                    <a class="btn btn-default" asp-controller="WorkOrders" asp-action="Index" asp-route-checklistCompletionId="@run.Id"><i class="fa fa-wrench"></i> @localizer["RelatedWorkOrders"]</a>
+                }
+                <form class="checklist-form" asp-action="Export" method="post">
+                    @Html.AntiForgeryToken()
+                    <input type="hidden" name="id" value="@run.Id" />
+                    <button class="btn btn-default" type="submit"><i class="fa fa-download"></i> @localizer["Export"]</button>
+                </form>
+                <button class="btn btn-default" type="button" onclick="window.print()"><i class="fa fa-print"></i> @localizer["Print"]</button>
+            </div>
+
+            <p class="text-muted">
+                <span class="label @RunPill(state)">@localizer[state.ToString()]</span>
+                @if (run.SubmittedOn.HasValue && run.Passed == true)
+                {
+                    <span class="label label-success">@localizer["Passed"]</span>
+                }
+                else if (run.SubmittedOn.HasValue && run.Passed == false)
+                {
+                    <span class="label label-danger">@localizer["Failed"]</span>
+                }
+                else if (!run.SubmittedOn.HasValue)
+                {
+                    <span class="label">@localizer["Incomplete"]</span>
+                }
+                @Model.Target.Name
+            </p>
+
+            <dl class="dl-horizontal">
+                <dt>@localizer["Score"]</dt><dd>@(run.Score.HasValue ? run.Score + "%" : localizer["NoScore"].Value)</dd>
+                <dt>@localizer["Author"]</dt><dd>@run.CreatedBy</dd>
+                <dt>@localizer["Submitted"] (UTC)</dt><dd>@run.SubmittedOn?.ToString("u")</dd>
+                <dt>@localizer["Version"]</dt><dd>@Model.VersionNumber</dd>
+                @if (run.WitnessedOn.HasValue)
+                {
+                    <dt>@localizer["WitnessLabel"]</dt><dd>@run.WitnessUserId &middot; @run.WitnessedOn.Value.ToString("u")</dd>
+                    <dt>@localizer["Attestation"]</dt><dd>@Model.WitnessAttestation</dd>
+                }
+            </dl>
+
+            <div class="hr-line-dashed"></div>
+
+            @foreach (var checklistSection in Model.Form.Sections)
             {
-                displayAnswer = item.Type == ChecklistItemType.PassFail ? localizer[answer.Value == "pass" ? "Pass" : "Fail"].Value
-                    : item.Type == ChecklistItemType.YesNo ? localizer[answer.Value == "true" ? "Yes" : "No"].Value
-                    : item.Type == ChecklistItemType.Checkbox ? localizer[answer.Value == "true" ? "Checked" : "Unchecked"].Value
-                    : answer.Value;
+                <div class="panel panel-default">
+                    <div class="panel-heading">@checklistSection.Name</div>
+                    <div class="table-responsive">
+                        <table class="table rgw-table">
+                            <thead><tr><th>@localizer["Item"]</th><th>@localizer["Answer"]</th><th>@localizer["Note"]</th><th>@localizer["Evidence"]</th></tr></thead>
+                            <tbody>
+                                @foreach (var item in checklistSection.Items)
+                                {
+                                    var answer = Model.Input.Answers.FirstOrDefault(a => a.ItemId == item.Id);
+                                    var displayAnswer = answer?.Status == ChecklistAnswerStatus.NotApplicable ? localizer["N/A"].Value + ": " + answer.NotApplicableReason : localizer["Unanswered"].Value;
+                                    if (answer?.Status == ChecklistAnswerStatus.Answered)
+                                    {
+                                        displayAnswer = item.Type == ChecklistItemType.PassFail ? localizer[answer.Value == "pass" ? "Pass" : "Fail"].Value
+                                            : item.Type == ChecklistItemType.YesNo ? localizer[answer.Value == "true" ? "Yes" : "No"].Value
+                                            : item.Type == ChecklistItemType.Checkbox ? localizer[answer.Value == "true" ? "Checked" : "Unchecked"].Value
+                                            : answer.Value;
+                                    }
+                                    <tr>
+                                        <td>
+                                            @item.Name
+                                            @if (item.Critical)
+                                            {
+                                                <span class="label label-danger">@localizer["Critical"]</span>
+                                            }
+                                        </td>
+                                        <td>@displayAnswer</td>
+                                        <td style="white-space: pre-wrap">@answer?.Note</td>
+                                        <td>
+                                            @foreach (var file in Model.Files.Where(f => f.ItemId == item.Id))
+                                            {
+                                                <a class="checklist-evidence" asp-action="Evidence" asp-route-id="@file.Id">@file.Content</a><br />
+                                            }
+                                        </td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
             }
-            <tr><td>@item.Name @if(item.Critical) { <strong>(@localizer["Critical"])</strong> }</td><td>@displayAnswer</td><td style="white-space: pre-wrap">@answer?.Note</td><td>
-            @foreach (var file in Model.Files.Where(f => f.ItemId == item.Id)) { <a class="checklist-evidence" asp-action="Evidence" asp-route-id="@file.Id">@file.Content</a><br /> }
-            </td></tr>
-        }
-        </tbody></table>
-    }
-    <p style="white-space: pre-wrap">@Model.Input.LocationDescription</p>
-    <p style="white-space: pre-wrap">@Model.Input.Note</p>
-    @if (Model.Input.Latitude.HasValue) { <p>@localizer["ReportedLocation"]: @Model.Input.Latitude, @Model.Input.Longitude</p> }
-    @if (run.State == (int)ChecklistRunState.AwaitingWitness)
-    {
-        <p class="alert alert-info">@localizer["WitnessInstructions"]</p>
-        @if (run.CreatedBy != (string)ViewBag.ChecklistUserId && ViewBag.ChecklistsEnabled == true)
-        {
-            <form class="checklist-form" asp-action="Witness" method="post">
-                @Html.AntiForgeryToken()<input type="hidden" name="id" value="@run.Id" /><input type="hidden" name="submissionHash" value="@run.SubmissionHash" />
-                <label for="attestation">@localizer["Attestation"]</label><textarea id="attestation" name="attestation" class="form-control" maxlength="2000" required></textarea>
-                <button class="btn btn-primary" type="submit">@localizer["Attest"]</button>
-            </form>
-        }
-    }
-    <form class="checklist-form" asp-action="Export" method="post">@Html.AntiForgeryToken()<input type="hidden" name="id" value="@run.Id" /><button class="btn btn-default" type="submit">@localizer["Export"]</button></form>
-    <button class="btn btn-default" type="button" onclick="window.print()">@localizer["Print"]</button>
-    <a class="btn btn-default" asp-action="Detail" asp-route-id="@run.ParentId">@localizer["History"]</a>
-</div></div></div>
+
+            @if (!string.IsNullOrEmpty(Model.Input.LocationDescription))
+            {
+                <p style="white-space: pre-wrap">@Model.Input.LocationDescription</p>
+            }
+            @if (!string.IsNullOrEmpty(Model.Input.Note))
+            {
+                <p style="white-space: pre-wrap">@Model.Input.Note</p>
+            }
+            @if (Model.Input.Latitude.HasValue)
+            {
+                <p class="text-muted">@localizer["ReportedLocation"]: @Model.Input.Latitude, @Model.Input.Longitude</p>
+            }
+
+            @if (run.State == (int)ChecklistRunState.AwaitingWitness)
+            {
+                <div class="alert alert-info"><i class="fa fa-user-plus"></i> @localizer["WitnessInstructions"]</div>
+                @if (run.CreatedBy != (string)ViewBag.ChecklistUserId && ViewBag.ChecklistsEnabled == true)
+                {
+                    <button class="btn btn-primary" type="button" data-toggle="modal" data-target="#checklist-witness">@localizer["Attest"]</button>
+                    <div class="modal fade rgw-modal" id="checklist-witness" tabindex="-1" role="dialog" aria-labelledby="checklist-witness-title">
+                        <div class="modal-dialog" role="document">
+                            <div class="modal-content">
+                                <div class="modal-header">
+                                    <button type="button" class="close" data-dismiss="modal" aria-label="@localizer["Close"]"><span aria-hidden="true">&times;</span></button>
+                                    <h4 class="modal-title" id="checklist-witness-title">@localizer["Attest"]</h4>
+                                </div>
+                                <div class="modal-body">
+                                    <p class="text-muted">@localizer["WitnessInstructions"]</p>
+                                    <form class="checklist-form" asp-action="Witness" method="post">
+                                        @Html.AntiForgeryToken()
+                                        <input type="hidden" name="id" value="@run.Id" />
+                                        <input type="hidden" name="submissionHash" value="@run.SubmissionHash" />
+                                        <div class="rgw-grid">
+                                            <div class="form-group rgw-wide">
+                                                <label for="attestation">@localizer["Attestation"]</label>
+                                                <textarea id="attestation" name="attestation" class="form-control" rows="3" maxlength="2000" required></textarea>
+                                            </div>
+                                        </div>
+                                        <div class="rgw-wizard-actions">
+                                            <div class="rgw-wizard-spacer"></div>
+                                            <button type="button" class="btn btn-white" data-dismiss="modal">@localizer["Close"]</button>
+                                            <button class="btn btn-primary" type="submit">@localizer["Attest"]</button>
+                                        </div>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                }
+            }
+        </div>
+    </div>
+</div>
+
+@section Styles {
+    <link rel="stylesheet" href="~/css/workspace.css" asp-append-version="true" />
+}
 @section Scripts { @await Html.PartialAsync("_ProtectionScripts") }

--- a/Web/Resgrid.Web/Areas/User/Views/Checklists/Compliance.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Checklists/Compliance.cshtml
@@ -1,36 +1,169 @@
 @model Resgrid.Model.Checklists.ChecklistComplianceSummary
 @using Resgrid.Model.Checklists
 @inject IStringLocalizer<Resgrid.Localization.Areas.User.Checklists.Checklists> localizer
-@{ ViewBag.Title = "Resgrid | " + localizer["ChecklistComplianceReport"]; }
-<div class="wrapper wrapper-content"><div class="ibox"><div class="ibox-content">
-<h2>@localizer["ChecklistComplianceReport"]</h2><p>@localizer["ComplianceMethod"]</p><p>@localizer["AuthorizedScope"]</p>
-@await Html.PartialAsync("_Protection")
-<form class="checklist-form" asp-action="Compliance" method="post">
-    @Html.AntiForgeryToken()
-    <label for="from">@localizer["ReportFrom"] (UTC)</label><input id="from" name="FromUtc" type="date" value="@Model.FromUtc.ToString("yyyy-MM-dd")" required />
-    <label for="until">@localizer["ReportUntil"] (UTC)</label><input id="until" name="UntilUtc" type="date" value="@Model.UntilUtc.ToString("yyyy-MM-dd")" required />
-    <label for="target-type">@localizer["TargetType"]</label><select id="target-type" name="TargetType"><option value="">@localizer["AllTargets"]</option>
-    @foreach (var type in Enum.GetValues<ChecklistTargetType>()) { <option value="@((int)type)" selected="@(Model.TargetType == type)">@localizer[type.ToString()]</option> }
-    </select>
-    <button class="btn btn-primary" type="submit">@localizer["RefreshReport"]</button>
-    <button class="btn btn-default" type="submit" formaction="@Url.Action("ComplianceCsv")">@localizer["ExportCsv"]</button>
-    <button class="btn btn-default" type="submit" formaction="@Url.Action("ChecklistComplianceReport", "Reports")">@localizer["PrintReport"]</button>
-</form>
-@if (!Model.IsRedacted)
-{
-    <div class="table-responsive"><table class="table table-striped"><thead><tr><th>@localizer["Target"]</th><th>@localizer["TargetType"]</th><th>@localizer["ExpectedChecks"]</th><th>@localizer["CompletedChecks"]</th><th>@localizer["OnTimeChecks"]</th><th>@localizer["MissedChecks"]</th><th>@localizer["ExcusedChecks"]</th><th>@localizer["CompletionRate"]</th></tr></thead><tbody>
-    @foreach (var group in Model.Groups)
-    { <tr><td>@group.Target.Name</td><td>@localizer[group.Target.Type.ToString()]</td><td>@group.Expected</td><td>@group.Completed</td><td>@group.OnTime</td><td>@group.Missed</td><td>@group.Skipped</td><td>@(group.CompletionRate.HasValue ? group.CompletionRate.Value.ToString("0.##") + "%" : "—")</td></tr> }
-    </tbody></table></div>
-    <h3>@localizer["MissedTrend"]</h3>
-    <table class="table"><thead><tr><th>@localizer["Date"] (UTC)</th><th>@localizer["ExpectedChecks"]</th><th>@localizer["MissedChecks"]</th></tr></thead><tbody>
-    @foreach (var day in Model.Trend) { <tr><td>@day.DayUtc.ToString("yyyy-MM-dd")</td><td>@day.Expected</td><td><progress max="@day.Expected" value="@day.Missed" aria-label="@localizer["MissedChecks"]"></progress> @day.Missed</td></tr> }
-    </tbody></table>
-    @foreach (var source in Model.UnavailableSources) { <p>@localizer[source]</p> }
+@{
+    ViewBag.Title = "Resgrid | " + localizer["ChecklistComplianceReport"];
+    ViewData["Tab"] = "Compliance";
+    ViewData["Title"] = localizer["ChecklistComplianceReport"].Value;
+    ViewData["Subtitle"] = localizer["AuthorizedScope"].Value;
+
+    var expected = Model.Groups.Sum(x => x.Expected);
+    var completed = Model.Groups.Sum(x => x.Completed);
+    var missed = Model.Groups.Sum(x => x.Missed);
+    var onTime = Model.Groups.Sum(x => x.OnTime);
 }
-<p>@localizer["ScheduledReportProtected"]</p>
-<a class="btn btn-default" asp-controller="Profile" asp-action="AddNewScheduledReport">@localizer["ScheduleReport"]</a>
-<a class="btn btn-default" asp-action="ReadinessPacket">@localizer["ReadinessPacketReport"]</a>
-<a class="btn btn-default" asp-action="Index">@localizer["Back"]</a>
-</div></div></div>
+
+@await Html.PartialAsync("_Shell")
+
+<div class="wrapper wrapper-content">
+    <div class="ibox float-e-margins">
+        <div class="ibox-title"><h5>@localizer["ChecklistComplianceReport"]</h5></div>
+        <div class="ibox-content">
+            @await Html.PartialAsync("_Tabs")
+            @await Html.PartialAsync("_Protection")
+
+            <div class="alert alert-info"><i class="fa fa-info-circle"></i> @localizer["ComplianceMethod"]</div>
+
+            <div class="rgw-filter">
+                <form class="checklist-form" asp-action="Compliance" method="post">
+                    @Html.AntiForgeryToken()
+                    <div class="rgw-grid">
+                        <div class="form-group">
+                            <label for="from">@localizer["ReportFrom"] (UTC)</label>
+                            <input class="form-control" id="from" name="FromUtc" type="date" value="@Model.FromUtc.ToString("yyyy-MM-dd")" required />
+                            <span class="help-block">@localizer["ReportRangeHint"]</span>
+                        </div>
+                        <div class="form-group">
+                            <label for="until">@localizer["ReportUntil"] (UTC)</label>
+                            <input class="form-control" id="until" name="UntilUtc" type="date" value="@Model.UntilUtc.ToString("yyyy-MM-dd")" required />
+                        </div>
+                        <div class="form-group">
+                            <label for="target-type">@localizer["TargetType"]</label>
+                            <select class="form-control" id="target-type" name="TargetType">
+                                <option value="">@localizer["AllTargets"]</option>
+                                @foreach (var type in Enum.GetValues<ChecklistTargetType>())
+                                {
+                                    <option value="@((int)type)" selected="@(Model.TargetType == type)">@localizer[type.ToString()]</option>
+                                }
+                            </select>
+                        </div>
+                    </div>
+                    <div class="rgw-filter-actions">
+                        <button class="btn btn-primary" type="submit"><i class="fa fa-filter"></i> @localizer["RefreshReport"]</button>
+                        <button class="btn btn-default" type="submit" formaction="@Url.Action("ComplianceCsv")"><i class="fa fa-download"></i> @localizer["ExportCsv"]</button>
+                        <button class="btn btn-default" type="submit" formaction="@Url.Action("ChecklistComplianceReport", "Reports")"><i class="fa fa-print"></i> @localizer["PrintReport"]</button>
+                    </div>
+                </form>
+            </div>
+
+            @if (!Model.IsRedacted)
+            {
+                <div class="row">
+                    <div class="col-lg-3 col-md-6">
+                        <div class="ibox"><div class="ibox-title"><h5>@localizer["ExpectedChecks"]</h5></div>
+                            <div class="ibox-content"><h1 class="no-margins">@expected</h1></div></div>
+                    </div>
+                    <div class="col-lg-3 col-md-6">
+                        <div class="ibox"><div class="ibox-title"><h5>@localizer["CompletedChecks"]</h5></div>
+                            <div class="ibox-content"><h1 class="no-margins">@completed</h1><small>@localizer["OnTimeChecks"]: @onTime</small></div></div>
+                    </div>
+                    <div class="col-lg-3 col-md-6">
+                        <div class="ibox"><div class="ibox-title"><h5>@localizer["MissedChecks"]</h5></div>
+                            <div class="ibox-content"><h1 class="no-margins @(missed > 0 ? "text-danger" : string.Empty)">@missed</h1></div></div>
+                    </div>
+                    <div class="col-lg-3 col-md-6">
+                        <div class="ibox"><div class="ibox-title"><h5>@localizer["CompletionRate"]</h5></div>
+                            <div class="ibox-content"><h1 class="no-margins">@(expected > 0 ? (100m * completed / expected).ToString("0.##") + "%" : "—")</h1></div></div>
+                    </div>
+                </div>
+
+                if (Model.Groups.Count == 0)
+                {
+                    <div class="text-center m-t-lg m-b-lg">
+                        <i class="fa fa-bar-chart fa-3x text-muted"></i>
+                        <h4 class="m-t-sm">@localizer["NoResults"]</h4>
+                    </div>
+                }
+                else
+                {
+                    <div class="table-responsive">
+                        <table class="table table-striped rgw-table">
+                            <thead>
+                                <tr>
+                                    <th>@localizer["Target"]</th>
+                                    <th>@localizer["TargetType"]</th>
+                                    <th class="text-right">@localizer["ExpectedChecks"]</th>
+                                    <th class="text-right">@localizer["CompletedChecks"]</th>
+                                    <th class="text-right">@localizer["OnTimeChecks"]</th>
+                                    <th class="text-right">@localizer["MissedChecks"]</th>
+                                    <th class="text-right">@localizer["ExcusedChecks"]</th>
+                                    <th class="text-right">@localizer["CompletionRate"]</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach (var group in Model.Groups)
+                                {
+                                    <tr>
+                                        <td>@group.Target.Name</td>
+                                        <td>@localizer[group.Target.Type.ToString()]</td>
+                                        <td class="text-right">@group.Expected</td>
+                                        <td class="text-right">@group.Completed</td>
+                                        <td class="text-right">@group.OnTime</td>
+                                        <td class="text-right">
+                                            @if (group.Missed > 0)
+                                            {
+                                                <span class="label label-danger">@group.Missed</span>
+                                            }
+                                            else
+                                            {
+                                                <span class="label label-success">0</span>
+                                            }
+                                        </td>
+                                        <td class="text-right">@group.Skipped</td>
+                                        <td class="text-right">@(group.CompletionRate.HasValue ? group.CompletionRate.Value.ToString("0.##") + "%" : "—")</td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <h3>@localizer["MissedTrend"]</h3>
+                    <div class="table-responsive">
+                        <table class="table table-striped rgw-table">
+                            <thead><tr><th>@localizer["Date"] (UTC)</th><th class="text-right">@localizer["ExpectedChecks"]</th><th>@localizer["MissedChecks"]</th></tr></thead>
+                            <tbody>
+                                @foreach (var day in Model.Trend)
+                                {
+                                    <tr>
+                                        <td>@day.DayUtc.ToString("yyyy-MM-dd")</td>
+                                        <td class="text-right">@day.Expected</td>
+                                        <td><progress max="@day.Expected" value="@day.Missed" aria-label="@localizer["MissedChecks"]"></progress> @day.Missed</td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    </div>
+                }
+
+                foreach (var source in Model.UnavailableSources)
+                {
+                    <div class="alert alert-warning">@localizer[source]</div>
+                }
+            }
+
+            <div class="hr-line-dashed"></div>
+            <p class="text-muted">@localizer["ScheduledReportProtected"]</p>
+            <div class="rgw-toolbar">
+                <a class="btn btn-default btn-sm" asp-action="Index"><i class="fa fa-arrow-left"></i> @localizer["Back"]</a>
+                <div class="rgw-toolbar-spacer"></div>
+                <a class="btn btn-default" asp-action="ReadinessPacket"><i class="fa fa-file-pdf-o"></i> @localizer["ReadinessPacketReport"]</a>
+                <a class="btn btn-default" asp-controller="Profile" asp-action="AddNewScheduledReport"><i class="fa fa-clock-o"></i> @localizer["ScheduleReport"]</a>
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Styles {
+    <link rel="stylesheet" href="~/css/workspace.css" asp-append-version="true" />
+}
 @section Scripts { @await Html.PartialAsync("_ProtectionScripts") }

--- a/Web/Resgrid.Web/Areas/User/Views/Checklists/Detail.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Checklists/Detail.cshtml
@@ -1,44 +1,205 @@
 @model Resgrid.Web.Areas.User.Models.Checklists.ChecklistDetailView
 @using Resgrid.Model.Checklists
 @inject IStringLocalizer<Resgrid.Localization.Areas.User.Checklists.Checklists> localizer
-@{ ViewBag.Title = "Resgrid | " + Model.Definition.Form.Name; var definition = Model.Definition.Definition; }
-<div class="wrapper wrapper-content"><div class="ibox"><div class="ibox-content">
-    <h2>@Model.Definition.Form.Name</h2><p style="white-space: pre-wrap">@Model.Definition.Form.Instructions</p>
-    <p>@localizer["PublishedVersion"]: @definition.PublishedVersion · @(definition.Retired ? localizer["Retired"] : localizer["Active"])</p>
-    @await Html.PartialAsync("_Protection")
-    @if (Model.CanManage)
+@functions {
+    string RunPill(ChecklistRunState state) => state switch
     {
-        <p><a class="btn btn-default" asp-action="Edit" asp-route-id="@definition.Id">@localizer["EditDraft"]</a><a class="btn btn-default" asp-action="Schedules" asp-route-id="@definition.Id">@localizer["Schedules"]</a></p>
-        <form class="checklist-form" asp-action="Publish" method="post">
-            @Html.AntiForgeryToken()<input type="hidden" name="id" value="@definition.Id" /><input type="hidden" name="revision" value="@definition.Revision" />
-            <button class="btn btn-primary" type="submit">@localizer["PublishDraft"]</button><span class="help-block">@localizer["PublishGuidance"]</span>
-        </form>
-        <form class="checklist-form" asp-action="Retire" method="post">
-            @Html.AntiForgeryToken()<input type="hidden" name="id" value="@definition.Id" /><input type="hidden" name="revision" value="@definition.Revision" />
-            <button class="btn btn-warning" type="submit">@localizer["Retire"]</button>
-            @if (definition.PublishedVersion == 0) { <button class="btn btn-danger" type="submit" name="delete" value="true">@localizer["DeleteDraft"]</button> }
-        </form>
-    }
-    @if (Model.CanStart)
-    {
-        <hr /><form class="checklist-form" asp-action="Start" method="post">
-            @Html.AntiForgeryToken()<input type="hidden" name="id" value="@definition.Id" /><input type="hidden" name="completionId" value="@Guid.NewGuid().ToString()" />
-            <label for="targetId">@localizer["Target"]</label><select id="targetId" name="targetId" class="form-control" required>
-                <option value="">@localizer["SelectTarget"]</option>
-                @foreach (var target in Model.Targets) { <option value="@target.Id">@target.Name</option> }
-            </select><button class="btn btn-success" type="submit">@localizer["StartRun"]</button>
-        </form>
-    }
-    <hr /><h3>@localizer["History"]</h3>
-    <table class="table table-striped"><thead><tr><th>@localizer["Started"] (UTC)</th><th>@localizer["Target"]</th><th>@localizer["State"]</th><th>@localizer["Score"]</th><th>@localizer["Result"]</th></tr></thead><tbody>
-    @foreach (var entry in Model.History)
-    {
-        var run = entry.Completion;
-        <tr><td><a asp-action="Run" asp-route-id="@run.Id">@run.CreatedOn.ToString("yyyy-MM-dd HH:mm:ss")</a></td><td>@entry.TargetName</td><td>@localizer[((ChecklistRunState)run.State).ToString()]</td><td>@(run.Score.HasValue ? run.Score + "%" : "—")</td><td>@(run.SubmittedOn.HasValue ? run.Passed.HasValue ? run.Passed.Value ? localizer["Passed"] : localizer["Failed"] : "—" : localizer["Incomplete"])</td></tr>
-    }
-    </tbody></table>
-    @if (Model.Page > 0) { <a class="btn btn-default" asp-route-id="@definition.Id" asp-route-page="@(Model.Page - 1)">@localizer["Previous"]</a> }
-    @if (Model.HasMore) { <a class="btn btn-default" asp-route-id="@definition.Id" asp-route-page="@(Model.Page + 1)">@localizer["Next"]</a> }
-    <a class="btn btn-default" asp-action="Index">@localizer["Back"]</a>
-</div></div></div>
+        ChecklistRunState.InProgress => "label-warning",
+        ChecklistRunState.AwaitingWitness => "label-info",
+        _ => "label-success"
+    };
+}
+@{
+    ViewBag.Title = "Resgrid | " + Model.Definition.Form.Name;
+    var definition = Model.Definition.Definition;
+    ViewData["Tab"] = "Index";
+    ViewData["Title"] = Model.Definition.Form.Name;
+}
+
+@await Html.PartialAsync("_Shell")
+
+<div class="wrapper wrapper-content">
+    <div class="ibox float-e-margins">
+        <div class="ibox-title"><h5>@Model.Definition.Form.Name</h5></div>
+        <div class="ibox-content">
+            @await Html.PartialAsync("_Tabs")
+            @await Html.PartialAsync("_Protection")
+
+            <div class="rgw-toolbar">
+                <a class="btn btn-default btn-sm" asp-action="Index"><i class="fa fa-arrow-left"></i> @localizer["Back"]</a>
+                <div class="rgw-toolbar-spacer"></div>
+                @if (Model.CanStart)
+                {
+                    <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#checklist-start"><i class="fa fa-play"></i> @localizer["StartRun"]</button>
+                }
+                @if (Model.CanManage)
+                {
+                    <a class="btn btn-default" asp-action="Edit" asp-route-id="@definition.Id"><i class="fa fa-pencil"></i> @localizer["EditDraft"]</a>
+                    <a class="btn btn-default" asp-action="Schedules" asp-route-id="@definition.Id"><i class="fa fa-calendar"></i> @localizer["Schedules"]</a>
+                    <button type="button" class="btn btn-default" data-toggle="modal" data-target="#checklist-lifecycle"><i class="fa fa-cog"></i> @localizer["PublishDraft"]</button>
+                }
+            </div>
+
+            <p class="text-muted">
+                <span class="label @(definition.Retired ? "label-danger" : "label-success")">@(definition.Retired ? localizer["Retired"] : localizer["Active"])</span>
+                @localizer["PublishedVersion"]: @definition.PublishedVersion
+            </p>
+            @if (!string.IsNullOrEmpty(Model.Definition.Form.Instructions))
+            {
+                <p style="white-space: pre-wrap">@Model.Definition.Form.Instructions</p>
+            }
+
+            <div class="hr-line-dashed"></div>
+
+            <h3>@localizer["History"]</h3>
+            @if (Model.History.Count == 0)
+            {
+                <div class="text-center m-t-lg m-b-lg">
+                    <i class="fa fa-history fa-3x text-muted"></i>
+                    <h4 class="m-t-sm">@localizer["NoResults"]</h4>
+                </div>
+            }
+            else
+            {
+                <div class="table-responsive">
+                    <table class="table table-striped rgw-table">
+                        <thead>
+                            <tr>
+                                <th>@localizer["Started"] (UTC)</th>
+                                <th>@localizer["Target"]</th>
+                                <th>@localizer["State"]</th>
+                                <th class="text-right">@localizer["Score"]</th>
+                                <th>@localizer["Result"]</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var entry in Model.History)
+                            {
+                                var run = entry.Completion;
+                                var state = (ChecklistRunState)run.State;
+                                <tr>
+                                    <td><a asp-action="Run" asp-route-id="@run.Id">@run.CreatedOn.ToString("yyyy-MM-dd HH:mm:ss")</a></td>
+                                    <td>@entry.TargetName</td>
+                                    <td><span class="label @RunPill(state)">@localizer[state.ToString()]</span></td>
+                                    <td class="text-right">@(run.Score.HasValue ? run.Score + "%" : "—")</td>
+                                    <td>
+                                        @if (!run.SubmittedOn.HasValue)
+                                        {
+                                            <span class="label">@localizer["Incomplete"]</span>
+                                        }
+                                        else if (run.Passed == true)
+                                        {
+                                            <span class="label label-success">@localizer["Passed"]</span>
+                                        }
+                                        else if (run.Passed == false)
+                                        {
+                                            <span class="label label-danger">@localizer["Failed"]</span>
+                                        }
+                                        else
+                                        {
+                                            <span class="text-muted">—</span>
+                                        }
+                                    </td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                </div>
+            }
+
+            @if (Model.Page > 0 || Model.HasMore)
+            {
+                <div class="rgw-pager">
+                    @if (Model.Page > 0)
+                    {
+                        <a class="btn btn-default btn-sm" asp-route-id="@definition.Id" asp-route-page="@(Model.Page - 1)"><i class="fa fa-chevron-left"></i> @localizer["Previous"]</a>
+                    }
+                    @if (Model.HasMore)
+                    {
+                        <a class="btn btn-default btn-sm" asp-route-id="@definition.Id" asp-route-page="@(Model.Page + 1)">@localizer["Next"] <i class="fa fa-chevron-right"></i></a>
+                    }
+                    <span class="text-muted">@(Model.Page + 1)</span>
+                </div>
+            }
+
+            @if (Model.CanStart)
+            {
+                <div class="modal fade rgw-modal" id="checklist-start" tabindex="-1" role="dialog" aria-labelledby="checklist-start-title">
+                    <div class="modal-dialog" role="document">
+                        <div class="modal-content">
+                            <div class="modal-header">
+                                <button type="button" class="close" data-dismiss="modal" aria-label="@localizer["Close"]"><span aria-hidden="true">&times;</span></button>
+                                <h4 class="modal-title" id="checklist-start-title">@localizer["StartRun"]</h4>
+                            </div>
+                            <div class="modal-body">
+                                <p class="text-muted">@localizer["StartRunHint"]</p>
+                                <form class="checklist-form" asp-action="Start" method="post">
+                                    @Html.AntiForgeryToken()
+                                    <input type="hidden" name="id" value="@definition.Id" />
+                                    <input type="hidden" name="completionId" value="@Guid.NewGuid().ToString()" />
+                                    <div class="rgw-grid">
+                                        <div class="form-group rgw-wide">
+                                            <label for="targetId">@localizer["Target"]</label>
+                                            <select id="targetId" name="targetId" class="form-control" required>
+                                                <option value="">@localizer["SelectTarget"]</option>
+                                                @foreach (var target in Model.Targets)
+                                                {
+                                                    <option value="@target.Id">@target.Name</option>
+                                                }
+                                            </select>
+                                        </div>
+                                    </div>
+                                    <div class="rgw-wizard-actions">
+                                        <div class="rgw-wizard-spacer"></div>
+                                        <button type="button" class="btn btn-white" data-dismiss="modal">@localizer["Close"]</button>
+                                        <button class="btn btn-primary" type="submit">@localizer["StartRun"]</button>
+                                    </div>
+                                </form>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            }
+
+            @if (Model.CanManage)
+            {
+                <div class="modal fade rgw-modal" id="checklist-lifecycle" tabindex="-1" role="dialog" aria-labelledby="checklist-lifecycle-title">
+                    <div class="modal-dialog" role="document">
+                        <div class="modal-content">
+                            <div class="modal-header">
+                                <button type="button" class="close" data-dismiss="modal" aria-label="@localizer["Close"]"><span aria-hidden="true">&times;</span></button>
+                                <h4 class="modal-title" id="checklist-lifecycle-title">@localizer["PublishDraft"]</h4>
+                            </div>
+                            <div class="modal-body">
+                                <form class="checklist-form" asp-action="Publish" method="post">
+                                    @Html.AntiForgeryToken()
+                                    <input type="hidden" name="id" value="@definition.Id" />
+                                    <input type="hidden" name="revision" value="@definition.Revision" />
+                                    <p class="text-muted">@localizer["PublishGuidance"]</p>
+                                    <button class="btn btn-primary" type="submit">@localizer["PublishDraft"]</button>
+                                </form>
+                                <div class="hr-line-dashed"></div>
+                                <form class="checklist-form" asp-action="Retire" method="post">
+                                    @Html.AntiForgeryToken()
+                                    <input type="hidden" name="id" value="@definition.Id" />
+                                    <input type="hidden" name="revision" value="@definition.Revision" />
+                                    <p class="text-muted">@localizer["RetireHint"]</p>
+                                    <button class="btn btn-warning" type="submit">@localizer["Retire"]</button>
+                                    @if (definition.PublishedVersion == 0)
+                                    {
+                                        <button class="btn btn-danger" type="submit" name="delete" value="true">@localizer["DeleteDraft"]</button>
+                                    }
+                                </form>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            }
+        </div>
+    </div>
+</div>
+
+@section Styles {
+    <link rel="stylesheet" href="~/css/workspace.css" asp-append-version="true" />
+}
 @section Scripts { @await Html.PartialAsync("_ProtectionScripts") }

--- a/Web/Resgrid.Web/Areas/User/Views/Checklists/Due.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Checklists/Due.cshtml
@@ -1,23 +1,147 @@
 @model Resgrid.Web.Areas.User.Models.Checklists.ChecklistDueView
 @using Resgrid.Model.Checklists
 @inject IStringLocalizer<Resgrid.Localization.Areas.User.Checklists.Checklists> localizer
-@{ ViewBag.Title = "Resgrid | " + localizer["DueChecks"]; }
-<div class="wrapper wrapper-content"><div class="ibox"><div class="ibox-content">
-    <h2>@localizer["DueChecks"]</h2><p>@localizer["DueGuidance"]</p>
-    @await Html.PartialAsync("_Protection")
-    @if (Model.Occurrences.Count == 0) { <p>@localizer["NoDueChecks"]</p> }
-    <div class="table-responsive"><table class="table table-striped"><thead><tr><th>@localizer["Name"]</th><th>@localizer["Target"]</th><th>@localizer["ScheduledFor"] (UTC)</th><th>@localizer["WindowEnds"] (UTC)</th><th>@localizer["State"]</th><th>@localizer["Actions"]</th></tr></thead><tbody>
-    @foreach (var entry in Model.Occurrences)
+@*
+    Excusing a check is a decision that needs a reason, so it opens in a dialog rather than an
+    inline disclosure. The textarea still lives on the page, which is what stops the live
+    refresh in checklist-live.js from throwing away a half typed reason.
+*@
+@functions {
+    string StatePill(ChecklistOccurrenceState state) => state switch
     {
-        var row = entry.Occurrence;
-        <tr><td>@entry.Name</td><td>@entry.Target.Name</td><td>@row.PeriodStartUtc?.ToString("yyyy-MM-dd HH:mm")</td><td>@row.WindowEndUtc?.ToString("yyyy-MM-dd HH:mm")</td><td>@localizer[((ChecklistOccurrenceState)row.State).ToString()]</td><td>
-            @if (entry.CanStart) { <form class="checklist-form" asp-action="StartOccurrence" method="post">@Html.AntiForgeryToken()<input type="hidden" name="id" value="@row.Id" /><button type="submit" class="btn btn-success">@localizer["OpenCheck"]</button></form> }
-            @if (entry.CanSkip) { <details><summary>@localizer["ExcuseCheck"]</summary><form class="checklist-form" asp-action="SkipOccurrence" method="post">@Html.AntiForgeryToken()<input type="hidden" name="id" value="@row.Id" /><input type="hidden" name="revision" value="@row.Revision" /><label for="reason-@row.Id">@localizer["SkipReason"]</label><textarea id="reason-@row.Id" name="reason" class="form-control" maxlength="4000" required></textarea><button type="submit" class="btn btn-warning">@localizer["ExcuseCheck"]</button></form></details> }
-        </td></tr>
-    }
-    </tbody></table></div>
-    @if (Model.Page > 0) { <a class="btn btn-default" asp-route-page="@(Model.Page - 1)">@localizer["Previous"]</a> }
-    @if (Model.HasMore) { <a class="btn btn-default" asp-route-page="@(Model.Page + 1)">@localizer["Next"]</a> }<a class="btn btn-default" asp-action="Index">@localizer["Back"]</a>
-</div></div></div>
+        ChecklistOccurrenceState.Scheduled => "label-info",
+        ChecklistOccurrenceState.InProgress => "label-warning",
+        ChecklistOccurrenceState.Missed => "label-danger",
+        ChecklistOccurrenceState.Skipped => "",
+        _ => ""
+    };
+}
+@{
+    ViewBag.Title = "Resgrid | " + localizer["DueChecks"];
+    ViewData["Tab"] = "Due";
+    ViewData["Title"] = localizer["DueChecks"].Value;
+    ViewData["Subtitle"] = localizer["DueGuidance"].Value;
+}
+
+@await Html.PartialAsync("_Shell")
+
+<div class="wrapper wrapper-content">
+    <div class="ibox float-e-margins">
+        <div class="ibox-title"><h5>@localizer["DueChecks"]</h5></div>
+        <div class="ibox-content">
+            @await Html.PartialAsync("_Tabs")
+            @await Html.PartialAsync("_Protection")
+
+            <div class="alert alert-info"><i class="fa fa-info-circle"></i> @localizer["DueGuidance"]</div>
+
+            @if (Model.Occurrences.Count == 0)
+            {
+                <div class="text-center m-t-lg m-b-lg">
+                    <i class="fa fa-clock-o fa-3x text-muted"></i>
+                    <h4 class="m-t-sm">@localizer["NoDueChecks"]</h4>
+                </div>
+            }
+            else
+            {
+                <div class="table-responsive">
+                    <table class="table table-striped rgw-table">
+                        <thead>
+                            <tr>
+                                <th>@localizer["Name"]</th>
+                                <th>@localizer["Target"]</th>
+                                <th>@localizer["ScheduledFor"] (UTC)</th>
+                                <th>@localizer["WindowEnds"] (UTC)</th>
+                                <th>@localizer["State"]</th>
+                                <th class="rgw-row-actions">@localizer["Actions"]</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var entry in Model.Occurrences)
+                            {
+                                var row = entry.Occurrence;
+                                var state = (ChecklistOccurrenceState)row.State;
+                                <tr>
+                                    <td>@entry.Name</td>
+                                    <td>@entry.Target.Name</td>
+                                    <td>@row.PeriodStartUtc?.ToString("yyyy-MM-dd HH:mm")</td>
+                                    <td>@row.WindowEndUtc?.ToString("yyyy-MM-dd HH:mm")</td>
+                                    <td><span class="label @StatePill(state)">@localizer[state.ToString()]</span></td>
+                                    <td class="rgw-row-actions">
+                                        @if (entry.CanStart)
+                                        {
+                                            <form class="checklist-form" asp-action="StartOccurrence" method="post">
+                                                @Html.AntiForgeryToken()
+                                                <input type="hidden" name="id" value="@row.Id" />
+                                                <button type="submit" class="btn btn-xs btn-primary">@localizer["OpenCheck"]</button>
+                                            </form>
+                                        }
+                                        @if (entry.CanSkip)
+                                        {
+                                            <button type="button" class="btn btn-xs btn-default" data-toggle="modal" data-target="#skip-@row.Id">@localizer["ExcuseCheck"]</button>
+                                        }
+                                    </td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                </div>
+            }
+
+            @if (Model.Page > 0 || Model.HasMore)
+            {
+                <div class="rgw-pager">
+                    @if (Model.Page > 0)
+                    {
+                        <a class="btn btn-default btn-sm" asp-route-page="@(Model.Page - 1)"><i class="fa fa-chevron-left"></i> @localizer["Previous"]</a>
+                    }
+                    @if (Model.HasMore)
+                    {
+                        <a class="btn btn-default btn-sm" asp-route-page="@(Model.Page + 1)">@localizer["Next"] <i class="fa fa-chevron-right"></i></a>
+                    }
+                    <span class="text-muted">@(Model.Page + 1)</span>
+                </div>
+            }
+
+            @foreach (var entry in Model.Occurrences.Where(x => x.CanSkip))
+            {
+                var row = entry.Occurrence;
+                <div class="modal fade rgw-modal" id="skip-@row.Id" tabindex="-1" role="dialog" aria-labelledby="skip-@(row.Id)-title">
+                    <div class="modal-dialog" role="document">
+                        <div class="modal-content">
+                            <div class="modal-header">
+                                <button type="button" class="close" data-dismiss="modal" aria-label="@localizer["Close"]"><span aria-hidden="true">&times;</span></button>
+                                <h4 class="modal-title" id="skip-@(row.Id)-title">@localizer["ExcuseCheck"] &middot; @entry.Name</h4>
+                            </div>
+                            <div class="modal-body">
+                                <p class="text-muted">@localizer["SkipHint"]</p>
+                                <form class="checklist-form" asp-action="SkipOccurrence" method="post">
+                                    @Html.AntiForgeryToken()
+                                    <input type="hidden" name="id" value="@row.Id" />
+                                    <input type="hidden" name="revision" value="@row.Revision" />
+                                    <div class="rgw-grid">
+                                        <div class="form-group rgw-wide">
+                                            <label for="reason-@row.Id">@localizer["SkipReason"]</label>
+                                            <textarea id="reason-@row.Id" name="reason" class="form-control" rows="3" maxlength="4000" required></textarea>
+                                        </div>
+                                    </div>
+                                    <div class="rgw-wizard-actions">
+                                        <div class="rgw-wizard-spacer"></div>
+                                        <button type="button" class="btn btn-white" data-dismiss="modal">@localizer["Close"]</button>
+                                        <button type="submit" class="btn btn-warning">@localizer["ExcuseCheck"]</button>
+                                    </div>
+                                </form>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            }
+        </div>
+    </div>
+</div>
+
 <form id="checklist-live-refresh" class="checklist-form" asp-action="Reopen" method="post" hidden>@Html.AntiForgeryToken()<input type="hidden" name="page" value="Due" /></form>
+
+@section Styles {
+    <link rel="stylesheet" href="~/css/workspace.css" asp-append-version="true" />
+}
 @section Scripts { @await Html.PartialAsync("_ProtectionScripts") @await Html.PartialAsync("_LiveScripts") }

--- a/Web/Resgrid.Web/Areas/User/Views/Checklists/Edit.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Checklists/Edit.cshtml
@@ -1,20 +1,49 @@
 @model Resgrid.Web.Areas.User.Models.Checklists.ChecklistEditView
 @using Newtonsoft.Json
 @inject IStringLocalizer<Resgrid.Localization.Areas.User.Checklists.Checklists> localizer
-@{ ViewBag.Title = "Resgrid | " + localizer["EditChecklist"]; }
-<div class="wrapper wrapper-content"><div class="ibox"><div class="ibox-content">
-    <h2>@localizer["EditChecklist"]</h2><p>@localizer["DraftGuidance"]</p>
-    @await Html.PartialAsync("_Protection")
-    <div id="checklist-error" class="alert alert-danger" role="alert" hidden></div>
-    <form id="checklist-editor" class="checklist-form" asp-action="SaveDefinition" method="post">
-        @Html.AntiForgeryToken()
-        <input type="hidden" name="id" value="@Model.Id" /><input type="hidden" name="revision" value="@Model.Revision" /><input type="hidden" name="formJson" />
-        <div id="checklist-builder" data-assets-available="@Model.AssetsAvailable.ToString().ToLowerInvariant()"></div>
-        <button class="btn btn-primary" type="submit">@localizer["SaveDraft"]</button>
-        <a class="btn btn-default" asp-action="Index">@localizer["Back"]</a>
-    </form>
-    <script id="checklist-form-data" type="application/json">@Html.Raw(JsonConvert.SerializeObject(Model.Form, new JsonSerializerSettings { StringEscapeHandling = StringEscapeHandling.EscapeHtml }))</script>
-</div></div></div>
+@*
+    The section and item builder is rendered by checklists.js into #checklist-builder, so this
+    view supplies the chrome and the form contract that script depends on.
+*@
+@{
+    ViewBag.Title = "Resgrid | " + localizer["EditChecklist"];
+    ViewData["Tab"] = "Index";
+    ViewData["Title"] = localizer["EditChecklist"].Value;
+    ViewData["Subtitle"] = localizer["DraftGuidance"].Value;
+}
+
+@await Html.PartialAsync("_Shell")
+
+<div class="wrapper wrapper-content">
+    <div class="ibox float-e-margins">
+        <div class="ibox-title"><h5>@localizer["EditChecklist"]</h5></div>
+        <div class="ibox-content">
+            @await Html.PartialAsync("_Protection")
+
+            <div class="alert alert-info"><i class="fa fa-info-circle"></i> @localizer["DraftGuidance"]</div>
+            <div id="checklist-error" class="alert alert-danger" role="alert" hidden></div>
+
+            <form id="checklist-editor" class="checklist-form" asp-action="SaveDefinition" method="post">
+                @Html.AntiForgeryToken()
+                <input type="hidden" name="id" value="@Model.Id" />
+                <input type="hidden" name="revision" value="@Model.Revision" />
+                <input type="hidden" name="formJson" />
+                <div id="checklist-builder" data-assets-available="@Model.AssetsAvailable.ToString().ToLowerInvariant()"></div>
+                <div class="rgw-wizard-actions">
+                    <div class="rgw-wizard-spacer"></div>
+                    <a class="btn btn-white" asp-action="Index">@localizer["Close"]</a>
+                    <button class="btn btn-primary" type="submit">@localizer["SaveDraft"]</button>
+                </div>
+            </form>
+
+            <script id="checklist-form-data" type="application/json">@Html.Raw(JsonConvert.SerializeObject(Model.Form, new JsonSerializerSettings { StringEscapeHandling = StringEscapeHandling.EscapeHtml }))</script>
+        </div>
+    </div>
+</div>
+
+@section Styles {
+    <link rel="stylesheet" href="~/css/workspace.css" asp-append-version="true" />
+}
 @section Scripts {
     @await Html.PartialAsync("_ProtectionScripts")
     <script src="~/js/app/internal/checklists/checklists.js" asp-append-version="true"></script>

--- a/Web/Resgrid.Web/Areas/User/Views/Checklists/EditSchedule.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Checklists/EditSchedule.cshtml
@@ -1,33 +1,196 @@
 @model Resgrid.Web.Areas.User.Models.Checklists.ChecklistScheduleEditView
 @using Resgrid.Model.Checklists
 @inject IStringLocalizer<Resgrid.Localization.Areas.User.Checklists.Checklists> localizer
-@{ ViewBag.Title = "Resgrid | " + localizer["EditSchedule"]; }
-<div class="wrapper wrapper-content"><div class="ibox"><div class="ibox-content">
-    <h2>@localizer["EditSchedule"]</h2>
-    @await Html.PartialAsync("_Protection")
-    <form class="checklist-form" asp-action="SaveSchedule" method="post">
-        @Html.AntiForgeryToken()<input asp-for="Input.Id" type="hidden" /><input asp-for="Input.DefinitionId" type="hidden" /><input asp-for="Input.Revision" type="hidden" />
-        <div class="form-group"><label asp-for="Input.Name">@localizer["Name"]</label><input asp-for="Input.Name" class="form-control" maxlength="200" required /></div>
-        <div class="form-group"><label asp-for="Input.Notes">@localizer["ScheduleNotes"]</label><textarea asp-for="Input.Notes" class="form-control" maxlength="4000"></textarea></div>
-        <div class="form-group"><label asp-for="Input.TargetId">@localizer["Target"]</label><select asp-for="Input.TargetId" class="form-control" required><option value="">@localizer["SelectTarget"]</option>@foreach (var target in Model.Targets) { <option value="@target.Id">@target.Name</option> }</select></div>
-        <div class="form-group"><label asp-for="Input.Frequency">@localizer["Frequency"]</label><select asp-for="Input.Frequency" class="form-control">@foreach (var frequency in Enum.GetValues<ChecklistScheduleFrequency>().Where(f => f != ChecklistScheduleFrequency.OnDemand)) { <option value="@((int)frequency)">@localizer[frequency.ToString()]</option> }</select></div>
-        <div class="form-group"><label asp-for="Input.TimeZoneId">@localizer["TimeZone"]</label><select asp-for="Input.TimeZoneId" class="form-control">@if (!TimeZoneInfo.GetSystemTimeZones().Any(z => z.Id == Model.Input.TimeZoneId)) { <option value="@Model.Input.TimeZoneId">@Model.Input.TimeZoneId</option> }@foreach (var zone in TimeZoneInfo.GetSystemTimeZones()) { <option value="@zone.Id">@zone.Id</option> }</select><p class="help-block">@localizer["ScheduleTimeGuidance"]</p></div>
-        <div class="form-group"><label asp-for="Input.StartDate">@localizer["ScheduleStartDate"]</label><input asp-for="Input.StartDate" type="date" class="form-control" required min="2000-01-01" max="2200-12-31" /></div>
-        <div class="form-group"><label asp-for="Input.EndDate">@localizer["ScheduleEndDate"]</label><input asp-for="Input.EndDate" type="date" class="form-control" min="2000-01-01" max="2200-12-31" /></div>
-        <div class="form-group"><label asp-for="Input.TimesOfDay">@localizer["TimesOfDay"]</label><input asp-for="Input.TimesOfDay" class="form-control" required maxlength="54" placeholder="08:00, 20:00" /><p class="help-block">@localizer["TimesOfDayGuidance"]</p></div>
-        <fieldset><legend>@localizer["WeeklyDays"]</legend>@for (var day = 0; day < 7; day++) { <label class="checkbox-inline"><input type="checkbox" name="selectedWeekdays" value="@day" checked="@((Model.Input.Weekdays & (1 << day)) != 0)" />@System.Globalization.CultureInfo.CurrentUICulture.DateTimeFormat.GetDayName((DayOfWeek)day)</label> }</fieldset>
-        <div class="form-group"><label asp-for="Input.DayOfMonth">@localizer["DayOfMonth"]</label><input asp-for="Input.DayOfMonth" class="form-control" type="number" min="1" max="31" required /></div>
-        <div class="form-group"><label asp-for="Input.MonthOfYear">@localizer["AnchorMonth"]</label><select asp-for="Input.MonthOfYear" class="form-control">@for (var month = 1; month <= 12; month++) { <option value="@month">@System.Globalization.CultureInfo.CurrentUICulture.DateTimeFormat.GetMonthName(month)</option> }</select><p class="help-block">@localizer["MonthGuidance"]</p></div>
-        <div class="form-group"><label asp-for="Input.WorkshiftId">@localizer["ScheduleWorkshift"]</label><select asp-for="Input.WorkshiftId" class="form-control"><option value="">@localizer["WorkshiftFallback"]</option>@foreach (var shift in Model.Workshifts) { <option value="@shift.Id">@shift.Name</option> }</select><p class="help-block">@localizer["WorkshiftGuidance"]</p></div>
-        <div class="form-group"><label asp-for="Input.WindowMinutes">@localizer["WindowMinutes"]</label><input asp-for="Input.WindowMinutes" class="form-control" type="number" min="1" max="10080" required /></div>
-        <div class="form-group"><label for="assignment">@localizer["Assignment"]</label><select id="assignment" name="assignment" class="form-control">
-            <option value="0:" selected="@(Model.Input.AssignmentType == 0)">@localizer["AssignmentAutomatic"]</option>
-            @if (Model.Input.AssignmentType != 0 && !Model.Assignments.Any(c => c.Type == Model.Input.AssignmentType && c.Id == Model.Input.AssignmentId)) { <option value="@Model.Input.AssignmentType:@Model.Input.AssignmentId" selected>@localizer["AssignmentUnavailable"]</option> }
-            @foreach (var choice in Model.Assignments) { <option value="@choice.Type:@choice.Id" selected="@(Model.Input.AssignmentType == choice.Type && Model.Input.AssignmentId == choice.Id)">@localizer["AssignmentType" + choice.Type]: @choice.Name</option> }
-        </select></div>
-        <div class="checkbox"><label><input asp-for="Input.IsActive" />@localizer["ScheduleEnabled"]</label></div>
-        <p>@localizer["ScheduleVersionGuidance"]</p>
-        <button class="btn btn-primary" type="submit">@localizer["SaveSchedule"]</button><a class="btn btn-default" asp-action="Schedules" asp-route-id="@Model.Input.DefinitionId">@localizer["Back"]</a>
-    </form>
-</div></div></div>
-@section Scripts { @await Html.PartialAsync("_ProtectionScripts") }
+@*
+    A schedule asks about fifteen things, so it is a step wizard: what it is called and what it
+    runs against, then when it fires, then who picks it up. The fields and their names are
+    unchanged, only the order they are asked in.
+*@
+@{
+    ViewBag.Title = "Resgrid | " + localizer["EditSchedule"];
+    ViewData["Tab"] = "Index";
+    ViewData["Title"] = localizer["EditSchedule"].Value;
+    ViewData["ParentText"] = localizer["Schedules"].Value;
+    ViewData["ParentAction"] = "Schedules";
+    ViewData["ParentId"] = Model.Input.DefinitionId;
+}
+
+@await Html.PartialAsync("_Shell")
+
+<div class="wrapper wrapper-content">
+    <div class="ibox float-e-margins">
+        <div class="ibox-title"><h5>@localizer["EditSchedule"]</h5></div>
+        <div class="ibox-content">
+            @await Html.PartialAsync("_Protection")
+
+            <form class="checklist-form rgw-wizard" asp-action="SaveSchedule" method="post">
+                @Html.AntiForgeryToken()
+                <input asp-for="Input.Id" type="hidden" />
+                <input asp-for="Input.DefinitionId" type="hidden" />
+                <input asp-for="Input.Revision" type="hidden" />
+
+                <ol class="rgw-steps"></ol>
+
+                <div class="rgw-step" data-title="@localizer["StepScheduleBasics"]">
+                    <h4>@localizer["StepScheduleBasics"]</h4>
+                    <p class="text-muted">@localizer["StepScheduleBasicsHint"]</p>
+                    <div class="rgw-grid">
+                        <div class="form-group">
+                            <label asp-for="Input.Name">@localizer["Name"]</label>
+                            <input asp-for="Input.Name" class="form-control" maxlength="200" required />
+                            <span class="help-block">@localizer["HelpFieldScheduleName"]</span>
+                        </div>
+                        <div class="form-group">
+                            <label asp-for="Input.TargetId">@localizer["Target"]</label>
+                            <select asp-for="Input.TargetId" class="form-control" required>
+                                <option value="">@localizer["SelectTarget"]</option>
+                                @foreach (var target in Model.Targets)
+                                {
+                                    <option value="@target.Id">@target.Name</option>
+                                }
+                            </select>
+                        </div>
+                        <div class="form-group rgw-wide">
+                            <label asp-for="Input.Notes">@localizer["ScheduleNotes"]</label>
+                            <textarea asp-for="Input.Notes" class="form-control" rows="3" maxlength="4000"></textarea>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="rgw-step" data-title="@localizer["StepScheduleTiming"]">
+                    <h4>@localizer["StepScheduleTiming"]</h4>
+                    <p class="text-muted">@localizer["StepScheduleTimingHint"]</p>
+                    <div class="rgw-grid">
+                        <div class="form-group">
+                            <label asp-for="Input.Frequency">@localizer["Frequency"]</label>
+                            <select asp-for="Input.Frequency" class="form-control">
+                                @foreach (var frequency in Enum.GetValues<ChecklistScheduleFrequency>().Where(f => f != ChecklistScheduleFrequency.OnDemand))
+                                {
+                                    <option value="@((int)frequency)">@localizer[frequency.ToString()]</option>
+                                }
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label asp-for="Input.TimeZoneId">@localizer["TimeZone"]</label>
+                            <select asp-for="Input.TimeZoneId" class="form-control">
+                                @if (!TimeZoneInfo.GetSystemTimeZones().Any(z => z.Id == Model.Input.TimeZoneId))
+                                {
+                                    <option value="@Model.Input.TimeZoneId">@Model.Input.TimeZoneId</option>
+                                }
+                                @foreach (var zone in TimeZoneInfo.GetSystemTimeZones())
+                                {
+                                    <option value="@zone.Id">@zone.Id</option>
+                                }
+                            </select>
+                            <span class="help-block">@localizer["ScheduleTimeGuidance"]</span>
+                        </div>
+                        <div class="form-group">
+                            <label asp-for="Input.StartDate">@localizer["ScheduleStartDate"]</label>
+                            <input asp-for="Input.StartDate" type="date" class="form-control" required min="2000-01-01" max="2200-12-31" />
+                        </div>
+                        <div class="form-group">
+                            <label asp-for="Input.EndDate">@localizer["ScheduleEndDate"]</label>
+                            <input asp-for="Input.EndDate" type="date" class="form-control" min="2000-01-01" max="2200-12-31" />
+                        </div>
+                        <div class="form-group rgw-wide">
+                            <label asp-for="Input.TimesOfDay">@localizer["TimesOfDay"]</label>
+                            <input asp-for="Input.TimesOfDay" class="form-control" required maxlength="54" placeholder="08:00, 20:00" />
+                            <span class="help-block">@localizer["TimesOfDayGuidance"]</span>
+                        </div>
+                        <div class="form-group rgw-wide">
+                            <label>@localizer["WeeklyDays"]</label>
+                            <div>
+                                @for (var day = 0; day < 7; day++)
+                                {
+                                    <label class="checkbox-inline">
+                                        <input type="checkbox" name="selectedWeekdays" value="@day" data-review-skip="true" checked="@((Model.Input.Weekdays & (1 << day)) != 0)" />
+                                        @System.Globalization.CultureInfo.CurrentUICulture.DateTimeFormat.GetDayName((DayOfWeek)day)
+                                    </label>
+                                }
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label asp-for="Input.DayOfMonth">@localizer["DayOfMonth"]</label>
+                            <input asp-for="Input.DayOfMonth" class="form-control" type="number" min="1" max="31" required />
+                        </div>
+                        <div class="form-group">
+                            <label asp-for="Input.MonthOfYear">@localizer["AnchorMonth"]</label>
+                            <select asp-for="Input.MonthOfYear" class="form-control">
+                                @for (var month = 1; month <= 12; month++)
+                                {
+                                    <option value="@month">@System.Globalization.CultureInfo.CurrentUICulture.DateTimeFormat.GetMonthName(month)</option>
+                                }
+                            </select>
+                            <span class="help-block">@localizer["MonthGuidance"]</span>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="rgw-step" data-title="@localizer["StepScheduleAssignment"]">
+                    <h4>@localizer["StepScheduleAssignment"]</h4>
+                    <p class="text-muted">@localizer["StepScheduleAssignmentHint"]</p>
+                    <div class="rgw-grid">
+                        <div class="form-group">
+                            <label for="assignment">@localizer["Assignment"]</label>
+                            <select id="assignment" name="assignment" class="form-control">
+                                <option value="0:" selected="@(Model.Input.AssignmentType == 0)">@localizer["AssignmentAutomatic"]</option>
+                                @if (Model.Input.AssignmentType != 0 && !Model.Assignments.Any(c => c.Type == Model.Input.AssignmentType && c.Id == Model.Input.AssignmentId))
+                                {
+                                    <option value="@Model.Input.AssignmentType:@Model.Input.AssignmentId" selected>@localizer["AssignmentUnavailable"]</option>
+                                }
+                                @foreach (var choice in Model.Assignments)
+                                {
+                                    <option value="@choice.Type:@choice.Id" selected="@(Model.Input.AssignmentType == choice.Type && Model.Input.AssignmentId == choice.Id)">@localizer["AssignmentType" + choice.Type]: @choice.Name</option>
+                                }
+                            </select>
+                            <span class="help-block">@localizer["HelpFieldAssignment"]</span>
+                        </div>
+                        <div class="form-group">
+                            <label asp-for="Input.WorkshiftId">@localizer["ScheduleWorkshift"]</label>
+                            <select asp-for="Input.WorkshiftId" class="form-control">
+                                <option value="">@localizer["WorkshiftFallback"]</option>
+                                @foreach (var shift in Model.Workshifts)
+                                {
+                                    <option value="@shift.Id">@shift.Name</option>
+                                }
+                            </select>
+                            <span class="help-block">@localizer["WorkshiftGuidance"]</span>
+                        </div>
+                        <div class="form-group">
+                            <label asp-for="Input.WindowMinutes">@localizer["WindowMinutes"]</label>
+                            <input asp-for="Input.WindowMinutes" class="form-control" type="number" min="1" max="10080" required />
+                            <span class="help-block">@localizer["HelpFieldWindowMinutes"]</span>
+                        </div>
+                        <div class="form-group">
+                            <div class="checkbox"><label><input asp-for="Input.IsActive" /> @localizer["ScheduleEnabled"]</label></div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="rgw-step" data-title="@localizer["Review"]">
+                    <h4>@localizer["Review"]</h4>
+                    <p class="text-muted">@localizer["ReviewHint"]</p>
+                    <dl class="rgw-review"></dl>
+                    <div class="alert alert-info"><i class="fa fa-info-circle"></i> @localizer["ScheduleVersionGuidance"]</div>
+                </div>
+
+                <div class="rgw-wizard-actions">
+                    <button type="button" class="btn btn-white rgw-step-prev">@localizer["Back"]</button>
+                    <div class="rgw-wizard-spacer"></div>
+                    <a class="btn btn-white" asp-action="Schedules" asp-route-id="@Model.Input.DefinitionId">@localizer["Close"]</a>
+                    <button type="button" class="btn btn-primary rgw-step-next">@localizer["Continue"]</button>
+                    <button type="submit" class="btn btn-primary rgw-step-submit">@localizer["SaveSchedule"]</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+@section Styles {
+    <link rel="stylesheet" href="~/css/workspace.css" asp-append-version="true" />
+}
+@section Scripts {
+    @await Html.PartialAsync("_ProtectionScripts")
+    <script id="workspace-settings" type="application/json">@Html.Raw(Newtonsoft.Json.JsonConvert.SerializeObject(new { required = localizer["RequiredFieldsMissing"].Value, nothingEntered = localizer["NoResults"].Value, yes = localizer["Yes"].Value, no = localizer["No"].Value }, new Newtonsoft.Json.JsonSerializerSettings { StringEscapeHandling = Newtonsoft.Json.StringEscapeHandling.EscapeHtml }))</script>
+    <script src="~/js/app/common/workspace/resgrid.common.workspace.js" asp-append-version="true"></script>
+}

--- a/Web/Resgrid.Web/Areas/User/Views/Checklists/Index.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Checklists/Index.cshtml
@@ -1,20 +1,86 @@
 @model Resgrid.Web.Areas.User.Models.Checklists.ChecklistIndexView
 @inject IStringLocalizer<Resgrid.Localization.Areas.User.Checklists.Checklists> localizer
-@{ ViewBag.Title = "Resgrid | " + localizer["Checklists"]; }
-<div class="row wrapper border-bottom white-bg page-heading"><div class="col-sm-12"><h2>@localizer["Checklists"]</h2><p>@localizer["Free"]</p></div></div>
-<div class="wrapper wrapper-content"><div class="ibox"><div class="ibox-content">
-    @await Html.PartialAsync("_Protection")
-    <p><a class="btn btn-default" asp-action="Templates">@localizer["Templates"]</a><a class="btn btn-default" asp-action="Due">@localizer["DueChecks"]</a>
-    <a class="btn btn-default" asp-action="Compliance">@localizer["ChecklistComplianceReport"]</a>
-    @if (Model.CanManage) { <a class="btn btn-default" asp-action="Reminders">@localizer["ReminderSettings"]</a> <a class="btn btn-primary" asp-action="New">@localizer["NewChecklist"]</a> }</p>
-    @if (Model.Definitions.Count == 0) { <p>@localizer["NoDefinitions"]</p> }
-    <table class="table table-striped"><thead><tr><th>@localizer["Name"]</th><th>@localizer["Version"]</th><th>@localizer["State"]</th></tr></thead><tbody>
-    @foreach (var item in Model.Definitions)
-    {
-        <tr><td><a asp-action="Detail" asp-route-id="@item.Definition.Id">@item.Form.Name</a></td><td>@item.Definition.PublishedVersion</td><td>@(item.Definition.Retired ? localizer["Retired"] : item.Definition.PublishedVersion == 0 ? localizer["Draft"] : localizer["Published"])</td></tr>
-    }
-    </tbody></table>
-    @if (Model.Page > 0) { <a class="btn btn-default" asp-route-page="@(Model.Page - 1)">@localizer["Previous"]</a> }
-    @if (Model.HasMore) { <a class="btn btn-default" asp-route-page="@(Model.Page + 1)">@localizer["Next"]</a> }
-</div></div></div>
+@{
+    ViewBag.Title = "Resgrid | " + localizer["Checklists"];
+    ViewData["Tab"] = "Index";
+    ViewData["Title"] = localizer["Checklists"].Value;
+    ViewData["Subtitle"] = localizer["ChecklistsIntro"].Value;
+}
+
+@await Html.PartialAsync("_Shell")
+
+<div class="wrapper wrapper-content">
+    <div class="ibox float-e-margins">
+        <div class="ibox-title"><h5>@localizer["Checklists"]</h5></div>
+        <div class="ibox-content">
+            @await Html.PartialAsync("_Tabs")
+            @await Html.PartialAsync("_Protection")
+
+            <div class="alert alert-info"><i class="fa fa-info-circle"></i> @localizer["HelpDefinitions"]</div>
+
+            @if (Model.CanManage)
+            {
+                <div class="rgw-toolbar">
+                    <div class="rgw-toolbar-spacer"></div>
+                    <a class="btn btn-primary" asp-action="New"><i class="fa fa-plus"></i> @localizer["NewChecklist"]</a>
+                </div>
+            }
+
+            @if (Model.Definitions.Count == 0)
+            {
+                <div class="text-center m-t-lg m-b-lg">
+                    <i class="fa fa-check-square-o fa-3x text-muted"></i>
+                    <h4 class="m-t-sm">@localizer["NoDefinitions"]</h4>
+                    <p class="text-muted">@localizer["NoRowsHelp"]</p>
+                </div>
+            }
+            else
+            {
+                <div class="table-responsive">
+                    <table class="table table-striped rgw-table">
+                        <thead><tr><th>@localizer["Name"]</th><th>@localizer["Version"]</th><th>@localizer["State"]</th><th class="rgw-row-actions">@localizer["Actions"]</th></tr></thead>
+                        <tbody>
+                            @foreach (var item in Model.Definitions)
+                            {
+                                var retired = item.Definition.Retired;
+                                var draft = item.Definition.PublishedVersion == 0;
+                                <tr>
+                                    <td>@item.Form.Name</td>
+                                    <td>@item.Definition.PublishedVersion</td>
+                                    <td>
+                                        <span class="label @(retired ? "label-danger" : draft ? "" : "label-success")">
+                                            @(retired ? localizer["Retired"] : draft ? localizer["Draft"] : localizer["Published"])
+                                        </span>
+                                    </td>
+                                    <td class="rgw-row-actions">
+                                        <a class="btn btn-xs btn-info" asp-action="Detail" asp-route-id="@item.Definition.Id">@localizer["History"]</a>
+                                    </td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                </div>
+            }
+
+            @if (Model.Page > 0 || Model.HasMore)
+            {
+                <div class="rgw-pager">
+                    @if (Model.Page > 0)
+                    {
+                        <a class="btn btn-default btn-sm" asp-route-page="@(Model.Page - 1)"><i class="fa fa-chevron-left"></i> @localizer["Previous"]</a>
+                    }
+                    @if (Model.HasMore)
+                    {
+                        <a class="btn btn-default btn-sm" asp-route-page="@(Model.Page + 1)">@localizer["Next"] <i class="fa fa-chevron-right"></i></a>
+                    }
+                    <span class="text-muted">@(Model.Page + 1)</span>
+                </div>
+            }
+        </div>
+    </div>
+</div>
+
+@section Styles {
+    <link rel="stylesheet" href="~/css/workspace.css" asp-append-version="true" />
+}
 @section Scripts { @await Html.PartialAsync("_ProtectionScripts") }

--- a/Web/Resgrid.Web/Areas/User/Views/Checklists/Locked.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Checklists/Locked.cshtml
@@ -1,14 +1,35 @@
 @model Resgrid.Web.Areas.User.Models.Checklists.ChecklistLockedView
 @inject IStringLocalizer<Resgrid.Localization.Areas.User.Checklists.Checklists> localizer
-@{ ViewBag.Title = "Resgrid | " + localizer["Protected checklists"]; ViewBag.ProtectionEnforced = true; }
-<div class="wrapper wrapper-content"><div class="ibox"><div class="ibox-content">
-    <h2>@localizer["Unlock checklist data"]</h2>
-    <p>@localizer["Verify your identity to view the checklist, answers and evidence."]</p>
-    @await Html.PartialAsync("_Protection")
-    <form id="checklist-reopen" class="checklist-form" asp-action="Reopen" method="post">
-        @Html.AntiForgeryToken()
-        <input type="hidden" name="page" value="@Model.Page" /><input type="hidden" name="id" value="@Model.Id" />
-        <button class="btn btn-primary" type="submit">@localizer["Verify and open"]</button>
-    </form>
-</div></div></div>
+@{
+    ViewBag.Title = "Resgrid | " + localizer["Protected checklists"];
+    ViewBag.ProtectionEnforced = true;
+    ViewData["Title"] = localizer["Protected checklists"].Value;
+}
+
+@await Html.PartialAsync("_Shell")
+
+<div class="wrapper wrapper-content">
+    <div class="ibox float-e-margins">
+        <div class="ibox-title"><h5>@localizer["Protected checklists"]</h5></div>
+        <div class="ibox-content">
+            @await Html.PartialAsync("_Protection")
+
+            <form id="checklist-reopen" class="checklist-form" asp-action="Reopen" method="post">
+                @Html.AntiForgeryToken()
+                <input type="hidden" name="page" value="@Model.Page" />
+                <input type="hidden" name="id" value="@Model.Id" />
+                <div class="text-center m-t-lg m-b-lg">
+                    <i class="fa fa-lock fa-3x text-muted"></i>
+                    <h4 class="m-t-sm">@localizer["Unlock checklist data"]</h4>
+                    <p class="text-muted">@localizer["Verify your identity to view the checklist, answers and evidence."]</p>
+                    <button class="btn btn-primary m-t" type="submit">@localizer["Verify and open"]</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+@section Styles {
+    <link rel="stylesheet" href="~/css/workspace.css" asp-append-version="true" />
+}
 @section Scripts { @await Html.PartialAsync("_ProtectionScripts") }

--- a/Web/Resgrid.Web/Areas/User/Views/Checklists/Occurrence.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Checklists/Occurrence.cshtml
@@ -1,13 +1,97 @@
 @model Resgrid.Model.Checklists.ChecklistOccurrenceView
+@using Resgrid.Model.Checklists
 @inject IStringLocalizer<Resgrid.Localization.Areas.User.Checklists.Checklists> localizer
-@{ ViewBag.Title = "Resgrid | " + localizer["DueChecks"]; }
-<div class="wrapper wrapper-content"><div class="ibox"><div class="ibox-content">
-    @await Html.PartialAsync("_Protection")
-    <h2>@Model.Name</h2><p>@Model.Target.Name</p>
-    <p><time datetime="@Model.Occurrence.PeriodStartUtc?.ToString("O")">@Model.Occurrence.PeriodStartUtc?.ToString("u")</time> — <time datetime="@Model.Occurrence.WindowEndUtc?.ToString("O")">@Model.Occurrence.WindowEndUtc?.ToString("u")</time></p>
-    <p>@localizer[((Resgrid.Model.Checklists.ChecklistOccurrenceState)Model.Occurrence.State).ToString()]</p>
-    @if (Model.CanStart) { <form class="checklist-form" asp-action="StartOccurrence" method="post"><input type="hidden" name="id" value="@Model.Occurrence.Id" /><button type="submit" class="btn btn-primary">@localizer["OpenCheck"]</button></form> }
-    @if (Model.CanSkip) { <form class="checklist-form" asp-action="SkipOccurrence" method="post"><input type="hidden" name="id" value="@Model.Occurrence.Id" /><input type="hidden" name="revision" value="@Model.Occurrence.Revision" /><label for="reason">@localizer["SkipReason"]</label><textarea id="reason" name="reason" maxlength="4000" required class="form-control"></textarea><button type="submit" class="btn btn-default">@localizer["ExcuseCheck"]</button></form> }
-    <a asp-action="Due">@localizer["DueChecks"]</a>
-</div></div></div>
+@functions {
+    string StatePill(ChecklistOccurrenceState state) => state switch
+    {
+        ChecklistOccurrenceState.Scheduled => "label-info",
+        ChecklistOccurrenceState.InProgress => "label-warning",
+        ChecklistOccurrenceState.Missed => "label-danger",
+        _ => ""
+    };
+}
+@{
+    ViewBag.Title = "Resgrid | " + localizer["DueChecks"];
+    var state = (ChecklistOccurrenceState)Model.Occurrence.State;
+    ViewData["Tab"] = "Due";
+    ViewData["Title"] = Model.Name;
+    ViewData["ParentText"] = localizer["DueChecks"].Value;
+    ViewData["ParentAction"] = "Due";
+}
+
+@await Html.PartialAsync("_Shell")
+
+<div class="wrapper wrapper-content">
+    <div class="ibox float-e-margins">
+        <div class="ibox-title"><h5>@Model.Name</h5></div>
+        <div class="ibox-content">
+            @await Html.PartialAsync("_Tabs")
+            @await Html.PartialAsync("_Protection")
+
+            <div class="rgw-toolbar">
+                <a class="btn btn-default btn-sm" asp-action="Due"><i class="fa fa-arrow-left"></i> @localizer["DueChecks"]</a>
+                <div class="rgw-toolbar-spacer"></div>
+                @if (Model.CanStart)
+                {
+                    <form class="checklist-form" asp-action="StartOccurrence" method="post">
+                        @Html.AntiForgeryToken()
+                        <input type="hidden" name="id" value="@Model.Occurrence.Id" />
+                        <button type="submit" class="btn btn-primary"><i class="fa fa-play"></i> @localizer["OpenCheck"]</button>
+                    </form>
+                }
+                @if (Model.CanSkip)
+                {
+                    <button type="button" class="btn btn-default" data-toggle="modal" data-target="#occurrence-skip">@localizer["ExcuseCheck"]</button>
+                }
+            </div>
+
+            <p class="text-muted">
+                <span class="label @StatePill(state)">@localizer[state.ToString()]</span>
+                @Model.Target.Name
+            </p>
+            <p class="text-muted">
+                <time datetime="@Model.Occurrence.PeriodStartUtc?.ToString("O")">@Model.Occurrence.PeriodStartUtc?.ToString("u")</time>
+                &mdash;
+                <time datetime="@Model.Occurrence.WindowEndUtc?.ToString("O")">@Model.Occurrence.WindowEndUtc?.ToString("u")</time>
+            </p>
+
+            @if (Model.CanSkip)
+            {
+                <div class="modal fade rgw-modal" id="occurrence-skip" tabindex="-1" role="dialog" aria-labelledby="occurrence-skip-title">
+                    <div class="modal-dialog" role="document">
+                        <div class="modal-content">
+                            <div class="modal-header">
+                                <button type="button" class="close" data-dismiss="modal" aria-label="@localizer["Close"]"><span aria-hidden="true">&times;</span></button>
+                                <h4 class="modal-title" id="occurrence-skip-title">@localizer["ExcuseCheck"]</h4>
+                            </div>
+                            <div class="modal-body">
+                                <p class="text-muted">@localizer["SkipHint"]</p>
+                                <form class="checklist-form" asp-action="SkipOccurrence" method="post">
+                                    @Html.AntiForgeryToken()
+                                    <input type="hidden" name="id" value="@Model.Occurrence.Id" />
+                                    <input type="hidden" name="revision" value="@Model.Occurrence.Revision" />
+                                    <div class="rgw-grid">
+                                        <div class="form-group rgw-wide">
+                                            <label for="reason">@localizer["SkipReason"]</label>
+                                            <textarea id="reason" name="reason" rows="3" maxlength="4000" required class="form-control"></textarea>
+                                        </div>
+                                    </div>
+                                    <div class="rgw-wizard-actions">
+                                        <div class="rgw-wizard-spacer"></div>
+                                        <button type="button" class="btn btn-white" data-dismiss="modal">@localizer["Close"]</button>
+                                        <button type="submit" class="btn btn-warning">@localizer["ExcuseCheck"]</button>
+                                    </div>
+                                </form>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            }
+        </div>
+    </div>
+</div>
+
+@section Styles {
+    <link rel="stylesheet" href="~/css/workspace.css" asp-append-version="true" />
+}
 @section Scripts { @await Html.PartialAsync("_ProtectionScripts") }

--- a/Web/Resgrid.Web/Areas/User/Views/Checklists/ReadinessPacket.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Checklists/ReadinessPacket.cshtml
@@ -1,20 +1,64 @@
 @model Resgrid.Model.Checklists.ReadinessEvidenceManifestV1
 @inject IStringLocalizer<Resgrid.Localization.Areas.User.Checklists.Checklists> localizer
-@{ ViewBag.Title = "Resgrid | " + localizer["ReadinessPacketReport"]; }
-<div class="wrapper wrapper-content"><div class="ibox"><div class="ibox-content">
-<h2>@localizer["ReadinessPacketReport"]</h2><p>@localizer["PacketMethod"]</p>
-@await Html.PartialAsync("_Protection")
-<form class="checklist-form" asp-action="ReadinessPacket" method="post">
-    @Html.AntiForgeryToken()
-    <label for="call-id">@localizer["CallId"]</label><input id="call-id" type="number" name="callId" min="1" value="@ViewBag.CallId" required />
-    <label for="lookback">@localizer["LookbackDays"]</label><input id="lookback" type="number" name="lookbackDays" min="1" max="93" value="@(ViewBag.LookbackDays ?? 30)" required />
-    <button class="btn btn-primary" type="submit">@localizer["RefreshReport"]</button>
-    <button class="btn btn-default" type="submit" formaction="@Url.Action("ReadinessPacketDownload")">@localizer["DownloadPacket"]</button>
-</form>
-@if (Model != null)
-{
-    <iframe title="@localizer["ReadinessPacketReport"]" sandbox="" referrerpolicy="no-referrer" style="width:100%;height:700px;border:0" srcdoc="@Resgrid.Services.ChecklistReportDocuments.Packet(Model)"></iframe>
+@{
+    ViewBag.Title = "Resgrid | " + localizer["ReadinessPacketReport"];
+    ViewData["Tab"] = "Compliance";
+    ViewData["Title"] = localizer["ReadinessPacketReport"].Value;
+    ViewData["Subtitle"] = localizer["PacketMethod"].Value;
 }
-<a class="btn btn-default" asp-action="Compliance">@localizer["Back"]</a>
-</div></div></div>
+
+@await Html.PartialAsync("_Shell")
+
+<div class="wrapper wrapper-content">
+    <div class="ibox float-e-margins">
+        <div class="ibox-title"><h5>@localizer["ReadinessPacketReport"]</h5></div>
+        <div class="ibox-content">
+            @await Html.PartialAsync("_Tabs")
+            @await Html.PartialAsync("_Protection")
+
+            <div class="alert alert-info"><i class="fa fa-info-circle"></i> @localizer["PacketMethod"]</div>
+
+            <div class="rgw-filter">
+                <form class="checklist-form" asp-action="ReadinessPacket" method="post">
+                    @Html.AntiForgeryToken()
+                    <div class="rgw-grid">
+                        <div class="form-group">
+                            <label for="call-id">@localizer["CallId"]</label>
+                            <input class="form-control" id="call-id" type="number" name="callId" min="1" value="@ViewBag.CallId" required />
+                            <span class="help-block">@localizer["HelpFieldCallId"]</span>
+                        </div>
+                        <div class="form-group">
+                            <label for="lookback">@localizer["LookbackDays"]</label>
+                            <input class="form-control" id="lookback" type="number" name="lookbackDays" min="1" max="93" value="@(ViewBag.LookbackDays ?? 30)" required />
+                        </div>
+                    </div>
+                    <div class="rgw-filter-actions">
+                        <button class="btn btn-primary" type="submit"><i class="fa fa-refresh"></i> @localizer["RefreshReport"]</button>
+                        <button class="btn btn-default" type="submit" formaction="@Url.Action("ReadinessPacketDownload")"><i class="fa fa-download"></i> @localizer["DownloadPacket"]</button>
+                    </div>
+                </form>
+            </div>
+
+            @if (Model != null)
+            {
+                <iframe title="@localizer["ReadinessPacketReport"]" sandbox="" referrerpolicy="no-referrer" style="width:100%;height:700px;border:0" srcdoc="@Resgrid.Services.ChecklistReportDocuments.Packet(Model)"></iframe>
+            }
+            else
+            {
+                <div class="text-center m-t-lg m-b-lg">
+                    <i class="fa fa-file-pdf-o fa-3x text-muted"></i>
+                    <h4 class="m-t-sm">@localizer["NoResults"]</h4>
+                </div>
+            }
+
+            <div class="rgw-toolbar m-t">
+                <a class="btn btn-default btn-sm" asp-action="Compliance"><i class="fa fa-arrow-left"></i> @localizer["Back"]</a>
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Styles {
+    <link rel="stylesheet" href="~/css/workspace.css" asp-append-version="true" />
+}
 @section Scripts { @await Html.PartialAsync("_ProtectionScripts") }

--- a/Web/Resgrid.Web/Areas/User/Views/Checklists/Reminders.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Checklists/Reminders.cshtml
@@ -1,22 +1,63 @@
 @model Resgrid.Model.Checklists.ChecklistReminderSettingsInput
 @inject IStringLocalizer<Resgrid.Localization.Areas.User.Checklists.Checklists> localizer
-@{ ViewBag.Title = "Resgrid | " + localizer["ReminderSettings"]; }
-<div class="row wrapper border-bottom white-bg page-heading"><div class="col-sm-12"><h2>@localizer["ReminderSettings"]</h2></div></div>
-<div class="wrapper wrapper-content"><div class="ibox"><div class="ibox-content">
-    @await Html.PartialAsync("_Protection")
-    <p>@localizer["ReminderHelp"]</p>
-    <form class="checklist-form" asp-action="SaveReminders" method="post">
-        @Html.AntiForgeryToken()
-        <input type="hidden" asp-for="Revision" />
-        <div class="checkbox"><label><input asp-for="Enabled" /> @localizer["ReminderEnabled"]</label></div>
-        <div class="form-group"><label asp-for="NotifyBeforeMinutes">@localizer["ReminderBefore"]</label><input class="form-control" asp-for="NotifyBeforeMinutes" min="0" max="10080" /></div>
-        <div class="checkbox"><label><input asp-for="NotifyMissed" /> @localizer["ReminderMissed"]</label></div>
-        <div class="checkbox"><label><input asp-for="DigestMode" /> @localizer["ReminderDigest"]</label></div>
-        <div class="checkbox"><label><input asp-for="NotifyAtShiftStart" /> @localizer["ReminderShiftStart"]</label></div>
-        <div class="form-group"><label asp-for="FixedDigestTime">@localizer["ReminderFixedTime"]</label><input class="form-control" asp-for="FixedDigestTime" type="time" /></div>
-        <div class="form-group"><label asp-for="EscalateAfterMinutes">@localizer["ReminderEscalate"]</label><input class="form-control" asp-for="EscalateAfterMinutes" min="1" max="43200" /></div>
-        <button class="btn btn-primary" type="submit">@localizer["SaveReminders"]</button>
-        <a class="btn btn-default" asp-action="Index">@localizer["Checklists"]</a>
-    </form>
-</div></div></div>
+@{
+    ViewBag.Title = "Resgrid | " + localizer["ReminderSettings"];
+    ViewData["Tab"] = "Reminders";
+    ViewData["Title"] = localizer["ReminderSettings"].Value;
+    ViewData["Subtitle"] = localizer["ReminderHelp"].Value;
+}
+
+@await Html.PartialAsync("_Shell")
+
+<div class="wrapper wrapper-content">
+    <div class="ibox float-e-margins">
+        <div class="ibox-title"><h5>@localizer["ReminderSettings"]</h5></div>
+        <div class="ibox-content">
+            @await Html.PartialAsync("_Tabs")
+            @await Html.PartialAsync("_Protection")
+
+            <div class="alert alert-info"><i class="fa fa-info-circle"></i> @localizer["ReminderHelp"]</div>
+
+            <form class="checklist-form" asp-action="SaveReminders" method="post">
+                @Html.AntiForgeryToken()
+                <input type="hidden" asp-for="Revision" />
+                <div class="rgw-grid">
+                    <div class="form-group rgw-wide">
+                        <div class="checkbox"><label><input asp-for="Enabled" /> @localizer["ReminderEnabled"]</label></div>
+                    </div>
+                    <div class="form-group">
+                        <label asp-for="NotifyBeforeMinutes">@localizer["ReminderBefore"]</label>
+                        <input class="form-control" asp-for="NotifyBeforeMinutes" min="0" max="10080" />
+                    </div>
+                    <div class="form-group">
+                        <label asp-for="EscalateAfterMinutes">@localizer["ReminderEscalate"]</label>
+                        <input class="form-control" asp-for="EscalateAfterMinutes" min="1" max="43200" />
+                    </div>
+                    <div class="form-group">
+                        <div class="checkbox"><label><input asp-for="NotifyMissed" /> @localizer["ReminderMissed"]</label></div>
+                    </div>
+                    <div class="form-group">
+                        <div class="checkbox"><label><input asp-for="NotifyAtShiftStart" /> @localizer["ReminderShiftStart"]</label></div>
+                    </div>
+                    <div class="form-group">
+                        <div class="checkbox"><label><input asp-for="DigestMode" /> @localizer["ReminderDigest"]</label></div>
+                    </div>
+                    <div class="form-group">
+                        <label asp-for="FixedDigestTime">@localizer["ReminderFixedTime"]</label>
+                        <input class="form-control" asp-for="FixedDigestTime" type="time" />
+                    </div>
+                </div>
+                <div class="rgw-wizard-actions">
+                    <div class="rgw-wizard-spacer"></div>
+                    <a class="btn btn-white" asp-action="Index">@localizer["Close"]</a>
+                    <button class="btn btn-primary" type="submit">@localizer["SaveReminders"]</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+@section Styles {
+    <link rel="stylesheet" href="~/css/workspace.css" asp-append-version="true" />
+}
 @section Scripts { @await Html.PartialAsync("_ProtectionScripts") }

--- a/Web/Resgrid.Web/Areas/User/Views/Checklists/Run.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Checklists/Run.cshtml
@@ -1,19 +1,60 @@
 @model Resgrid.Model.Checklists.ChecklistRunView
 @using Newtonsoft.Json
 @inject IStringLocalizer<Resgrid.Localization.Areas.User.Checklists.Checklists> localizer
-@{ ViewBag.Title = "Resgrid | " + Model.Form.Name; }
-<div class="wrapper wrapper-content"><div class="ibox"><div class="ibox-content">
-    <h2>@Model.Form.Name</h2><p>@Model.Target.Name · @localizer["Started"] @Model.Completion.CreatedOn.ToString("u")</p>
-    <p style="white-space: pre-wrap">@Model.Form.Instructions</p><p>@localizer["RunGuidance"]</p>
-    @await Html.PartialAsync("_Protection")
-    <div id="checklist-error" class="alert alert-danger" role="alert" hidden></div><div id="checklist-saved" class="alert alert-success" role="status" hidden></div>
-    <form id="checklist-run" class="checklist-form" asp-action="SaveRun" method="post" data-upload="@Url.Action("Upload")" data-remove="@Url.Action("RemoveFile")" data-evidence="@Url.Action("Evidence")">
-        @Html.AntiForgeryToken()<input type="hidden" name="id" value="@Model.Completion.Id" /><input type="hidden" name="inputJson" />
-        <div id="checklist-answers"></div>
-        <button class="btn btn-default" type="submit" name="submit" value="false">@localizer["SaveProgress"]</button>
-        <button class="btn btn-primary" type="submit" name="submit" value="true">@localizer["SubmitRun"]</button>
-        <a class="btn btn-default" asp-action="Detail" asp-route-id="@Model.Completion.ParentId">@localizer["History"]</a>
-    </form>
-    <script id="checklist-run-data" type="application/json">@Html.Raw(JsonConvert.SerializeObject(Model, new JsonSerializerSettings { StringEscapeHandling = StringEscapeHandling.EscapeHtml }))</script>
-</div></div></div>
-@section Scripts { @await Html.PartialAsync("_ProtectionScripts") <script src="~/js/app/internal/checklists/checklists.js" asp-append-version="true"></script> }
+@*
+    The answer sheet itself is rendered by checklists.js into #checklist-answers, so this view
+    only supplies the chrome, the guidance and the form contract that script depends on.
+*@
+@{
+    ViewBag.Title = "Resgrid | " + Model.Form.Name;
+    ViewData["Tab"] = "Index";
+    ViewData["Title"] = Model.Form.Name;
+    ViewData["ParentText"] = localizer["History"].Value;
+    ViewData["ParentAction"] = "Detail";
+    ViewData["ParentId"] = Model.Completion.ParentId;
+    ViewData["Subtitle"] = Model.Target.Name;
+}
+
+@await Html.PartialAsync("_Shell")
+
+<div class="wrapper wrapper-content">
+    <div class="ibox float-e-margins">
+        <div class="ibox-title"><h5>@Model.Form.Name</h5></div>
+        <div class="ibox-content">
+            @await Html.PartialAsync("_Protection")
+
+            <p class="text-muted">@Model.Target.Name &middot; @localizer["Started"] @Model.Completion.CreatedOn.ToString("u")</p>
+            @if (!string.IsNullOrEmpty(Model.Form.Instructions))
+            {
+                <p style="white-space: pre-wrap">@Model.Form.Instructions</p>
+            }
+            <div class="alert alert-info"><i class="fa fa-info-circle"></i> @localizer["RunGuidance"]</div>
+
+            <div id="checklist-error" class="alert alert-danger" role="alert" hidden></div>
+            <div id="checklist-saved" class="alert alert-success" role="status" hidden></div>
+
+            <form id="checklist-run" class="checklist-form" asp-action="SaveRun" method="post" data-upload="@Url.Action("Upload")" data-remove="@Url.Action("RemoveFile")" data-evidence="@Url.Action("Evidence")">
+                @Html.AntiForgeryToken()
+                <input type="hidden" name="id" value="@Model.Completion.Id" />
+                <input type="hidden" name="inputJson" />
+                <div id="checklist-answers"></div>
+                <div class="rgw-wizard-actions">
+                    <a class="btn btn-white" asp-action="Detail" asp-route-id="@Model.Completion.ParentId">@localizer["History"]</a>
+                    <div class="rgw-wizard-spacer"></div>
+                    <button class="btn btn-default" type="submit" name="submit" value="false"><i class="fa fa-save"></i> @localizer["SaveProgress"]</button>
+                    <button class="btn btn-primary" type="submit" name="submit" value="true">@localizer["SubmitRun"]</button>
+                </div>
+            </form>
+
+            <script id="checklist-run-data" type="application/json">@Html.Raw(JsonConvert.SerializeObject(Model, new JsonSerializerSettings { StringEscapeHandling = StringEscapeHandling.EscapeHtml }))</script>
+        </div>
+    </div>
+</div>
+
+@section Styles {
+    <link rel="stylesheet" href="~/css/workspace.css" asp-append-version="true" />
+}
+@section Scripts {
+    @await Html.PartialAsync("_ProtectionScripts")
+    <script src="~/js/app/internal/checklists/checklists.js" asp-append-version="true"></script>
+}

--- a/Web/Resgrid.Web/Areas/User/Views/Checklists/Schedules.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Checklists/Schedules.cshtml
@@ -1,21 +1,81 @@
 @model Resgrid.Web.Areas.User.Models.Checklists.ChecklistSchedulesView
 @using Resgrid.Model.Checklists
 @inject IStringLocalizer<Resgrid.Localization.Areas.User.Checklists.Checklists> localizer
-@{ ViewBag.Title = "Resgrid | " + localizer["Schedules"]; }
-<div class="wrapper wrapper-content"><div class="ibox"><div class="ibox-content">
-    <h2>@localizer["Schedules"]</h2>
-    @await Html.PartialAsync("_Protection")
-    <p>@localizer["ScheduleVersionGuidance"]</p>
-    @if (Model.CanEdit) { <a class="btn btn-primary" asp-action="EditSchedule" asp-route-definitionId="@Model.DefinitionId">@localizer["NewSchedule"]</a> }
-    @if (Model.Schedules.Count == 0) { <p>@localizer["NoSchedules"]</p> }
-    <table class="table table-striped"><thead><tr><th>@localizer["Name"]</th><th>@localizer["Frequency"]</th><th>@localizer["TimeZone"]</th><th>@localizer["State"]</th></tr></thead><tbody>
-    @foreach (var entry in Model.Schedules)
-    {
-        <tr><td>@if (Model.CanEdit) { <a asp-action="EditSchedule" asp-route-id="@entry.Schedule.Id">@entry.Content.Name</a> } else { @entry.Content.Name }</td><td>@localizer[((ChecklistScheduleFrequency)entry.Schedule.Frequency).ToString()]</td><td>@entry.Schedule.TimeZoneId</td><td>@localizer[entry.Schedule.IsActive && !entry.Schedule.IsSuspended ? "Active" : "SchedulePaused"]</td></tr>
-    }
-    </tbody></table>
-    @if (Model.Page > 0) { <a class="btn btn-default" asp-route-id="@Model.DefinitionId" asp-route-page="@(Model.Page - 1)">@localizer["Previous"]</a> }
-    <a class="btn btn-default" asp-route-id="@Model.DefinitionId" asp-route-page="@(Model.Page + 1)">@localizer["Next"]</a>
-    <a class="btn btn-default" asp-action="Detail" asp-route-id="@Model.DefinitionId">@localizer["Back"]</a>
-</div></div></div>
+@{
+    ViewBag.Title = "Resgrid | " + localizer["Schedules"];
+    ViewData["Tab"] = "Index";
+    ViewData["Title"] = localizer["Schedules"].Value;
+    ViewData["Subtitle"] = localizer["ScheduleVersionGuidance"].Value;
+}
+
+@await Html.PartialAsync("_Shell")
+
+<div class="wrapper wrapper-content">
+    <div class="ibox float-e-margins">
+        <div class="ibox-title"><h5>@localizer["Schedules"]</h5></div>
+        <div class="ibox-content">
+            @await Html.PartialAsync("_Tabs")
+            @await Html.PartialAsync("_Protection")
+
+            <div class="alert alert-info"><i class="fa fa-info-circle"></i> @localizer["ScheduleVersionGuidance"]</div>
+
+            <div class="rgw-toolbar">
+                <a class="btn btn-default btn-sm" asp-action="Detail" asp-route-id="@Model.DefinitionId"><i class="fa fa-arrow-left"></i> @localizer["Back"]</a>
+                <div class="rgw-toolbar-spacer"></div>
+                @if (Model.CanEdit)
+                {
+                    <a class="btn btn-primary" asp-action="EditSchedule" asp-route-definitionId="@Model.DefinitionId"><i class="fa fa-plus"></i> @localizer["NewSchedule"]</a>
+                }
+            </div>
+
+            @if (Model.Schedules.Count == 0)
+            {
+                <div class="text-center m-t-lg m-b-lg">
+                    <i class="fa fa-calendar fa-3x text-muted"></i>
+                    <h4 class="m-t-sm">@localizer["NoSchedules"]</h4>
+                    <p class="text-muted">@localizer["NoRowsHelp"]</p>
+                </div>
+            }
+            else
+            {
+                <div class="table-responsive">
+                    <table class="table table-striped rgw-table">
+                        <thead><tr><th>@localizer["Name"]</th><th>@localizer["Frequency"]</th><th>@localizer["TimeZone"]</th><th>@localizer["State"]</th><th class="rgw-row-actions">@localizer["Actions"]</th></tr></thead>
+                        <tbody>
+                            @foreach (var entry in Model.Schedules)
+                            {
+                                var running = entry.Schedule.IsActive && !entry.Schedule.IsSuspended;
+                                <tr>
+                                    <td>@entry.Content.Name</td>
+                                    <td>@localizer[((ChecklistScheduleFrequency)entry.Schedule.Frequency).ToString()]</td>
+                                    <td>@entry.Schedule.TimeZoneId</td>
+                                    <td><span class="label @(running ? "label-success" : "label-warning")">@localizer[running ? "Active" : "SchedulePaused"]</span></td>
+                                    <td class="rgw-row-actions">
+                                        @if (Model.CanEdit)
+                                        {
+                                            <a class="btn btn-xs btn-primary" asp-action="EditSchedule" asp-route-id="@entry.Schedule.Id">@localizer["EditSchedule"]</a>
+                                        }
+                                    </td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                </div>
+            }
+
+            <div class="rgw-pager">
+                @if (Model.Page > 0)
+                {
+                    <a class="btn btn-default btn-sm" asp-route-id="@Model.DefinitionId" asp-route-page="@(Model.Page - 1)"><i class="fa fa-chevron-left"></i> @localizer["Previous"]</a>
+                }
+                <a class="btn btn-default btn-sm" asp-route-id="@Model.DefinitionId" asp-route-page="@(Model.Page + 1)">@localizer["Next"] <i class="fa fa-chevron-right"></i></a>
+                <span class="text-muted">@(Model.Page + 1)</span>
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Styles {
+    <link rel="stylesheet" href="~/css/workspace.css" asp-append-version="true" />
+}
 @section Scripts { @await Html.PartialAsync("_ProtectionScripts") }

--- a/Web/Resgrid.Web/Areas/User/Views/Checklists/Template.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Checklists/Template.cshtml
@@ -1,33 +1,70 @@
 @model Resgrid.Model.Checklists.ChecklistTemplate
 @inject IStringLocalizer<Resgrid.Localization.Areas.User.Checklists.Checklists> localizer
-@{ ViewBag.Title = "Resgrid | " + Model.Name; }
+@{
+    ViewBag.Title = "Resgrid | " + Model.Name;
+    ViewData["Tab"] = "Templates";
+    ViewData["Title"] = Model.Name;
+    ViewData["ParentText"] = localizer["Templates"].Value;
+    ViewData["ParentAction"] = "Templates";
+    ViewData["Subtitle"] = Model.Sector;
+}
 
-<div class="row wrapper border-bottom white-bg page-heading">
-	<div class="col-sm-12"><h2>@Model.Name</h2><p>@Model.Sector</p></div>
-</div>
+@await Html.PartialAsync("_Shell")
+
 <div class="wrapper wrapper-content">
-	<div class="ibox"><div class="ibox-content">
-		<p>@Model.Description</p>@if (ClaimsAuthorizationHelper.CanManageChecklists()) { <p><a class="btn btn-primary" asp-action="New" asp-route-templateId="@Model.Id">@localizer["Use this template"]</a></p> }
-		<p>@localizer["Guidance"]</p>
-		@if (Model.RequiresIndependentWitness)
-		{
-			<p class="alert alert-info">@localizer["Witness"]</p>
-		}
-		@foreach (var checklistSection in Model.Sections)
-		{
-			<h3>@checklistSection.Name</h3>
-			<ul class="list-group">
-				@foreach (var item in checklistSection.Items)
-				{
-					<li class="list-group-item">
-						@item.Name
-						@if (item.Critical) { <span class="label label-danger">@localizer["Critical"]</span> }
-						@if (item.Required) { <span class="label label-default">@localizer["Required"]</span> }
-						@if (item.RequireNoteOnFail) { <p class="help-block">@localizer["FailNote"]</p> }
-					</li>
-				}
-			</ul>
-		}
-		<a asp-action="Templates" asp-controller="Checklists" asp-area="User" class="btn btn-default">@localizer["Back"]</a>
-	</div></div>
+    <div class="ibox float-e-margins">
+        <div class="ibox-title"><h5>@Model.Name</h5></div>
+        <div class="ibox-content">
+            @await Html.PartialAsync("_Tabs")
+
+            <div class="rgw-toolbar">
+                <a asp-action="Templates" asp-controller="Checklists" asp-area="User" class="btn btn-default btn-sm"><i class="fa fa-arrow-left"></i> @localizer["Back"]</a>
+                <div class="rgw-toolbar-spacer"></div>
+                @if (ClaimsAuthorizationHelper.CanManageChecklists())
+                {
+                    <a class="btn btn-primary" asp-action="New" asp-route-templateId="@Model.Id"><i class="fa fa-plus"></i> @localizer["Use this template"]</a>
+                }
+            </div>
+
+            <p><span class="label">@Model.Sector</span></p>
+            <p class="text-muted">@Model.Description</p>
+
+            <div class="alert alert-info"><i class="fa fa-info-circle"></i> @localizer["Guidance"]</div>
+            @if (Model.RequiresIndependentWitness)
+            {
+                <div class="alert alert-warning"><i class="fa fa-user-plus"></i> @localizer["Witness"]</div>
+            }
+
+            @foreach (var checklistSection in Model.Sections)
+            {
+                <div class="panel panel-default">
+                    <div class="panel-heading">@checklistSection.Name</div>
+                    <ul class="list-group">
+                        @foreach (var item in checklistSection.Items)
+                        {
+                            <li class="list-group-item">
+                                @item.Name
+                                @if (item.Critical)
+                                {
+                                    <span class="label label-danger">@localizer["Critical"]</span>
+                                }
+                                @if (item.Required)
+                                {
+                                    <span class="label">@localizer["Required"]</span>
+                                }
+                                @if (item.RequireNoteOnFail)
+                                {
+                                    <p class="help-block">@localizer["FailNote"]</p>
+                                }
+                            </li>
+                        }
+                    </ul>
+                </div>
+            }
+        </div>
+    </div>
 </div>
+
+@section Styles {
+    <link rel="stylesheet" href="~/css/workspace.css" asp-append-version="true" />
+}

--- a/Web/Resgrid.Web/Areas/User/Views/Checklists/Templates.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Checklists/Templates.cshtml
@@ -1,31 +1,67 @@
 @model Resgrid.Web.Areas.User.Models.Checklists.ChecklistTemplatesView
 @inject IStringLocalizer<Resgrid.Localization.Areas.User.Checklists.Checklists> localizer
-@{ ViewBag.Title = "Resgrid | " + localizer["Templates"]; }
+@{
+    ViewBag.Title = "Resgrid | " + localizer["Templates"];
+    ViewData["Tab"] = "Templates";
+    ViewData["Title"] = localizer["Templates"].Value;
+    ViewData["Subtitle"] = localizer["Free"].Value;
+}
 
-<div class="row wrapper border-bottom white-bg page-heading">
-	<div class="col-sm-12"><h2>@localizer["Templates"]</h2><p>@localizer["Free"]</p></div>
-</div>
+@await Html.PartialAsync("_Shell")
+
 <div class="wrapper wrapper-content">
-	<div class="ibox"><div class="ibox-content">
-		<p>@localizer["Guidance"]</p>
-		<form method="get" asp-action="Templates" asp-controller="Checklists" asp-area="User" class="form-inline m-b-md">
-			<label for="query">@localizer["SearchLabel"]</label>
-			<input id="query" name="query" value="@Model.Query" maxlength="256" class="form-control" type="search" />
-			<button type="submit" class="btn btn-primary">@localizer["Search"]</button>
-		</form>
-		@if (Model.Templates.Count == 0)
-		{
-			<p role="status">@localizer["NoResults"]</p>
-		}
-		@foreach (var template in Model.Templates)
-		{
-			<div class="panel panel-default">
-				<div class="panel-body">
-					<h3>@template.Name <small>@template.Sector</small></h3>
-					<p>@template.Description</p>
-					<a asp-action="Template" asp-controller="Checklists" asp-area="User" asp-route-id="@template.Id" class="btn btn-default">@localizer["Preview"] <span class="sr-only">@template.Name</span></a>
-				</div>
-			</div>
-		}
-	</div></div>
+    <div class="ibox float-e-margins">
+        <div class="ibox-title"><h5>@localizer["Templates"]</h5></div>
+        <div class="ibox-content">
+            @await Html.PartialAsync("_Tabs")
+
+            <div class="alert alert-info"><i class="fa fa-info-circle"></i> @localizer["Guidance"]</div>
+
+            <div class="rgw-filter">
+                <form method="get" asp-action="Templates" asp-controller="Checklists" asp-area="User">
+                    <div class="rgw-grid">
+                        <div class="form-group">
+                            <label for="query">@localizer["SearchLabel"]</label>
+                            <input id="query" name="query" value="@Model.Query" maxlength="256" class="form-control" type="search" />
+                        </div>
+                    </div>
+                    <div class="rgw-filter-actions">
+                        <button type="submit" class="btn btn-primary"><i class="fa fa-search"></i> @localizer["Search"]</button>
+                    </div>
+                </form>
+            </div>
+
+            @if (Model.Templates.Count == 0)
+            {
+                <div class="text-center m-t-lg m-b-lg" role="status">
+                    <i class="fa fa-clone fa-3x text-muted"></i>
+                    <h4 class="m-t-sm">@localizer["NoResults"]</h4>
+                </div>
+            }
+            else
+            {
+                <div class="row">
+                    @foreach (var template in Model.Templates)
+                    {
+                        <div class="col-lg-4 col-md-6">
+                            <div class="ibox">
+                                <div class="ibox-title"><h5>@template.Name</h5></div>
+                                <div class="ibox-content">
+                                    <p><span class="label">@template.Sector</span></p>
+                                    <p class="text-muted">@template.Description</p>
+                                    <a asp-action="Template" asp-controller="Checklists" asp-area="User" asp-route-id="@template.Id" class="btn btn-default btn-sm">
+                                        <i class="fa fa-eye"></i> @localizer["Preview"] <span class="sr-only">@template.Name</span>
+                                    </a>
+                                </div>
+                            </div>
+                        </div>
+                    }
+                </div>
+            }
+        </div>
+    </div>
 </div>
+
+@section Styles {
+    <link rel="stylesheet" href="~/css/workspace.css" asp-append-version="true" />
+}

--- a/Web/Resgrid.Web/Areas/User/Views/Checklists/_Shell.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Checklists/_Shell.cshtml
@@ -1,0 +1,43 @@
+@using Resgrid.Web.Helpers
+@inject IStringLocalizer<Resgrid.Localization.Areas.User.Checklists.Checklists> localizer
+@*
+    Page heading shared by every checklist screen, laid out the same way as the rest of the
+    application: title and breadcrumb on the left, primary actions on the right.
+
+    ViewData["Title"]    heading and last breadcrumb crumb (defaults to the module name)
+    ViewData["Subtitle"] optional one line description under the breadcrumb
+    ViewData["Parent"]   optional intermediate crumb, as (text, action, id)
+*@
+@{
+    var title = (string)ViewData["Title"] ?? localizer["Checklists"].Value;
+    var subtitle = (string)ViewData["Subtitle"];
+    var parentText = (string)ViewData["ParentText"];
+    var parentAction = (string)ViewData["ParentAction"];
+    var parentId = (string)ViewData["ParentId"];
+    var isRoot = string.Equals(title, localizer["Checklists"].Value, StringComparison.Ordinal);
+}
+<div class="row wrapper border-bottom white-bg page-heading">
+    <div class="col-sm-12">
+        <h2>@title</h2>
+        <ol class="breadcrumb">
+            <li><a asp-controller="Home" asp-action="Dashboard" asp-route-area="User">@commonLocalizer["HomeModule"]</a></li>
+            @if (isRoot)
+            {
+                <li class="active"><strong>@localizer["Checklists"]</strong></li>
+            }
+            else
+            {
+                <li><a asp-controller="Checklists" asp-action="Index" asp-route-area="User">@localizer["Checklists"]</a></li>
+                @if (!string.IsNullOrEmpty(parentText))
+                {
+                    <li><a asp-controller="Checklists" asp-action="@parentAction" asp-route-id="@parentId" asp-route-area="User">@parentText</a></li>
+                }
+                <li class="active"><strong>@title</strong></li>
+            }
+        </ol>
+        @if (!string.IsNullOrEmpty(subtitle))
+        {
+            <small class="text-muted">@subtitle</small>
+        }
+    </div>
+</div>

--- a/Web/Resgrid.Web/Areas/User/Views/Checklists/_Tabs.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Checklists/_Tabs.cshtml
@@ -1,0 +1,35 @@
+@using Resgrid.Web.Helpers
+@inject IStringLocalizer<Resgrid.Localization.Areas.User.Checklists.Checklists> localizer
+@*
+    The module's tab strip. ViewData["Tab"] names the tab that owns the current screen, so a
+    sub page (a definition, a run, a schedule) still shows where in the module it sits.
+
+    These are plain links: unlike inventory, checklist navigation is GET, so the theme's own
+    nav-tabs markup works without any help.
+*@
+@{
+    var current = (string)ViewData["Tab"] ?? "Index";
+    var tabs = new List<(string Action, string Icon, string Label)>
+    {
+        ("Index", "fa-check-square-o", localizer["Checklists"].Value),
+        ("Due", "fa-clock-o", localizer["DueChecks"].Value),
+        ("Compliance", "fa-bar-chart", localizer["ChecklistComplianceReport"].Value),
+        ("Templates", "fa-clone", localizer["Templates"].Value)
+    };
+
+    if (ClaimsAuthorizationHelper.CanManageChecklists())
+    {
+        tabs.Add(("Reminders", "fa-bell-o", localizer["ReminderSettings"].Value));
+    }
+}
+<ul class="nav nav-tabs" role="tablist">
+    @foreach (var tab in tabs)
+    {
+        <li class="nav-item @(current == tab.Action ? "active" : null)">
+            <a asp-controller="Checklists" asp-action="@tab.Action" asp-route-area="User"
+               aria-current="@(current == tab.Action ? "page" : "false")">
+                <i class="fa @tab.Icon"></i> @tab.Label
+            </a>
+        </li>
+    }
+</ul>

--- a/Web/Resgrid.Web/Areas/User/Views/IncidentReports/Details.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/IncidentReports/Details.cshtml
@@ -35,32 +35,54 @@
 		</ol>
 	</div>
 	<div class="col-sm-8">
-		<div class="btn-group top-page-buttons" style="float:right;padding-right:15px;">
-			@if (Model.CanEdit && Model.IsEditable)
+		@{
+			// Lifecycle actions stay as buttons; the document formats and the side trips live in menus.
+			var editable = Model.CanEdit && Model.IsEditable;
+			var canExport = Model.CanExport && r.CurrentRevisionId != null;
+			var canAmend = Model.CanAmend && RmsLifecycle.CanTransition((RmsLifecyclePreset)r.LifecyclePreset, state, RmsRecordState.Amended) && r.AmendsRevisionId == null;
+			var amendmentOpen = r.AmendsRevisionId != null && Model.CanAmend;
+		}
+		<div class="btn-toolbar top-page-buttons" style="float:right;padding-right:15px;">
+			@if (editable)
 			{
-				<a class="btn btn-primary" id="adp-edit-link" asp-controller="IncidentReports" asp-action="Edit" asp-route-area="User" asp-route-id="@r.RmsIncidentReportId">@commonLocalizer["Edit"]</a>
-				<a class="btn btn-default" asp-controller="RecordsInventory" asp-action="Edit" asp-route-area="User" asp-route-recordId="@r.RmsIncidentReportId" asp-route-kind="IncidentReport">Inventory usage</a>
-				<form method="post" style="display:inline" asp-controller="IncidentReports" asp-action="Validate" asp-route-area="User" asp-route-id="@r.RmsIncidentReportId">@Html.AntiForgeryToken()<button type="submit" class="btn btn-default">@(Model.SubmissionEnabled ? localizer["ValidateWithDestination"] : localizer["Validate"])</button></form>
+				<div class="btn-group">
+					<a class="btn btn-primary" id="adp-edit-link" asp-controller="IncidentReports" asp-action="Edit" asp-route-area="User" asp-route-id="@r.RmsIncidentReportId"><i class="fa fa-pencil"></i> @commonLocalizer["Edit"]</a>
+				</div>
+				<form class="btn-group" method="post" asp-controller="IncidentReports" asp-action="Validate" asp-route-area="User" asp-route-id="@r.RmsIncidentReportId">@Html.AntiForgeryToken()<button type="submit" class="btn btn-default"><i class="fa fa-check"></i> @(Model.SubmissionEnabled ? localizer["ValidateWithDestination"] : localizer["Validate"])</button></form>
 			}
 			@if (Model.CanSubmit && Model.CanQueueSubmission)
 			{
-				<form method="post" style="display:inline" asp-controller="IncidentReports" asp-action="Submit" asp-route-area="User" asp-route-id="@r.RmsIncidentReportId">@Html.AntiForgeryToken()<button type="submit" class="btn btn-success"><i class="fa fa-cloud-upload"></i> @localizer["SubmitToNeris"]</button></form>
+				<form class="btn-group" method="post" asp-controller="IncidentReports" asp-action="Submit" asp-route-area="User" asp-route-id="@r.RmsIncidentReportId">@Html.AntiForgeryToken()<button type="submit" class="btn btn-success"><i class="fa fa-cloud-upload"></i> @localizer["SubmitToNeris"]</button></form>
 			}
-			@if (Model.CanAmend && RmsLifecycle.CanTransition((RmsLifecyclePreset)r.LifecyclePreset, state, RmsRecordState.Amended) && r.AmendsRevisionId == null)
+			@if (canAmend)
 			{
-				<form method="post" style="display:inline" asp-controller="IncidentReports" asp-action="Amend" asp-route-area="User" asp-route-id="@r.RmsIncidentReportId">@Html.AntiForgeryToken()<button type="submit" class="btn btn-warning">@localizer["Amend"]</button></form>
+				<form class="btn-group" method="post" asp-controller="IncidentReports" asp-action="Amend" asp-route-area="User" asp-route-id="@r.RmsIncidentReportId">@Html.AntiForgeryToken()<button type="submit" class="btn btn-warning">@localizer["Amend"]</button></form>
 			}
-			@if (r.AmendsRevisionId != null && Model.CanAmend)
+			@if (amendmentOpen)
 			{
-				<form method="post" style="display:inline" asp-controller="IncidentReports" asp-action="AbandonAmendment" asp-route-area="User" asp-route-id="@r.RmsIncidentReportId">@Html.AntiForgeryToken()<button type="submit" class="btn btn-default">@localizer["AbandonAmendment"]</button></form>
+				<form class="btn-group" method="post" asp-controller="IncidentReports" asp-action="AbandonAmendment" asp-route-area="User" asp-route-id="@r.RmsIncidentReportId">@Html.AntiForgeryToken()<button type="submit" class="btn btn-default">@localizer["AbandonAmendment"]</button></form>
 			}
-			@if (Model.CanExport && r.CurrentRevisionId != null)
+			@if (canExport)
 			{
-				<a class="btn btn-info" asp-controller="RecordDocuments" asp-action="Export" asp-route-kind="IncidentReport" asp-route-id="@r.RmsIncidentReportId" asp-route-format="pdf"><i class="fa fa-print"></i> @localizer["Print"]</a>
-				<a class="btn btn-default" asp-controller="RecordDocuments" asp-action="Export" asp-route-kind="IncidentReport" asp-route-id="@r.RmsIncidentReportId" asp-route-format="json">JSON</a>
-				<a class="btn btn-default" asp-controller="RecordDocuments" asp-action="Export" asp-route-kind="IncidentReport" asp-route-id="@r.RmsIncidentReportId" asp-route-format="csv">CSV</a>
+				<div class="btn-group">
+					<button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-download"></i> @localizer["Export"] <span class="caret"></span></button>
+					<ul class="dropdown-menu dropdown-menu-right">
+						<li><a asp-controller="RecordDocuments" asp-action="Export" asp-route-kind="IncidentReport" asp-route-id="@r.RmsIncidentReportId" asp-route-format="pdf"><i class="fa fa-print"></i> @localizer["Print"]</a></li>
+						<li><a asp-controller="RecordDocuments" asp-action="Export" asp-route-kind="IncidentReport" asp-route-id="@r.RmsIncidentReportId" asp-route-format="json"><i class="fa fa-file-code-o"></i> @localizer["ExportJson"]</a></li>
+						<li><a asp-controller="RecordDocuments" asp-action="Export" asp-route-kind="IncidentReport" asp-route-id="@r.RmsIncidentReportId" asp-route-format="csv"><i class="fa fa-file-text-o"></i> @localizer["ExportCsv"]</a></li>
+					</ul>
+				</div>
 			}
-			<a class="btn btn-default" asp-controller="IncidentReports" asp-action="NfirsLegacy" asp-route-area="User" asp-route-callId="@r.CallId" title="@localizer["NfirsLegacyIntro"]"><i class="fa fa-history"></i> @localizer["NfirsLegacyButton"]</a>
+			<div class="btn-group">
+				<button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-ellipsis-h"></i> @localizer["MoreMenu"] <span class="caret"></span></button>
+				<ul class="dropdown-menu dropdown-menu-right">
+					@if (editable)
+					{
+						<li><a asp-controller="RecordsInventory" asp-action="Edit" asp-route-area="User" asp-route-recordId="@r.RmsIncidentReportId" asp-route-kind="IncidentReport"><i class="fa fa-cubes"></i> @localizer["InventoryUsage"]</a></li>
+					}
+					<li><a asp-controller="IncidentReports" asp-action="NfirsLegacy" asp-route-area="User" asp-route-callId="@r.CallId" title="@localizer["NfirsLegacyIntro"]"><i class="fa fa-history"></i> @localizer["NfirsLegacyButton"]</a></li>
+				</ul>
+			</div>
 		</div>
 	</div>
 </div>
@@ -715,6 +737,10 @@
 		</div>
 	</div>
 </div>
+
+@section Styles {
+	<link rel="stylesheet" href="~/css/workspace.css" asp-append-version="true" />
+}
 
 @section Scripts {
 	@if (isProtected)

--- a/Web/Resgrid.Web/Areas/User/Views/Inventory/Operations.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Inventory/Operations.cshtml
@@ -1,116 +1,551 @@
 @using System.Globalization
 @using System.Linq
+@using Microsoft.AspNetCore.Html
+@using Microsoft.AspNetCore.Mvc.Rendering
 @using Newtonsoft.Json
 @using Resgrid.Model.Inventories
 @using Resgrid.Services
 @using Resgrid.Web.Areas.User.Models
 @using Resgrid.Web.Areas.User.Models.Inventory
+@using Resgrid.Web.Helpers
 @model InventoryWorkspaceView
 @inject IStringLocalizer<Resgrid.Localization.Areas.User.Inventory.Inventory> localizer
+@*
+    Operations: physical counts, the alerts they and the catalog raise, and printable reports.
+
+    Starting a count and building a report are both wizards, because both ask a couple of
+    scoping questions whose answers change what the rest of the form means. Entering the
+    counted numbers is deliberately not a wizard: it is one long list to work down.
+*@
+@functions {
+    IHtmlContent Field(string name, string label, object value = null, string type = "text",
+        IEnumerable<SelectListItem> options = null, string help = null, bool required = false,
+        bool wide = false, int maxLength = 16000, string min = null)
+        => WorkspaceFormHelper.Field(localizer, name, label, value, type, options, help, required, false, wide, maxLength, null, min);
+
+    IHtmlContent Hide(string name, object value) => WorkspaceFormHelper.Hidden(name, value);
+
+    IEnumerable<SelectListItem> Choice(IEnumerable<InventoryChoice> list) => WorkspaceFormHelper.Choices(list.Select(x => (x.Id, x.Name)));
+
+    // Theme label colours; a bare "label" is the theme's neutral grey, used for a cancelled count.
+    string CountPill(int status) => status switch
+    {
+        0 => "label-warning",
+        1 => "label-info",
+        2 => "label-success",
+        _ => ""
+    };
+}
 @{
     ViewBag.Title = "Resgrid | " + localizer["M5Operations"];
     var protectedData = ViewBag.ProtectionEnforced == true;
     var count = Model.CountDetail?.Count;
-    string LocationName(string id) => Model.Locations.FirstOrDefault(l => l.Id == id) is { } row ? InventoryWorkspaceView.Details<InventoryLabel>(row).Name : id;
+
+    string LocationName(string id) => string.IsNullOrEmpty(id) ? "" : Model.Locations.FirstOrDefault(l => l.Id == id) is { } row ? InventoryWorkspaceView.Details<InventoryLabel>(row).Name : id;
     string ItemName(string id) => Model.Items.FirstOrDefault(i => i.Id == id) is { } row ? InventoryWorkspaceView.Details<InventoryItemContent>(row).Name : id;
+
+    var locationChoices = Choice(Model.Locations.Select(x => new InventoryChoice { Id = x.Id, Name = InventoryWorkspaceView.Details<InventoryLabel>(x).Name }));
+
+    var tabs = new (string Key, string Icon)[] { ("Counts", "fa-check-square-o"), ("Alerts", "fa-bell-o"), ("Reports", "fa-file-pdf-o") };
+    var help = new Dictionary<string, string> { ["Counts"] = "M5CountHelp", ["Alerts"] = "M5AlertHelp", ["Reports"] = "M5ReportHelp" };
+
+    ViewData["Module"] = "Operations";
+    ViewData["Intro"] = localizer["M5OperationsIntro"].Value;
 }
-<div class="wrapper wrapper-content"><div class="ibox"><div class="ibox-title"><h2>@localizer["M5Operations"]</h2></div><div class="ibox-content">
-    @if (protectedData) { @await Html.PartialAsync("_AdpRevealBanner", new AdpRevealView { BannerTitle = localizer["ProtectedDataRequired"].Value }) }
-    <div id="inventory-message" class="alert alert-info" role="status" hidden></div>
-    <form id="inventory-page" asp-action="ReopenOperations" method="post" class="inventory-navigation">
-        <input type="hidden" name="kind" value="@((int)Model.ReportKind)"/>
-        @Html.AntiForgeryToken()<input type="hidden" name="tab" value="@Model.Tab"/><input type="hidden" name="page" value="@Model.Page"/><input type="hidden" name="id" value="@Model.Id"/><input type="hidden" name="locationId" value="@Model.LocationId"/><input type="hidden" name="itemId" value="@Model.ItemId"/>
-        @if (Model.Locked) { <button type="submit" class="btn btn-primary">@localizer["Unlock"]</button> }
-    </form>
-    @if (!Model.Locked) {
-        <nav class="btn-toolbar" aria-label="@localizer["M5Operations"]">
-            <form asp-action="Reopen" method="post" class="inventory-navigation" style="display:inline-block">@Html.AntiForgeryToken()<button class="btn btn-default" type="submit">@localizer["Inventory"]</button></form>
-            @foreach (var tab in new[] { "Counts", "Alerts", "Reports" }.Where(t => t != "Reports" || Model.CanViewReports)) {
-                <form asp-action="ReopenOperations" method="post" class="inventory-navigation" style="display:inline-block">@Html.AntiForgeryToken()<input type="hidden" name="tab" value="@tab"/><button class="btn @(Model.Tab == tab ? "btn-primary" : "btn-default")" type="submit">@localizer["M5" + tab]</button></form>
+
+@await Html.PartialAsync("_Shell", Model)
+
+<div class="wrapper wrapper-content">
+    <div class="ibox float-e-margins">
+        <div class="ibox-title">
+            <h5>@localizer[Model.Locked || !Model.Migrated ? "M5Operations" : "M5" + Model.Tab]</h5>
+        </div>
+        <div class="ibox-content">
+
+            @if (protectedData)
+            {
+                @await Html.PartialAsync("_AdpRevealBanner", new AdpRevealView { BannerTitle = localizer["ProtectedDataRequired"].Value })
             }
-        </nav><hr/>
-        @if (!Model.Migrated) { <p>@localizer["InitializeDescription"]</p> }
-    }
-    @if (!Model.Locked && Model.Migrated) {
-        <h3>@localizer["M5" + Model.Tab]</h3>
-        @if (Model.Tab == "Counts" && count == null) {
-            <p>@localizer["M5CountHelp"]</p>
-            @if (Model.CanWrite) {
-                <form asp-action="StartCount" method="post" class="inventory-command">
-                    @Html.AntiForgeryToken()<input type="hidden" name="Id" value="@Guid.NewGuid().ToString("D")"/>
-                    <div class="form-group"><label for="count-name">@localizer["Name"]</label><input class="form-control" id="count-name" name="Name" required maxlength="250"/></div>
-                    <div class="form-group"><label for="count-location">@localizer["Location"]</label><select class="form-control" id="count-location" name="LocationId"><option value="">@localizer["M5AllLocations"]</option>
-                        @foreach (var location in Model.Locations) { <option value="@location.Id">@LocationName(location.Id)</option> }
-                    </select></div>
-                    <div class="form-group"><label for="count-note">@localizer["Note"]</label><textarea class="form-control" id="count-note" name="Note" maxlength="16000"></textarea></div>
-                    <button class="btn btn-primary" type="submit">@localizer["M5StartCount"]</button>
-                </form><hr/>
-            }
-            <table class="table table-striped"><thead><tr><th>@localizer["Name"]</th><th>@localizer["Location"]</th><th>@localizer["Status"]</th><th>@localizer["Actions"]</th></tr></thead><tbody>
-                @foreach (var row in Model.Rows.OfType<InventoryCount>()) { <tr><td>@(InventoryWorkspaceView.Details<InventoryCountContent>(row).Name)</td><td>@(row.LocationId == null ? localizer["M5AllLocations"].Value : LocationName(row.LocationId))</td><td>@localizer["M5CountStatus" + row.Status]</td><td><form asp-action="ReopenOperations" method="post" class="inventory-navigation">@Html.AntiForgeryToken()<input type="hidden" name="id" value="@row.Id"/><button class="btn btn-default" type="submit">@localizer["Details"]</button></form></td></tr> }
-            </tbody></table>
-        }
-        @if (count != null) {
-            var details = InventoryWorkspaceView.Details<InventoryCountContent>(count);
-            <h4>@details.Name · @localizer["M5CountStatus" + count.Status]</h4><p>@details.Note</p><p>@localizer["M5SnapshotOn"]: @count.SnapshotOn.ToString("u")</p>
-            <form asp-action="SaveCount" method="post" class="inventory-command">
-                @Html.AntiForgeryToken()<input type="hidden" name="CountId" value="@count.Id"/><input type="hidden" name="Revision" value="@count.Revision"/>
-                <div class="table-responsive"><table class="table table-striped"><thead><tr><th>@localizer["Items"]</th><th>@localizer["Location"]</th><th>@localizer["M5Expected"]</th><th>@localizer["M5Counted"]</th><th>@localizer["M5Variance"]</th></tr></thead><tbody>
-                    @for (var i = 0; i < Model.CountDetail.Lines.Count; i++) {
-                        var line = Model.CountDetail.Lines[i]; var data = InventoryWorkspaceView.Details<InventoryCountItemContent>(line);
-                        <tr><td>@data.ItemName <small>@data.LotNumber @data.SerialNumber</small></td><td>@LocationName(line.LocationId)</td><td>@line.ExpectedQuantity.ToString(CultureInfo.CurrentCulture) @data.UnitOfMeasure</td><td>
-                            @if (count.Status == 0 && Model.CanWrite) { <input type="hidden" name="Lines[@i].Id" value="@line.Id"/><input class="form-control" aria-label="@localizer["M5Counted"] @data.ItemName" type="number" name="Lines[@i].Quantity" value="@line.CountedQuantity?.ToString(CultureInfo.InvariantCulture)" min="0" max="@(line.AssetId == null ? "100000000" : "1")" step="@(line.AssetId == null ? "0.000001" : "1")" required/> }
-                            else { @line.CountedQuantity?.ToString(CultureInfo.CurrentCulture) }
-                        </td><td>@((line.CountedQuantity - line.ExpectedQuantity)?.ToString(CultureInfo.CurrentCulture))</td></tr>
-                    }
-                </tbody></table></div>
-                @if (count.Status == 0 && Model.CanWrite) { <button class="btn btn-primary" type="submit">@localizer["Save"]</button> }
-            </form>
-            @if (Model.CanWrite && count.Status == 0) {
-                <form asp-action="CompleteCount" method="post" class="inventory-command">@Html.AntiForgeryToken()<input type="hidden" name="CountId" value="@count.Id"/><input type="hidden" name="Revision" value="@count.Revision"/><input type="hidden" name="RequestId" value="@Guid.NewGuid().ToString("D")"/><button class="btn btn-success" type="submit">@localizer["M5CompleteCount"]</button></form>
-            }
-            @if (Model.CanWrite && count.Status is 0 or 1) {
-                <form asp-action="CancelCount" method="post" class="inventory-command">@Html.AntiForgeryToken()<input type="hidden" name="countId" value="@count.Id"/><input type="hidden" name="revision" value="@count.Revision"/><button class="btn btn-default" type="submit">@localizer["M5CancelCount"]</button></form>
-            }
-            @if (count.Status == 1) { <p>@localizer["M5WitnessHelp"]</p><form asp-action="Reopen" method="post" class="inventory-navigation">@Html.AntiForgeryToken()<input type="hidden" name="tab" value="History"/><button class="btn btn-default">@localizer["Witness"]</button></form> }
-            @if (count.Status == 2) {
-                <p>@localizer["M5VarianceLines"]: @details.VarianceLineCount</p>
-                @foreach (var total in details.Totals) { <p>@(total.CurrencyCode ?? localizer["M4UnspecifiedCurrency"].Value): @total.KnownValue.ToString(CultureInfo.CurrentCulture) · @localizer["M4UnknownCost"]: @total.UncostedRows</p> }
-            }
-        }
-        @if (Model.Tab == "Alerts") {
-            <p>@localizer["M5AlertHelp"]</p>
-            @if (Model.CanWrite) { <form asp-action="RefreshAlerts" method="post" class="inventory-command">@Html.AntiForgeryToken()<button class="btn btn-primary" type="submit">@localizer["M5RefreshAlerts"]</button></form> }
-            <div class="table-responsive"><table class="table table-striped"><thead><tr><th>@localizer["Type"]</th><th>@localizer["Items"]</th><th>@localizer["Location"]</th><th>@localizer["Status"]</th><th>@localizer["Amount"]</th><th>@localizer["M5DueOn"]</th></tr></thead><tbody>
-                @foreach (var alert in Model.Rows.OfType<InventoryAlert>()) { <tr><td>@localizer["M5AlertType" + alert.AlertType]</td><td>@ItemName(alert.ItemId)<small style="display:block">@alert.AssetId @alert.LotId @alert.IssuanceId</small></td><td>@(alert.LocationId == null ? localizer["M5AllLocations"].Value : LocationName(alert.LocationId))</td><td>@localizer[alert.Status == 0 ? "M5Open" : "M5Resolved"]</td><td>@alert.Quantity?.ToString(CultureInfo.CurrentCulture)</td><td>@alert.DueOn?.ToString("u")</td></tr> }
-            </tbody></table></div>
-        }
-        @if (Model.Tab == "Reports" && Model.CanViewReports) {
-            <p>@localizer["M5ReportHelp"]</p>
-            <form asp-action="ReportPdf" method="post" class="inventory-navigation" id="inventory-report-form">
+
+            <div id="inventory-message" class="alert alert-info" role="status" hidden></div>
+
+            <form id="inventory-page" asp-action="ReopenOperations" method="post" class="inventory-navigation">
                 @Html.AntiForgeryToken()
-                <div class="form-group"><label for="report-kind">@localizer["M5Reports"]</label><select class="form-control" id="report-kind" name="Kind">@foreach (var kind in Enum.GetValues<InventoryReportKind>()) { <option value="@((int)kind)" selected="@(kind == Model.ReportKind)">@InventoryReportDocuments.Title(kind)</option> }</select></div>
-                <div class="form-group"><label for="report-location">@localizer["Location"]</label><select class="form-control" id="report-location" name="LocationId"><option value="">@localizer["M5AllLocations"]</option>@foreach (var location in Model.Locations) { <option value="@location.Id">@LocationName(location.Id)</option> }</select></div>
-                <div class="form-group"><label for="report-item">@localizer["Items"]</label><select class="form-control" id="report-item" name="ItemId"><option value="">—</option>@foreach (var item in Model.Items) { <option value="@item.Id">@ItemName(item.Id)</option> }</select></div>
-                <div class="form-group"><label for="report-from">@localizer["M5FromUtc"]</label><input class="form-control" id="report-from" type="date" name="FromUtc"/></div>
-                <div class="form-group"><label for="report-person">@localizer["Person"]</label><select class="form-control" id="report-person" name="UserId"><option value="">—</option>@foreach (var person in Model.People) { <option value="@person.Id">@person.Name</option> }</select></div>
-                <div class="form-group"><label for="report-unit">@localizer["Unit"]</label><select class="form-control" id="report-unit" name="UnitId"><option value="">—</option>@foreach (var unit in Model.Units) { <option value="@unit.Id">@unit.Name</option> }</select></div>
-                <div class="form-group"><label for="report-until">@localizer["M5UntilUtc"]</label><input class="form-control" id="report-until" type="date" name="UntilUtc"/></div>
-                <button class="btn btn-primary" type="submit">@localizer["M5DownloadPdf"]</button>
+                @Hide("kind", (int)Model.ReportKind)
+                @Hide("tab", Model.Tab)@Hide("page", Model.Page)@Hide("id", Model.Id)
+                @Hide("locationId", Model.LocationId)@Hide("itemId", Model.ItemId)
+                @if (Model.Locked)
+                {
+                    <div class="text-center m-t-lg m-b-lg">
+                        <i class="fa fa-lock fa-3x text-muted"></i>
+                        <h4 class="m-t-sm">@localizer["ProtectedDataRequired"]</h4>
+                        <p>@commonLocalizer["AdpProtectedBannerDescription"]</p>
+                        <button type="submit" class="btn btn-primary m-t">@localizer["Unlock"]</button>
+                    </div>
+                }
             </form>
-            <p><a asp-controller="Profile" asp-action="Reporting">@localizer["M5ScheduleReports"]</a></p>
-        }
-        @if (Model.Tab != "Reports" && count == null) {
-            if (Model.Rows.Count == 0) { <p>@localizer["NoRows"]</p> }
-            foreach (var nextPage in new[] { Model.Page - 1, Model.Page + 1 }.Where(p => p >= 0 && (p < Model.Page || Model.HasMore))) {
-                <form asp-action="ReopenOperations" method="post" class="inventory-navigation" style="display:inline-block">@Html.AntiForgeryToken()<input type="hidden" name="tab" value="@Model.Tab"/><input type="hidden" name="page" value="@nextPage"/><input type="hidden" name="itemId" value="@Model.ItemId"/><input type="hidden" name="locationId" value="@Model.LocationId"/><button class="btn btn-default" type="submit">@localizer[nextPage < Model.Page ? "Previous" : "Next"]</button></form>
+
+            @if (!Model.Locked)
+            {
+                <ul class="nav nav-tabs" role="tablist" aria-label="@localizer["M5Operations"]">
+                    @foreach (var tab in tabs.Where(t => t.Key != "Reports" || Model.CanViewReports))
+                    {
+                        <li class="nav-item @(Model.Tab == tab.Key ? "active" : null)">
+                            <form asp-action="ReopenOperations" method="post" class="inventory-navigation">
+                                @Html.AntiForgeryToken()
+                                @Hide("tab", tab.Key)
+                                <button type="submit" aria-current="@(Model.Tab == tab.Key ? "page" : "false")">
+                                    <i class="fa @tab.Icon"></i> @localizer["M5" + tab.Key]
+                                </button>
+                            </form>
+                        </li>
+                    }
+                </ul>
+
+                if (!Model.Migrated)
+                {
+                    <div class="text-center m-t-lg m-b-lg">
+                        <i class="fa fa-cubes fa-3x text-muted"></i>
+                        <h4 class="m-t-sm">@localizer["Initialize"]</h4>
+                        <p>@localizer["InitializeDescription"]</p>
+                    </div>
+                }
             }
-        }
-    }
-</div></div></div>
+
+            @if (!Model.Locked && Model.Migrated)
+            {
+                @if (count == null && help.ContainsKey(Model.Tab))
+                {
+                    <div class="alert alert-info"><i class="fa fa-info-circle"></i> @localizer[help[Model.Tab]]</div>
+                }
+
+                @* ── Count list ──────────────────────────────────────────────────── *@
+                @if (Model.Tab == "Counts" && count == null)
+                {
+                    if (Model.CanWrite)
+                    {
+                        <div class="rgw-toolbar">
+                            <div class="rgw-toolbar-spacer"></div>
+                            <button class="btn btn-primary" type="button" data-toggle="modal" data-target="#m5-start-count"><i class="fa fa-plus"></i> @localizer["M5StartCount"]</button>
+                        </div>
+                    }
+
+                    if (!Model.Rows.OfType<InventoryCount>().Any())
+                    {
+                        <div class="text-center m-t-lg m-b-lg">
+                            <i class="fa fa-check-square-o fa-3x text-muted"></i>
+                            <h4 class="m-t-sm">@localizer["NoRows"]</h4>
+                            <p>@localizer["NoRowsHelp"]</p>
+                        </div>
+                    }
+                    else
+                    {
+                        <div class="table-responsive">
+                            <table class="table table-striped rgw-table">
+                                <thead><tr><th>@localizer["Name"]</th><th>@localizer["Location"]</th><th>@localizer["Status"]</th><th class="rgw-row-actions">@localizer["Actions"]</th></tr></thead>
+                                <tbody>
+                                    @foreach (var row in Model.Rows.OfType<InventoryCount>())
+                                    {
+                                        <tr>
+                                            <td>@(InventoryWorkspaceView.Details<InventoryCountContent>(row).Name)</td>
+                                            <td>@(row.LocationId == null ? localizer["M5AllLocations"].Value : LocationName(row.LocationId))</td>
+                                            <td><span class="label @CountPill(row.Status)">@localizer["M5CountStatus" + row.Status]</span></td>
+                                            <td class="rgw-row-actions">
+                                                <form asp-action="ReopenOperations" method="post" class="inventory-navigation">
+                                                    @Html.AntiForgeryToken()
+                                                    @Hide("id", row.Id)
+                                                    <button class="btn btn-xs btn-info" type="submit">@localizer["Details"]</button>
+                                                </form>
+                                            </td>
+                                        </tr>
+                                    }
+                                </tbody>
+                            </table>
+                        </div>
+                    }
+                }
+
+                @* ── One count ───────────────────────────────────────────────────── *@
+                @if (count != null)
+                {
+                    var details = InventoryWorkspaceView.Details<InventoryCountContent>(count);
+                    var open = count.Status == 0 && Model.CanWrite;
+
+                    <div class="rgw-toolbar">
+                        <form asp-action="ReopenOperations" method="post" class="inventory-navigation">
+                            @Html.AntiForgeryToken()
+                            @Hide("tab", "Counts")
+                            <button class="btn btn-default btn-sm" type="submit"><i class="fa fa-arrow-left"></i> @localizer["Back"]</button>
+                        </form>
+                        <div class="rgw-toolbar-spacer"></div>
+                        @if (Model.CanWrite && count.Status == 0)
+                        {
+                            <form asp-action="CompleteCount" method="post" class="inventory-command">
+                                @Html.AntiForgeryToken()
+                                @Hide("CountId", count.Id)@Hide("Revision", count.Revision)@Hide("RequestId", Guid.NewGuid().ToString("D"))
+                                <button class="btn btn-primary" type="submit"><i class="fa fa-check"></i> @localizer["M5CompleteCount"]</button>
+                            </form>
+                        }
+                        @if (Model.CanWrite && count.Status is 0 or 1)
+                        {
+                            <form asp-action="CancelCount" method="post" class="inventory-command">
+                                @Html.AntiForgeryToken()
+                                @Hide("countId", count.Id)@Hide("revision", count.Revision)
+                                <button class="btn btn-default" type="submit">@localizer["M5CancelCount"]</button>
+                            </form>
+                        }
+                    </div>
+
+                    <h3>@details.Name</h3>
+                    <p class="text-muted">
+                        <span class="label @CountPill(count.Status)">@localizer["M5CountStatus" + count.Status]</span>
+                        @(count.LocationId == null ? localizer["M5AllLocations"].Value : LocationName(count.LocationId))
+                        &middot; @localizer["M5SnapshotOn"]: <time datetime="@count.SnapshotOn.ToString("u")">@count.SnapshotOn.ToString("g", CultureInfo.CurrentCulture)</time>
+                    </p>
+                    @if (!string.IsNullOrEmpty(details.Note))
+                    {
+                        <p>@details.Note</p>
+                    }
+                    <div class="hr-line-dashed"></div>
+
+                    @if (open)
+                    {
+                        <div class="alert alert-info"><i class="fa fa-info-circle"></i> @localizer["M5CountEnterHelp"]</div>
+                    }
+
+                    <form asp-action="SaveCount" method="post" class="inventory-command">
+                        @Html.AntiForgeryToken()
+                        @Hide("CountId", count.Id)@Hide("Revision", count.Revision)
+                        <div class="table-responsive">
+                            <table class="table table-striped rgw-table">
+                                <thead><tr><th>@localizer["Items"]</th><th>@localizer["Location"]</th><th class="text-right">@localizer["M5Expected"]</th><th class="text-right">@localizer["M5Counted"]</th><th class="text-right">@localizer["M5Variance"]</th></tr></thead>
+                                <tbody>
+                                    @for (var i = 0; i < Model.CountDetail.Lines.Count; i++)
+                                    {
+                                        var line = Model.CountDetail.Lines[i];
+                                        var data = InventoryWorkspaceView.Details<InventoryCountItemContent>(line);
+                                        var variance = line.CountedQuantity - line.ExpectedQuantity;
+                                        <tr>
+                                            <td>
+                                                @data.ItemName
+                                                @if (!string.IsNullOrEmpty(data.LotNumber) || !string.IsNullOrEmpty(data.SerialNumber))
+                                                {
+                                                    <small class="text-muted rgw-sub">@data.LotNumber @data.SerialNumber</small>
+                                                }
+                                            </td>
+                                            <td>@LocationName(line.LocationId)</td>
+                                            <td class="text-right">@line.ExpectedQuantity.ToString(CultureInfo.CurrentCulture) @data.UnitOfMeasure</td>
+                                            <td class="text-right">
+                                                @if (open)
+                                                {
+                                                    @Hide("Lines[" + i + "].Id", line.Id)
+                                                    <input class="form-control" aria-label="@localizer["M5Counted"] @data.ItemName" type="number"
+                                                           name="Lines[@i].Quantity" value="@line.CountedQuantity?.ToString(CultureInfo.InvariantCulture)"
+                                                           min="0" max="@(line.AssetId == null ? "100000000" : "1")"
+                                                           step="@(line.AssetId == null ? "0.000001" : "1")" required />
+                                                }
+                                                else
+                                                {
+                                                    @line.CountedQuantity?.ToString(CultureInfo.CurrentCulture)
+                                                }
+                                            </td>
+                                            <td class="text-right">
+                                                @if (variance.HasValue && variance.Value != 0)
+                                                {
+                                                    <span class="label label-warning">@variance.Value.ToString(CultureInfo.CurrentCulture)</span>
+                                                }
+                                                else if (variance.HasValue)
+                                                {
+                                                    <span class="label label-success">0</span>
+                                                }
+                                            </td>
+                                        </tr>
+                                    }
+                                </tbody>
+                            </table>
+                        </div>
+                        @if (open)
+                        {
+                            <div class="rgw-wizard-actions">
+                                <div class="rgw-wizard-spacer"></div>
+                                <button class="btn btn-primary" type="submit">@localizer["Save"]</button>
+                            </div>
+                        }
+                    </form>
+
+                    @if (count.Status == 1)
+                    {
+                        <div class="alert alert-info"><i class="fa fa-info-circle"></i> @localizer["M5WitnessHelp"]</div>
+                        <form asp-action="Reopen" method="post" class="inventory-navigation">
+                            @Html.AntiForgeryToken()
+                            @Hide("tab", "History")
+                            <button class="btn btn-default" type="submit">@localizer["Witness"]</button>
+                        </form>
+                    }
+
+                    @if (count.Status == 2)
+                    {
+                        @* Totals use the same ibox statistic tile as the records dashboard. *@
+                        <div class="row">
+                            <div class="col-lg-3 col-md-6">
+                                <div class="ibox">
+                                    <div class="ibox-title"><h5>@localizer["M5VarianceLines"]</h5></div>
+                                    <div class="ibox-content"><h1 class="no-margins">@details.VarianceLineCount</h1></div>
+                                </div>
+                            </div>
+                            @foreach (var total in details.Totals)
+                            {
+                                <div class="col-lg-3 col-md-6">
+                                    <div class="ibox">
+                                        <div class="ibox-title"><h5>@(total.CurrencyCode ?? localizer["M4UnspecifiedCurrency"].Value)</h5></div>
+                                        <div class="ibox-content">
+                                            <h1 class="no-margins">@total.KnownValue.ToString(CultureInfo.CurrentCulture)</h1>
+                                            <small>@localizer["M4UnknownCost"]: @total.UncostedRows</small>
+                                        </div>
+                                    </div>
+                                </div>
+                            }
+                        </div>
+                    }
+                }
+
+                @* ── Alerts ──────────────────────────────────────────────────────── *@
+                @if (Model.Tab == "Alerts")
+                {
+                    if (Model.CanWrite)
+                    {
+                        <div class="rgw-toolbar">
+                            <div class="rgw-toolbar-spacer"></div>
+                            <form asp-action="RefreshAlerts" method="post" class="inventory-command">
+                                @Html.AntiForgeryToken()
+                                <button class="btn btn-primary" type="submit"><i class="fa fa-refresh"></i> @localizer["M5RefreshAlerts"]</button>
+                            </form>
+                        </div>
+                    }
+
+                    if (!Model.Rows.OfType<InventoryAlert>().Any())
+                    {
+                        <div class="text-center m-t-lg m-b-lg">
+                            <i class="fa fa-bell-o fa-3x text-muted"></i>
+                            <h4 class="m-t-sm">@localizer["NoRows"]</h4>
+                            <p>@localizer["M5NoAlertsHelp"]</p>
+                        </div>
+                    }
+                    else
+                    {
+                        <div class="table-responsive">
+                            <table class="table table-striped rgw-table">
+                                <thead><tr><th>@localizer["Type"]</th><th>@localizer["Items"]</th><th>@localizer["Location"]</th><th>@localizer["Status"]</th><th class="text-right">@localizer["Amount"]</th><th>@localizer["M5DueOn"]</th></tr></thead>
+                                <tbody>
+                                    @foreach (var alert in Model.Rows.OfType<InventoryAlert>())
+                                    {
+                                        <tr>
+                                            <td><span class="label label-warning">@localizer["M5AlertType" + alert.AlertType]</span></td>
+                                            <td>
+                                                @ItemName(alert.ItemId)
+                                                @if (!string.IsNullOrEmpty(alert.AssetId) || !string.IsNullOrEmpty(alert.LotId) || !string.IsNullOrEmpty(alert.IssuanceId))
+                                                {
+                                                    <small class="text-muted rgw-sub">@alert.AssetId @alert.LotId @alert.IssuanceId</small>
+                                                }
+                                            </td>
+                                            <td>@(alert.LocationId == null ? localizer["M5AllLocations"].Value : LocationName(alert.LocationId))</td>
+                                            <td><span class="label @(alert.Status == 0 ? "label-warning" : "label-success")">@localizer[alert.Status == 0 ? "M5Open" : "M5Resolved"]</span></td>
+                                            <td class="text-right">@alert.Quantity?.ToString(CultureInfo.CurrentCulture)</td>
+                                            <td>
+                                                @if (alert.DueOn.HasValue)
+                                                {
+                                                    <time datetime="@alert.DueOn.Value.ToString("u")">@alert.DueOn.Value.ToString("g", CultureInfo.CurrentCulture)</time>
+                                                }
+                                            </td>
+                                        </tr>
+                                    }
+                                </tbody>
+                            </table>
+                        </div>
+                    }
+                }
+
+                @* ── Reports ─────────────────────────────────────────────────────── *@
+                @if (Model.Tab == "Reports" && Model.CanViewReports)
+                {
+                    <form asp-action="ReportPdf" method="post" class="inventory-navigation rgw-wizard" id="inventory-report-form">
+                        @Html.AntiForgeryToken()
+                        <ol class="rgw-steps"></ol>
+
+                        <div class="rgw-step" data-title="@localizer["M5StepReportKind"]">
+                            <h4>@localizer["M5StepReportKind"]</h4>
+                            <p class="text-muted">@localizer["M5StepReportKindHint"]</p>
+                            <div class="rgw-grid">
+                                <div class="form-group rgw-wide">
+                                    <label for="report-kind">@localizer["M5Reports"]</label>
+                                    <select class="form-control" id="report-kind" name="Kind" required>
+                                        @foreach (var kind in Enum.GetValues<InventoryReportKind>())
+                                        {
+                                            <option value="@((int)kind)" selected="@(kind == Model.ReportKind)">@InventoryReportDocuments.Title(kind)</option>
+                                        }
+                                    </select>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="rgw-step" data-title="@localizer["M5StepReportFilters"]">
+                            <h4>@localizer["M5StepReportFilters"]</h4>
+                            <p class="text-muted">@localizer["M5StepReportFiltersHint"]</p>
+                            <div class="rgw-grid">
+                                <div class="form-group">
+                                    <label for="report-location">@localizer["Location"]</label>
+                                    <select class="form-control" id="report-location" name="LocationId">
+                                        <option value="">@localizer["M5AllLocations"]</option>
+                                        @foreach (var location in Model.Locations)
+                                        {
+                                            <option value="@location.Id">@LocationName(location.Id)</option>
+                                        }
+                                    </select>
+                                </div>
+                                <div class="form-group">
+                                    <label for="report-item">@localizer["Items"]</label>
+                                    <select class="form-control" id="report-item" name="ItemId">
+                                        <option value="">—</option>
+                                        @foreach (var item in Model.Items)
+                                        {
+                                            <option value="@item.Id">@ItemName(item.Id)</option>
+                                        }
+                                    </select>
+                                </div>
+                                <div class="form-group">
+                                    <label for="report-person">@localizer["Person"]</label>
+                                    <select class="form-control" id="report-person" name="UserId">
+                                        <option value="">—</option>
+                                        @foreach (var person in Model.People)
+                                        {
+                                            <option value="@person.Id">@person.Name</option>
+                                        }
+                                    </select>
+                                    <span class="help-block">@localizer["HelpFieldHolder"]</span>
+                                </div>
+                                <div class="form-group">
+                                    <label for="report-unit">@localizer["Unit"]</label>
+                                    <select class="form-control" id="report-unit" name="UnitId">
+                                        <option value="">—</option>
+                                        @foreach (var unit in Model.Units)
+                                        {
+                                            <option value="@unit.Id">@unit.Name</option>
+                                        }
+                                    </select>
+                                    <span class="help-block">@localizer["HelpFieldHolder"]</span>
+                                </div>
+                                <div class="form-group">
+                                    <label for="report-from">@localizer["M5FromUtc"]</label>
+                                    <input class="form-control" id="report-from" type="date" name="FromUtc" />
+                                    <span class="help-block">@localizer["HelpFieldReportRange"]</span>
+                                </div>
+                                <div class="form-group">
+                                    <label for="report-until">@localizer["M5UntilUtc"]</label>
+                                    <input class="form-control" id="report-until" type="date" name="UntilUtc" />
+                                    <span class="help-block">@localizer["HelpFieldReportRange"]</span>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="rgw-wizard-actions">
+                            <button type="button" class="btn btn-white rgw-step-prev">@localizer["Back"]</button>
+                            <div class="rgw-wizard-spacer"></div>
+                            <button type="button" class="btn btn-primary rgw-step-next">@localizer["Continue"]</button>
+                            <button type="submit" class="btn btn-primary rgw-step-submit"><i class="fa fa-download"></i> @localizer["M5DownloadPdf"]</button>
+                        </div>
+                    </form>
+
+                    <p class="m-t"><a asp-controller="Profile" asp-action="Reporting">@localizer["M5ScheduleReports"]</a></p>
+                }
+
+                @if (Model.Tab != "Reports" && count == null && (Model.Page > 0 || Model.HasMore))
+                {
+                    <div class="rgw-pager">
+                        @foreach (var nextPage in new[] { Model.Page - 1, Model.Page + 1 }.Where(p => p >= 0 && (p < Model.Page || Model.HasMore)))
+                        {
+                            <form asp-action="ReopenOperations" method="post" class="inventory-navigation">
+                                @Html.AntiForgeryToken()
+                                @Hide("tab", Model.Tab)@Hide("page", nextPage)@Hide("itemId", Model.ItemId)@Hide("locationId", Model.LocationId)
+                                <button class="btn btn-default btn-sm" type="submit">
+                                    <i class="fa @(nextPage < Model.Page ? "fa-chevron-left" : "fa-chevron-right")"></i>
+                                    @localizer[nextPage < Model.Page ? "Previous" : "Next"]
+                                </button>
+                            </form>
+                        }
+                        <span class="text-muted">@(Model.Page + 1)</span>
+                    </div>
+                }
+
+                @* ── Dialogs ─────────────────────────────────────────────────────── *@
+                @if (Model.CanWrite && Model.Tab == "Counts" && count == null)
+                {
+                    <div class="modal fade rgw-modal" id="m5-start-count" tabindex="-1" role="dialog" aria-labelledby="m5-start-count-title">
+                        <div class="modal-dialog modal-lg" role="document">
+                            <div class="modal-content">
+                                <div class="modal-header">
+                                    <button type="button" class="close" data-dismiss="modal" aria-label="@localizer["Close"]"><span aria-hidden="true">&times;</span></button>
+                                    <h4 class="modal-title" id="m5-start-count-title">@localizer["M5StartCount"]</h4>
+                                </div>
+                                <div class="modal-body">
+                                    <div class="alert rgw-modal-message" role="status"></div>
+                                    <form asp-action="StartCount" method="post" class="inventory-command rgw-wizard">
+                                        @Html.AntiForgeryToken()
+                                        @Hide("Id", Guid.NewGuid().ToString("D"))
+                                        <ol class="rgw-steps"></ol>
+
+                                        <div class="rgw-step" data-title="@localizer["M5StepCountBasics"]">
+                                            <h4>@localizer["M5StepCountBasics"]</h4>
+                                            <p class="text-muted">@localizer["M5StepCountBasicsHint"]</p>
+                                            <div class="rgw-grid">
+                                                @Field("Name", "Name", null, required: true, maxLength: 250, help: "M5CountNameHelp", wide: true)
+                                                @Field("Note", "Note", null, "textarea", wide: true)
+                                            </div>
+                                        </div>
+
+                                        <div class="rgw-step" data-title="@localizer["M5StepCountScope"]">
+                                            <h4>@localizer["M5StepCountScope"]</h4>
+                                            <p class="text-muted">@localizer["M5StepCountScopeHint"]</p>
+                                            <div class="rgw-grid">
+                                                @Field("LocationId", "Location", null, options: locationChoices, help: "HelpFieldCountLocation", wide: true)
+                                            </div>
+                                        </div>
+
+                                        <div class="rgw-step" data-title="@localizer["Review"]">
+                                            <h4>@localizer["Review"]</h4>
+                                            <p class="text-muted">@localizer["ReviewHint"]</p>
+                                            <dl class="rgw-review"></dl>
+                                        </div>
+
+                                        <div class="rgw-wizard-actions">
+                                            <button type="button" class="btn btn-white rgw-step-prev">@localizer["Back"]</button>
+                                            <div class="rgw-wizard-spacer"></div>
+                                            <button type="button" class="btn btn-white" data-dismiss="modal">@localizer["Close"]</button>
+                                            <button type="button" class="btn btn-primary rgw-step-next">@localizer["Continue"]</button>
+                                            <button type="submit" class="btn btn-primary rgw-step-submit">@localizer["M5StartCount"]</button>
+                                        </div>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                }
+            }
+        </div>
+    </div>
+</div>
+
+@section Styles {
+    <link rel="stylesheet" href="~/css/workspace.css" asp-append-version="true" />
+}
+
 @section Scripts {
-<script id="inventory-settings" type="application/json">@Html.Raw(JsonConvert.SerializeObject(new { protectedData, grant = (string)ViewBag.ProtectedGrant, expiry = (DateTime?)ViewBag.GrantExpiresOn, index = Url.Action("Operations", new { tab = Model.Tab, id = Model.Id, page = Model.Page }), failed = localizer["UnableToComplete"].Value, witness = localizer["WitnessPending"].Value }, new JsonSerializerSettings { StringEscapeHandling = StringEscapeHandling.EscapeHtml }))</script>
-<script src="~/js/app/internal/inventory/inventory-modern.js" asp-append-version="true"></script>
-<script src="~/js/app/internal/inventory/inventory-operations.js" asp-append-version="true"></script>
-@if (protectedData) { @await Html.PartialAsync("_AdpRevealScripts", new AdpRevealView { BannerTitle = localizer["ProtectedDataRequired"].Value, GrantExpiresOnUtc = (DateTime?)ViewBag.GrantExpiresOn, BindForms = new List<string> { "form.inventory-navigation", "form.inventory-command" } }) }
+    <script id="inventory-settings" type="application/json">@Html.Raw(JsonConvert.SerializeObject(new { protectedData, grant = (string)ViewBag.ProtectedGrant, expiry = (DateTime?)ViewBag.GrantExpiresOn, index = Url.Action("Operations", new { tab = Model.Tab, id = Model.Id, page = Model.Page }), failed = localizer["UnableToComplete"].Value, witness = localizer["WitnessPending"].Value }, new JsonSerializerSettings { StringEscapeHandling = StringEscapeHandling.EscapeHtml }))</script>
+    <script id="workspace-settings" type="application/json">@Html.Raw(JsonConvert.SerializeObject(new { required = localizer["RequiredFieldsMissing"].Value, nothingEntered = localizer["NoRows"].Value, yes = localizer["Yes"].Value, no = localizer["No"].Value }, new JsonSerializerSettings { StringEscapeHandling = StringEscapeHandling.EscapeHtml }))</script>
+    <script src="~/js/app/internal/inventory/inventory-modern.js" asp-append-version="true"></script>
+    <script src="~/js/app/internal/inventory/inventory-operations.js" asp-append-version="true"></script>
+    <script src="~/js/app/common/workspace/resgrid.common.workspace.js" asp-append-version="true"></script>
+    @if (protectedData)
+    {
+        @await Html.PartialAsync("_AdpRevealScripts", new AdpRevealView { BannerTitle = localizer["ProtectedDataRequired"].Value, GrantExpiresOnUtc = (DateTime?)ViewBag.GrantExpiresOn, BindForms = new List<string> { "form.inventory-navigation", "form.inventory-command" } })
+    }
 }

--- a/Web/Resgrid.Web/Areas/User/Views/Inventory/Purchasing.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Inventory/Purchasing.cshtml
@@ -6,200 +6,668 @@
 @using Resgrid.Model.Inventories
 @using Resgrid.Web.Areas.User.Models
 @using Resgrid.Web.Areas.User.Models.Inventory
+@using Resgrid.Web.Helpers
 @model InventoryWorkspaceView
 @inject IStringLocalizer<Resgrid.Localization.Areas.User.Inventory.Inventory> localizer
+@*
+    Purchasing: suppliers, purchase orders and what the stock on hand is worth.
+
+    Raising an order is the one flow here with enough moving parts to deserve a wizard;
+    receiving against an order is a single screen because it is a list of lines to confirm,
+    not a sequence of decisions.
+*@
 @functions {
-    IHtmlContent PurchasingField(string name, string label, object value = null, string type = "text", IEnumerable<SelectListItem> options = null, bool required = false, bool readOnly = false, int maxLength = 16000) {
-        var wrap = new TagBuilder("div"); wrap.AddCssClass("form-group");
-        var caption = new TagBuilder("label"); var identity = "purchase-" + Guid.NewGuid().ToString("N"); caption.Attributes["for"] = identity; caption.InnerHtml.Append(localizer[label].Value); wrap.InnerHtml.AppendHtml(caption);
-        var element = new TagBuilder(options == null ? "input" : "select"); element.AddCssClass("form-control"); element.Attributes["name"] = name; element.Attributes["id"] = identity;
-        if (required) element.Attributes["required"] = "required";
-        if (readOnly) element.Attributes["readonly"] = "readonly";
-        var text = value is DateTime date ? date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture) : Convert.ToString(value, CultureInfo.InvariantCulture) ?? "";
-        if (options == null) {
-            element.Attributes["type"] = type; element.Attributes["value"] = text; element.Attributes["maxlength"] = maxLength.ToString(CultureInfo.InvariantCulture);
-            if (type == "number") { element.Attributes["step"] = "0.000001"; element.Attributes["min"] = name.EndsWith(".UnitCost", StringComparison.Ordinal) ? "0" : "0.000001"; }
-            if (name == "CurrencyCode") { element.Attributes["pattern"] = "[A-Za-z]{3}"; element.Attributes["autocomplete"] = "off"; }
-        } else foreach (var option in options) {
-            var item = new TagBuilder("option"); item.Attributes["value"] = option.Value ?? ""; if ((option.Value ?? "") == text) item.Attributes["selected"] = "selected"; item.InnerHtml.Append(option.Text); element.InnerHtml.AppendHtml(item);
-        }
-        wrap.InnerHtml.AppendHtml(element); return wrap;
-    }
-    IEnumerable<SelectListItem> PurchasingChoices(IEnumerable<InventoryChoice> choices) => new[] { new SelectListItem { Value = "", Text = "—" } }.Concat(choices.Select(x => new SelectListItem { Value = x.Id, Text = x.Name }));
+    IHtmlContent Field(string name, string label, object value = null, string type = "text",
+        IEnumerable<SelectListItem> options = null, string help = null, bool required = false,
+        bool wide = false, int maxLength = 16000, string min = null, bool readOnly = false)
+        => WorkspaceFormHelper.Field(localizer, name, label, value, type, options, help, required, readOnly, wide, maxLength, null, min);
+
+    IHtmlContent Hide(string name, object value) => WorkspaceFormHelper.Hidden(name, value);
+
+    IEnumerable<SelectListItem> Choice(IEnumerable<InventoryChoice> list) => WorkspaceFormHelper.Choices(list.Select(x => (x.Id, x.Name)));
+
+    // Theme label colours; a bare "label" is the theme's neutral grey, used for a draft.
+    string StatusPill(int status) => status switch
+    {
+        0 => "",
+        1 => "label-info",
+        2 => "label-warning",
+        3 => "label-success",
+        _ => "label-danger"
+    };
 }
 @{
     ViewBag.Title = "Resgrid | " + localizer["M4Purchasing"];
     var protectedData = ViewBag.ProtectionEnforced == true;
-    var itemOptions = PurchasingChoices(Model.Items.Where(x => !x.IsDeleted && x.IsActive).Select(x => new InventoryChoice { Id = x.Id, Name = InventoryWorkspaceView.Details<InventoryItemContent>(x).Name }));
-    var locationOptions = PurchasingChoices(Model.Locations.Select(x => new InventoryChoice { Id = x.Id, Name = InventoryWorkspaceView.Details<InventoryLabel>(x).Name }));
-    var contactOptions = PurchasingChoices(Model.VendorContacts.Select(x => new InventoryChoice { Id = x.Id, Name = x.Name }));
+
+    var itemOptions = Choice(Model.Items.Where(x => !x.IsDeleted && x.IsActive).Select(x => new InventoryChoice { Id = x.Id, Name = InventoryWorkspaceView.Details<InventoryItemContent>(x).Name }));
+    var locationOptions = Choice(Model.Locations.Select(x => new InventoryChoice { Id = x.Id, Name = InventoryWorkspaceView.Details<InventoryLabel>(x).Name }));
+    var contactOptions = Choice(Model.VendorContacts.Select(x => new InventoryChoice { Id = x.Id, Name = x.Name }));
+
     string ContactName(string id) => Model.VendorContacts.FirstOrDefault(x => x.Id == id)?.Name ?? id;
-    var vendorOptions = PurchasingChoices(Model.Vendors.Select(x => new InventoryChoice { Id = x.Id, Name = ContactName(x.ContactId) }));
-    string LocationName(string id) => Model.Locations.FirstOrDefault(x => x.Id == id) is { } row ? InventoryWorkspaceView.Details<InventoryLabel>(row).Name : id;
+    string LocationName(string id) => string.IsNullOrEmpty(id) ? "" : Model.Locations.FirstOrDefault(x => x.Id == id) is { } row ? InventoryWorkspaceView.Details<InventoryLabel>(row).Name : id;
+    string ItemName(string id) => Model.Items.FirstOrDefault(x => x.Id == id) is { } row ? InventoryWorkspaceView.Details<InventoryItemContent>(row).Name : id;
+
+    var vendorOptions = Choice(Model.Vendors.Select(x => new InventoryChoice { Id = x.Id, Name = ContactName(x.ContactId) }));
+
     var detail = Model.PurchaseOrder;
     var order = detail?.Order;
     var orderContent = InventoryWorkspaceView.Details<InventoryPurchaseOrderContent>(order);
+
+    var tabs = new (string Key, string Icon)[]
+    {
+        ("Vendors", "fa-truck"), ("PurchaseOrders", "fa-file-text-o"), ("Valuation", "fa-money")
+    };
+
+    ViewData["Module"] = "Purchasing";
+    ViewData["Intro"] = localizer["M4PurchasingIntro"].Value;
 }
-<div class="wrapper wrapper-content"><div class="ibox"><div class="ibox-title"><h2>@localizer["M4Purchasing"]</h2></div><div class="ibox-content">
-    @if (protectedData) { @await Html.PartialAsync("_AdpRevealBanner", new AdpRevealView { BannerTitle = localizer["ProtectedDataRequired"].Value }) }
-    <div id="inventory-message" class="alert alert-info" role="status" hidden></div>
-    <form id="inventory-page" asp-action="ReopenPurchasing" method="post" class="inventory-navigation">
-        @Html.AntiForgeryToken()<input type="hidden" name="tab" value="@Model.Tab"/><input type="hidden" name="page" value="@Model.Page"/><input type="hidden" name="id" value="@Model.Id"/><input type="hidden" name="locationId" value="@Model.LocationId"/>
-        @if (Model.Locked) { <button type="submit" class="btn btn-primary">@localizer["Unlock"]</button> }
-    </form>
-    @if (!Model.Locked) {
-        <nav class="btn-toolbar" aria-label="@localizer["M4Purchasing"]">
-            <form asp-action="Reopen" method="post" class="inventory-navigation" style="display:inline-block">@Html.AntiForgeryToken()<button class="btn btn-default" type="submit">@localizer["Inventory"]</button></form>
-            @foreach (var tab in new[] { "Vendors", "PurchaseOrders", "Valuation" }) {
-                <form asp-action="ReopenPurchasing" method="post" class="inventory-navigation" style="display:inline-block">@Html.AntiForgeryToken()<input type="hidden" name="tab" value="@tab"/><button class="btn @(Model.Tab == tab ? "btn-primary" : "btn-default")" type="submit">@localizer["M4" + tab]</button></form>
+
+@await Html.PartialAsync("_Shell", Model)
+
+<div class="wrapper wrapper-content">
+    <div class="ibox float-e-margins">
+        <div class="ibox-title">
+            <h5>@localizer[Model.Locked || !Model.Migrated ? "M4Purchasing" : "M4" + Model.Tab]</h5>
+        </div>
+        <div class="ibox-content">
+
+            @if (protectedData)
+            {
+                @await Html.PartialAsync("_AdpRevealBanner", new AdpRevealView { BannerTitle = localizer["ProtectedDataRequired"].Value })
             }
-        </nav><hr/>
-        @if (!Model.Migrated) { <p>@localizer["InitializeDescription"]</p> }
-    }
-    @if (!Model.Locked && Model.Migrated) {
-        <h3>@localizer["M4" + Model.Tab]</h3>
-        @if (Model.Tab == "Vendors") {
-            <p>@localizer["M4VendorHelp"]</p>
-            @foreach (var vendor in Model.Rows.OfType<InventoryVendor>()) {
-                var details = InventoryWorkspaceView.Details<InventoryVendorContent>(vendor);
-                <section class="panel panel-default"><div class="panel-heading"><h4>@ContactName(vendor.ContactId)</h4><small>@vendor.Id</small></div><div class="panel-body">
-                    <p>@localizer["M4AccountNumber"]: @details.AccountNumber</p><p>@details.Note</p>
-                    @if (Model.CanWrite) {
-                        <details><summary>@localizer["Edit"]</summary><form asp-action="SaveVendor" method="post" class="inventory-command">
-                            @Html.AntiForgeryToken()<input type="hidden" name="Id" value="@vendor.Id"/><input type="hidden" name="Revision" value="@vendor.Revision"/>
-                            <input type="hidden" name="ContactId" value="@vendor.ContactId"/><p>@localizer["M4CompanyContact"]: @ContactName(vendor.ContactId)</p>
-                            @PurchasingField("Details.AccountNumber", "M4AccountNumber", details.AccountNumber, maxLength: 250)@PurchasingField("Details.Note", "Note", details.Note)
-                            <button class="btn btn-primary" type="submit">@localizer["Save"]</button>
-                        </form></details>
-                        <form asp-action="ArchiveVendor" method="post" class="inventory-command">
-                            @Html.AntiForgeryToken()<input type="hidden" name="id" value="@vendor.Id"/><input type="hidden" name="revision" value="@vendor.Revision"/><button class="btn btn-default" type="submit">@localizer["Archive"]</button>
+
+            <div id="inventory-message" class="alert alert-info" role="status" hidden></div>
+
+            <form id="inventory-page" asp-action="ReopenPurchasing" method="post" class="inventory-navigation">
+                @Html.AntiForgeryToken()
+                @Hide("tab", Model.Tab)@Hide("page", Model.Page)@Hide("id", Model.Id)@Hide("locationId", Model.LocationId)
+                @if (Model.Locked)
+                {
+                    <div class="text-center m-t-lg m-b-lg">
+                        <i class="fa fa-lock fa-3x text-muted"></i>
+                        <h4 class="m-t-sm">@localizer["ProtectedDataRequired"]</h4>
+                        <p>@commonLocalizer["AdpProtectedBannerDescription"]</p>
+                        <button type="submit" class="btn btn-primary m-t">@localizer["Unlock"]</button>
+                    </div>
+                }
+            </form>
+
+            @if (!Model.Locked)
+            {
+                <ul class="nav nav-tabs" role="tablist" aria-label="@localizer["M4Purchasing"]">
+                    @foreach (var tab in tabs)
+                    {
+                        <li class="nav-item @(Model.Tab == tab.Key ? "active" : null)">
+                            <form asp-action="ReopenPurchasing" method="post" class="inventory-navigation">
+                                @Html.AntiForgeryToken()
+                                @Hide("tab", tab.Key)
+                                <button type="submit" aria-current="@(Model.Tab == tab.Key ? "page" : "false")">
+                                    <i class="fa @tab.Icon"></i> @localizer["M4" + tab.Key]
+                                </button>
+                            </form>
+                        </li>
+                    }
+                </ul>
+
+                if (!Model.Migrated)
+                {
+                    <div class="text-center m-t-lg m-b-lg">
+                        <i class="fa fa-cubes fa-3x text-muted"></i>
+                        <h4 class="m-t-sm">@localizer["Initialize"]</h4>
+                        <p>@localizer["InitializeDescription"]</p>
+                    </div>
+                }
+            }
+
+            @if (!Model.Locked && Model.Migrated)
+            {
+                <div class="alert alert-info">
+                    <i class="fa fa-info-circle"></i>@localizer["M4Help" + Model.Tab]
+                </div>
+
+                @* ── Suppliers ───────────────────────────────────────────────────── *@
+                @if (Model.Tab == "Vendors")
+                {
+                    if (Model.CanWrite)
+                    {
+                        <div class="rgw-toolbar">
+                            <div class="rgw-toolbar-spacer"></div>
+                            <button class="btn btn-primary" type="button" data-toggle="modal" data-target="#m4-new-vendor"><i class="fa fa-plus"></i> @localizer["M4NewVendor"]</button>
+                        </div>
+                    }
+
+                    if (!Model.Rows.OfType<InventoryVendor>().Any())
+                    {
+                        <div class="text-center m-t-lg m-b-lg">
+                            <i class="fa fa-truck fa-3x text-muted"></i>
+                            <h4 class="m-t-sm">@localizer["NoRows"]</h4>
+                            <p>@localizer["NoRowsHelp"]</p>
+                        </div>
+                    }
+                    else
+                    {
+                        <div class="table-responsive">
+                            <table class="table table-striped rgw-table">
+                                <thead><tr><th>@localizer["M4Supplier"]</th><th>@localizer["M4AccountNumber"]</th><th>@localizer["Note"]</th><th class="rgw-row-actions">@localizer["Actions"]</th></tr></thead>
+                                <tbody>
+                                    @foreach (var vendor in Model.Rows.OfType<InventoryVendor>())
+                                    {
+                                        var details = InventoryWorkspaceView.Details<InventoryVendorContent>(vendor);
+                                        <tr>
+                                            <td>@ContactName(vendor.ContactId)</td>
+                                            <td>@details.AccountNumber</td>
+                                            <td>@details.Note</td>
+                                            <td class="rgw-row-actions">
+                                                @if (Model.CanWrite)
+                                                {
+                                                    <button class="btn btn-xs btn-primary" type="button" data-toggle="modal" data-target="#m4-vendor-@vendor.Id">@localizer["Edit"]</button>
+                                                    <form asp-action="ArchiveVendor" method="post" class="inventory-command">
+                                                        @Html.AntiForgeryToken()
+                                                        @Hide("id", vendor.Id)@Hide("revision", vendor.Revision)
+                                                        <button class="btn btn-xs btn-danger" type="submit">@localizer["Archive"]</button>
+                                                    </form>
+                                                }
+                                            </td>
+                                        </tr>
+                                    }
+                                </tbody>
+                            </table>
+                        </div>
+                    }
+                }
+
+                @* ── Purchase order list ─────────────────────────────────────────── *@
+                @if (Model.Tab == "PurchaseOrders" && order == null)
+                {
+                    if (Model.CanWrite)
+                    {
+                        <div class="rgw-toolbar">
+                            <div class="rgw-toolbar-spacer"></div>
+                            <button class="btn btn-primary" type="button" data-toggle="modal" data-target="#m4-new-order"><i class="fa fa-plus"></i> @localizer["M4NewPurchaseOrder"]</button>
+                        </div>
+                    }
+
+                    if (!Model.Rows.OfType<InventoryPurchaseOrder>().Any())
+                    {
+                        <div class="text-center m-t-lg m-b-lg">
+                            <i class="fa fa-file-text-o fa-3x text-muted"></i>
+                            <h4 class="m-t-sm">@localizer["NoRows"]</h4>
+                            <p>@localizer["NoRowsHelp"]</p>
+                        </div>
+                    }
+                    else
+                    {
+                        <div class="table-responsive">
+                            <table class="table table-striped rgw-table">
+                                <thead><tr><th>@localizer["M4PurchaseOrderNumber"]</th><th>@localizer["M4Supplier"]</th><th>@localizer["Status"]</th><th>@localizer["M4Currency"]</th><th class="rgw-row-actions">@localizer["Actions"]</th></tr></thead>
+                                <tbody>
+                                    @foreach (var purchase in Model.Rows.OfType<InventoryPurchaseOrder>())
+                                    {
+                                        var details = InventoryWorkspaceView.Details<InventoryPurchaseOrderContent>(purchase);
+                                        <tr>
+                                            <td>@details.Number</td>
+                                            <td>@details.SupplierName</td>
+                                            <td><span class="label @StatusPill(purchase.Status)">@localizer["M4Status" + purchase.Status]</span></td>
+                                            <td>@purchase.CurrencyCode</td>
+                                            <td class="rgw-row-actions">
+                                                <form asp-action="ReopenPurchasing" method="post" class="inventory-navigation">
+                                                    @Html.AntiForgeryToken()
+                                                    @Hide("id", purchase.Id)
+                                                    <button class="btn btn-xs btn-info" type="submit">@localizer["M4ViewPurchaseOrder"]</button>
+                                                </form>
+                                            </td>
+                                        </tr>
+                                    }
+                                </tbody>
+                            </table>
+                        </div>
+                    }
+                }
+
+                @* ── One purchase order ──────────────────────────────────────────── *@
+                @if (Model.Tab == "PurchaseOrders" && order != null)
+                {
+                    var outstanding = detail.Lines.Where(x => x.QuantityOrdered > x.QuantityReceived).OrderBy(x => x.LineNumber).ToList();
+
+                    <div class="rgw-toolbar">
+                        <form asp-action="ReopenPurchasing" method="post" class="inventory-navigation">
+                            @Html.AntiForgeryToken()
+                            @Hide("tab", "PurchaseOrders")
+                            <button class="btn btn-default btn-sm" type="submit"><i class="fa fa-arrow-left"></i> @localizer["Back"]</button>
                         </form>
+                        <div class="rgw-toolbar-spacer"></div>
+                        @if (Model.CanWrite && order.Status == (int)InventoryPurchaseOrderStatus.Draft)
+                        {
+                            <button class="btn btn-default" type="button" data-toggle="modal" data-target="#m4-new-order"><i class="fa fa-pencil"></i> @localizer["Edit"]</button>
+                            <form asp-action="OrderPurchaseOrder" method="post" class="inventory-command">
+                                @Html.AntiForgeryToken()
+                                @Hide("Id", order.Id)@Hide("Revision", order.Revision)@Hide("RequestId", Guid.NewGuid().ToString("D"))
+                                <button class="btn btn-primary" type="submit"><i class="fa fa-paper-plane-o"></i> @localizer["M4Order"]</button>
+                            </form>
+                        }
+                        @if (Model.CanWrite && order.Status is 1 or 2 && outstanding.Count > 0)
+                        {
+                            <button class="btn btn-primary" type="button" data-toggle="modal" data-target="#m4-receive"><i class="fa fa-inbox"></i> @localizer["M4Receive"]</button>
+                        }
+                        @if (Model.CanWrite && order.Status is 0 or 1 or 2)
+                        {
+                            <form asp-action="CancelPurchaseOrder" method="post" class="inventory-command">
+                                @Html.AntiForgeryToken()
+                                @Hide("Id", order.Id)@Hide("Revision", order.Revision)@Hide("RequestId", Guid.NewGuid().ToString("D"))
+                                <button class="btn btn-default" type="submit">@localizer["M4CancelOrder"]</button>
+                            </form>
+                        }
+                    </div>
+
+                    <h3>@orderContent.Number</h3>
+                    <p class="text-muted">
+                        <span class="label @StatusPill(order.Status)">@localizer["M4Status" + order.Status]</span>
+                        @orderContent.SupplierName &middot; @order.CurrencyCode
+                    </p>
+                    @if (!string.IsNullOrEmpty(orderContent.Note))
+                    {
+                        <p>@orderContent.Note</p>
                     }
-                </div></section>
-            }
-            @if (Model.CanWrite) {
-                <details><summary>@localizer["M4NewVendor"]</summary><form asp-action="SaveVendor" method="post" class="inventory-command">
-                    @Html.AntiForgeryToken()<input type="hidden" name="Revision" value="0"/>
-                    @PurchasingField("ContactId", "M4CompanyContact", options: contactOptions, required: true)
-                    @PurchasingField("Details.AccountNumber", "M4AccountNumber", maxLength: 250)@PurchasingField("Details.Note", "Note")
-                    <button class="btn btn-primary" type="submit">@localizer["Save"]</button>
-                </form></details>
-            }
-        }
-        @if (Model.Tab == "PurchaseOrders" && order == null) {
-            <div class="table-responsive"><table class="table table-striped"><thead><tr><th>@localizer["M4PurchaseOrderNumber"]</th><th>@localizer["M4Supplier"]</th><th>@localizer["Status"]</th><th>@localizer["M4Currency"]</th><th>@localizer["Actions"]</th></tr></thead><tbody>
-                @foreach (var purchase in Model.Rows.OfType<InventoryPurchaseOrder>()) {
-                    var details = InventoryWorkspaceView.Details<InventoryPurchaseOrderContent>(purchase);
-                    <tr><td>@details.Number</td><td>@details.SupplierName</td><td>@localizer["M4Status" + purchase.Status]</td><td>@purchase.CurrencyCode</td><td>
-                        <form asp-action="ReopenPurchasing" method="post" class="inventory-navigation">@Html.AntiForgeryToken()<input type="hidden" name="id" value="@purchase.Id"/><button class="btn btn-default" type="submit">@localizer["M4ViewPurchaseOrder"]</button></form>
-                    </td></tr>
-                }
-            </tbody></table></div>
-        }
-        @if (Model.Tab == "PurchaseOrders" && order != null) {
-            <h4>@orderContent.Number · @localizer["M4Status" + order.Status]</h4>
-            <p>@orderContent.SupplierName · @order.CurrencyCode</p><p>@orderContent.Note</p><small>@order.Id</small>
-            <div class="table-responsive"><table class="table table-striped"><thead><tr><th>@localizer["Items"]</th><th>@localizer["UnitOfMeasure"]</th><th>@localizer["M4QuantityOrdered"]</th><th>@localizer["M4QuantityReceived"]</th><th>@localizer["M4Remaining"]</th><th>@localizer["UnitCost"]</th></tr></thead><tbody>
-                @foreach (var line in detail.Lines.OrderBy(x => x.LineNumber)) {
-                    var content = InventoryWorkspaceView.Details<InventoryPurchaseOrderItemContent>(line);
-                    <tr><td>@content.ItemName<p>@content.Note</p></td><td>@content.UnitOfMeasure</td><td>@line.QuantityOrdered.ToString(CultureInfo.CurrentCulture)</td><td>@line.QuantityReceived.ToString(CultureInfo.CurrentCulture)</td><td>@((line.QuantityOrdered - line.QuantityReceived).ToString(CultureInfo.CurrentCulture))</td><td>@content.UnitCost.ToString(CultureInfo.CurrentCulture) @order.CurrencyCode</td></tr>
-                }
-            </tbody></table></div>
-            @if (Model.CanWrite && order.Status is 0 or 1 or 2) {
-                <p>@localizer["M4OrderHelp"]</p>
-                @if (order.Status == (int)InventoryPurchaseOrderStatus.Draft) {
-                    <form asp-action="OrderPurchaseOrder" method="post" class="inventory-command">@Html.AntiForgeryToken()<input type="hidden" name="Id" value="@order.Id"/><input type="hidden" name="Revision" value="@order.Revision"/><input type="hidden" name="RequestId" value="@Guid.NewGuid().ToString("D")"/><button class="btn btn-primary" type="submit">@localizer["M4Order"]</button></form>
-                }
-                <form asp-action="CancelPurchaseOrder" method="post" class="inventory-command">@Html.AntiForgeryToken()<input type="hidden" name="Id" value="@order.Id"/><input type="hidden" name="Revision" value="@order.Revision"/><input type="hidden" name="RequestId" value="@Guid.NewGuid().ToString("D")"/><button class="btn btn-default" type="submit">@localizer["M4CancelOrder"]</button></form>
-            }
-            @if (Model.CanWrite && order.Status is 1 or 2 && detail.Lines.Any(x => x.QuantityOrdered > x.QuantityReceived)) {
-                <h4>@localizer["M4Receive"]</h4><p>@localizer["M4ReceiptHelp"]</p><p>@localizer["M4SerializedReceiptHelp"]</p>
-                <form asp-action="ReceivePurchaseOrder" method="post" class="inventory-command m4-lines-form" data-receipt="true">
-                    @Html.AntiForgeryToken()<input type="hidden" name="PurchaseOrderId" value="@order.Id"/><input type="hidden" name="Revision" value="@order.Revision"/><input type="hidden" name="RequestId" value="@Guid.NewGuid().ToString("D")"/>
-                    <div class="m4-lines">
-                    @{ var receiptIndex = 0; }
-                    @foreach (var line in detail.Lines.Where(x => x.QuantityOrdered > x.QuantityReceived).OrderBy(x => x.LineNumber)) {
-                        var content = InventoryWorkspaceView.Details<InventoryPurchaseOrderItemContent>(line);
-                        var item = Model.Items.FirstOrDefault(x => x.Id == line.ItemId);
-                        var serialized = item?.TrackingMode == (int)InventoryTrackingMode.Serialized;
-                        var prefix = "Lines[" + receiptIndex++ + "].";
-                        var lotOptions = PurchasingChoices(Model.Lots.Where(x => x.ItemId == line.ItemId).Select(x => new InventoryChoice { Id = x.Id, Name = InventoryWorkspaceView.Details<InventoryLotContent>(x).LotNumber }));
-                        <fieldset class="m4-line"><legend>@content.ItemName · @localizer["M4Remaining"]: @((line.QuantityOrdered - line.QuantityReceived).ToString(CultureInfo.CurrentCulture)) @content.UnitOfMeasure</legend>
-                            <input type="hidden" name="@(prefix + "PurchaseOrderItemId")" value="@line.Id"/>
-                            @PurchasingField(prefix + "Quantity", "M4ReceiveQuantity", serialized ? 1m : line.QuantityOrdered - line.QuantityReceived, "number", required: true, readOnly: serialized)
-                            @PurchasingField(prefix + "LocationId", "ToLocation", options: locationOptions, required: true)
-                            @PurchasingField(prefix + "LotId", "Batch", options: lotOptions, required: item?.RequiresLotTracking == true)
-                            @if (serialized) {
-                                @PurchasingField(prefix + "Asset.SerialNumber", "SerialNumber", required: true, maxLength: 250)@PurchasingField(prefix + "Asset.AssetTag", "AssetTag", maxLength: 250)@PurchasingField(prefix + "Asset.Barcode", "Barcode", maxLength: 250)@PurchasingField(prefix + "Asset.ExpiresOn", "Expiration", type: "date", required: item?.RequiresExpiration == true)
-                            }
-                            <button class="btn btn-default m4-copy-line" type="button">@localizer["AddLine"]</button><button class="btn btn-default m4-remove-line" type="button">@localizer["M4RemoveLine"]</button>
-                        </fieldset>
+                    <div class="hr-line-dashed"></div>
+
+                    @if (Model.CanWrite && order.Status is 0 or 1 or 2)
+                    {
+                        <div class="alert alert-info"><i class="fa fa-info-circle"></i> @localizer["M4OrderHelp"]</div>
                     }
-                    </div><button class="btn btn-primary" type="submit">@localizer["M4Receive"]</button>
-                </form>
-                <form asp-action="Reopen" method="post" class="inventory-navigation">@Html.AntiForgeryToken()<input type="hidden" name="tab" value="History"/><button class="btn btn-default" type="submit">@localizer["Witness"]</button></form>
-            }
-            @if (detail.Receipts.Count > 0) {
-                <h4>@localizer["M4Receipts"]</h4>
-                <div class="table-responsive"><table class="table table-striped"><thead><tr><th>@localizer["Items"]</th><th>@localizer["Amount"]</th><th>@localizer["ToLocation"]</th><th>@localizer["Details"]</th></tr></thead><tbody>
-                    @foreach (var receipt in detail.Receipts) {
-                        var content = InventoryWorkspaceView.Details<InventoryLabel>(receipt);
-                        <tr><td>@receipt.ItemId</td><td>@receipt.Quantity.ToString(CultureInfo.CurrentCulture)</td><td>@LocationName(receipt.ToLocationId)</td><td><time>@receipt.OccurredOn.ToString("u")</time><p>@content.Note</p><form asp-action="Reopen" method="post" class="inventory-navigation">@Html.AntiForgeryToken()<input type="hidden" name="tab" value="Transaction"/><input type="hidden" name="id" value="@receipt.Id"/><button class="btn btn-default" type="submit">@localizer["ViewHistory"]</button></form></td></tr>
+
+                    <div class="table-responsive">
+                        <table class="table table-striped rgw-table">
+                            <thead><tr><th>@localizer["Items"]</th><th>@localizer["UnitOfMeasure"]</th><th class="text-right">@localizer["M4QuantityOrdered"]</th><th class="text-right">@localizer["M4QuantityReceived"]</th><th class="text-right">@localizer["M4Remaining"]</th><th class="text-right">@localizer["UnitCost"]</th></tr></thead>
+                            <tbody>
+                                @foreach (var line in detail.Lines.OrderBy(x => x.LineNumber))
+                                {
+                                    var content = InventoryWorkspaceView.Details<InventoryPurchaseOrderItemContent>(line);
+                                    var remaining = line.QuantityOrdered - line.QuantityReceived;
+                                    <tr>
+                                        <td>
+                                            @content.ItemName
+                                            @if (!string.IsNullOrEmpty(content.Note))
+                                            {
+                                                <small class="text-muted rgw-sub">@content.Note</small>
+                                            }
+                                        </td>
+                                        <td>@content.UnitOfMeasure</td>
+                                        <td class="text-right">@line.QuantityOrdered.ToString(CultureInfo.CurrentCulture)</td>
+                                        <td class="text-right">@line.QuantityReceived.ToString(CultureInfo.CurrentCulture)</td>
+                                        <td class="text-right">
+                                            <span class="label @(remaining > 0 ? "label-warning" : "label-success")">@remaining.ToString(CultureInfo.CurrentCulture)</span>
+                                        </td>
+                                        <td class="text-right">@content.UnitCost.ToString(CultureInfo.CurrentCulture) @order.CurrencyCode</td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    </div>
+
+                    @if (detail.Receipts.Count > 0)
+                    {
+                        <h4 class="m-t-lg">@localizer["M4Receipts"]</h4>
+                        <div class="table-responsive">
+                            <table class="table table-striped rgw-table">
+                                <thead><tr><th>@localizer["When"]</th><th>@localizer["Items"]</th><th class="text-right">@localizer["Amount"]</th><th>@localizer["ToLocation"]</th><th class="rgw-row-actions">@localizer["Actions"]</th></tr></thead>
+                                <tbody>
+                                    @foreach (var receipt in detail.Receipts)
+                                    {
+                                        var content = InventoryWorkspaceView.Details<InventoryLabel>(receipt);
+                                        <tr>
+                                            <td><time datetime="@receipt.OccurredOn.ToString("u")">@receipt.OccurredOn.ToString("g", CultureInfo.CurrentCulture)</time></td>
+                                            <td>
+                                                @ItemName(receipt.ItemId)
+                                                @if (!string.IsNullOrEmpty(content.Note))
+                                                {
+                                                    <small class="text-muted rgw-sub">@content.Note</small>
+                                                }
+                                            </td>
+                                            <td class="text-right">@receipt.Quantity.ToString(CultureInfo.CurrentCulture)</td>
+                                            <td>@LocationName(receipt.ToLocationId)</td>
+                                            <td class="rgw-row-actions">
+                                                <form asp-action="Reopen" method="post" class="inventory-navigation">
+                                                    @Html.AntiForgeryToken()
+                                                    @Hide("tab", "Transaction")@Hide("id", receipt.Id)
+                                                    <button class="btn btn-xs btn-info" type="submit">@localizer["ViewHistory"]</button>
+                                                </form>
+                                            </td>
+                                        </tr>
+                                    }
+                                </tbody>
+                            </table>
+                        </div>
                     }
-                </tbody></table></div>
-            }
-        }
-        @if (Model.CanWrite && Model.Tab == "PurchaseOrders" && (order == null || order.Status == (int)InventoryPurchaseOrderStatus.Draft)) {
-            <details open="@(order != null)"><summary>@localizer[order == null ? "M4NewPurchaseOrder" : "Edit"]</summary>
-                <form asp-action="SavePurchaseOrder" method="post" class="inventory-command m4-lines-form">
-                    @Html.AntiForgeryToken()<input type="hidden" name="Id" value="@(order?.Id ?? Guid.NewGuid().ToString("D"))"/><input type="hidden" name="Revision" value="@(order?.Revision ?? 0)"/>
-                    @PurchasingField("Number", "M4PurchaseOrderNumber", orderContent.Number, required: true, maxLength: 80)
-                    @PurchasingField("VendorId", "M4Supplier", order?.VendorId, options: vendorOptions, required: true)
-                    @PurchasingField("CurrencyCode", "M4Currency", order?.CurrencyCode, required: true, maxLength: 3)
-                    @PurchasingField("Note", "Note", orderContent.Note)
-                    <div class="m4-lines">
-                    @{ var draftIndex = 0; var draftLines = detail?.Lines.OrderBy(x => x.LineNumber).ToList() ?? new List<InventoryPurchaseOrderItem>(); }
-                    @foreach (var line in draftLines.DefaultIfEmpty(new InventoryPurchaseOrderItem { QuantityOrdered = 1 })) {
-                        var prefix = "Lines[" + draftIndex++ + "].";
-                        var content = InventoryWorkspaceView.Details<InventoryPurchaseOrderItemContent>(line);
-                        <fieldset class="m4-line"><legend>@localizer["Items"]</legend>
-                            <input type="hidden" name="@(prefix + "Id")" value="@(draftLines.Contains(line) ? line.Id : null)"/>
-                            @PurchasingField(prefix + "ItemId", "Items", line.ItemId, options: itemOptions, required: true)
-                            @PurchasingField(prefix + "QuantityOrdered", "M4QuantityOrdered", line.QuantityOrdered, "number", required: true)
-                            @PurchasingField(prefix + "UnitCost", "UnitCost", content.UnitCost, "number", required: true)
-                            @PurchasingField(prefix + "Note", "Note", content.Note)
-                            <button class="btn btn-default m4-remove-line" type="button">@localizer["M4RemoveLine"]</button>
-                        </fieldset>
-                    }
-                    </div><button class="btn btn-default m4-add-line" type="button">@localizer["AddLine"]</button><button class="btn btn-primary" type="submit">@localizer["Save"]</button>
-                </form>
-            </details>
-        }
-        @if (Model.Tab == "Valuation" && Model.Valuation != null) {
-            <p>@localizer["M4ValuationScope"]</p><p>@localizer["M4AsOfUtc"]: <time>@Model.Valuation.AsOfUtc.ToString("u")</time></p>
-            <form asp-action="ReopenPurchasing" method="post" class="inventory-navigation">@Html.AntiForgeryToken()<input type="hidden" name="tab" value="Valuation"/>@PurchasingField("locationId", "Location", Model.LocationId, options: locationOptions)<button class="btn btn-default" type="submit">@localizer["M4Valuation"]</button></form>
-            @if (Model.Valuation.HasNegativeStock) { <p class="alert alert-warning">@localizer["M4NegativeStock"]</p> }
-            <div class="table-responsive"><table class="table table-striped"><thead><tr><th>@localizer["M4Currency"]</th><th>@localizer["M4KnownValue"]</th><th>@localizer["M4UncostedRows"]</th></tr></thead><tbody>
-                @foreach (var total in Model.Valuation.Totals) { <tr><td>@(string.IsNullOrEmpty(total.CurrencyCode) ? localizer["M4UnspecifiedCurrency"].Value : total.CurrencyCode)</td><td>@total.KnownValue.ToString(CultureInfo.CurrentCulture)</td><td>@total.UncostedRows</td></tr> }
-            </tbody></table></div>
-            <div class="table-responsive"><table class="table table-striped"><thead><tr><th>@localizer["Items"]</th><th>@localizer["Location"]</th><th>@localizer["Amount"]</th><th>@localizer["UnitCost"]</th><th>@localizer["M4KnownValue"]</th><th>@localizer["M4Currency"]</th></tr></thead><tbody>
-                @foreach (var line in Model.Valuation.Lines) {
-                    <tr><td>@line.ItemName<small class="text-muted" style="display:block">@line.AssetId @line.LotId</small></td><td>@LocationName(line.LocationId)</td><td>@line.Quantity.ToString(CultureInfo.CurrentCulture)</td><td>@(line.UnitCost?.ToString(CultureInfo.CurrentCulture) ?? localizer["M4UnknownCost"].Value)</td><td>@(line.Value?.ToString(CultureInfo.CurrentCulture) ?? localizer["M4UnknownCost"].Value)</td><td>@(string.IsNullOrEmpty(line.CurrencyCode) ? localizer["M4UnspecifiedCurrency"].Value : line.CurrencyCode)</td></tr>
                 }
-            </tbody></table></div>
-            @if (Model.Valuation.Lines.Count == 0) { <p>@localizer["NoRows"]</p> }
-        }
-        @if (Model.Tab != "Valuation" && order == null) {
-            if (Model.Rows.Count == 0) { <p>@localizer["NoRows"]</p> }
-            foreach (var nextPage in new[] { Model.Page - 1, Model.Page + 1 }.Where(p => p >= 0 && (p < Model.Page || Model.HasMore))) {
-                <form asp-action="ReopenPurchasing" method="post" class="inventory-navigation" style="display:inline-block">@Html.AntiForgeryToken()<input type="hidden" name="tab" value="@Model.Tab"/><input type="hidden" name="page" value="@nextPage"/><button class="btn btn-default" type="submit">@localizer[nextPage < Model.Page ? "Previous" : "Next"]</button></form>
+
+                @* ── Valuation ───────────────────────────────────────────────────── *@
+                @if (Model.Tab == "Valuation" && Model.Valuation != null)
+                {
+                    <div class="rgw-filter">
+                        <form asp-action="ReopenPurchasing" method="post" class="inventory-navigation">
+                            @Html.AntiForgeryToken()
+                            @Hide("tab", "Valuation")
+                            <div class="rgw-grid">
+                                @Field("locationId", "Location", Model.LocationId, options: locationOptions, help: "M4ValuationScope")
+                            </div>
+                            <div class="rgw-filter-actions">
+                                <button class="btn btn-primary" type="submit"><i class="fa fa-filter"></i> @localizer["Filter"]</button>
+                            </div>
+                        </form>
+                    </div>
+
+                    @* Totals use the same ibox statistic tile as the records dashboard. *@
+                    <div class="row">
+                        @foreach (var total in Model.Valuation.Totals)
+                        {
+                            <div class="col-lg-3 col-md-6">
+                                <div class="ibox">
+                                    <div class="ibox-title"><h5>@(string.IsNullOrEmpty(total.CurrencyCode) ? localizer["M4UnspecifiedCurrency"].Value : total.CurrencyCode)</h5></div>
+                                    <div class="ibox-content">
+                                        <h1 class="no-margins">@total.KnownValue.ToString(CultureInfo.CurrentCulture)</h1>
+                                        <small>@localizer["M4UncostedRows"]: @total.UncostedRows</small>
+                                    </div>
+                                </div>
+                            </div>
+                        }
+                        <div class="col-lg-3 col-md-6">
+                            <div class="ibox">
+                                <div class="ibox-title"><h5>@localizer["M4AsOfUtc"]</h5></div>
+                                <div class="ibox-content">
+                                    <h3 class="no-margins"><time datetime="@Model.Valuation.AsOfUtc.ToString("u")">@Model.Valuation.AsOfUtc.ToString("g", CultureInfo.CurrentCulture)</time></h3>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    @if (Model.Valuation.HasNegativeStock)
+                    {
+                        <div class="alert alert-warning">@localizer["M4NegativeStock"]</div>
+                    }
+
+                    @if (Model.Valuation.Lines.Count == 0)
+                    {
+                        <div class="text-center m-t-lg m-b-lg">
+                            <i class="fa fa-money fa-3x text-muted"></i>
+                            <h4 class="m-t-sm">@localizer["NoRows"]</h4>
+                            <p>@localizer["NoRowsHelp"]</p>
+                        </div>
+                    }
+                    else
+                    {
+                        <div class="table-responsive">
+                            <table class="table table-striped rgw-table">
+                                <thead><tr><th>@localizer["Items"]</th><th>@localizer["Location"]</th><th class="text-right">@localizer["Amount"]</th><th class="text-right">@localizer["UnitCost"]</th><th class="text-right">@localizer["M4KnownValue"]</th><th>@localizer["M4Currency"]</th></tr></thead>
+                                <tbody>
+                                    @foreach (var line in Model.Valuation.Lines)
+                                    {
+                                        <tr>
+                                            <td>
+                                                @line.ItemName
+                                                @if (!string.IsNullOrEmpty(line.AssetId) || !string.IsNullOrEmpty(line.LotId))
+                                                {
+                                                    <small class="text-muted rgw-sub">@line.AssetId @line.LotId</small>
+                                                }
+                                            </td>
+                                            <td>@LocationName(line.LocationId)</td>
+                                            <td class="text-right">@line.Quantity.ToString(CultureInfo.CurrentCulture)</td>
+                                            <td class="text-right">@(line.UnitCost?.ToString(CultureInfo.CurrentCulture) ?? localizer["M4UnknownCost"].Value)</td>
+                                            <td class="text-right">@(line.Value?.ToString(CultureInfo.CurrentCulture) ?? localizer["M4UnknownCost"].Value)</td>
+                                            <td>@(string.IsNullOrEmpty(line.CurrencyCode) ? localizer["M4UnspecifiedCurrency"].Value : line.CurrencyCode)</td>
+                                        </tr>
+                                    }
+                                </tbody>
+                            </table>
+                        </div>
+                    }
+                }
+
+                @if (Model.Tab != "Valuation" && order == null && (Model.Page > 0 || Model.HasMore))
+                {
+                    <div class="rgw-pager">
+                        @foreach (var nextPage in new[] { Model.Page - 1, Model.Page + 1 }.Where(p => p >= 0 && (p < Model.Page || Model.HasMore)))
+                        {
+                            <form asp-action="ReopenPurchasing" method="post" class="inventory-navigation">
+                                @Html.AntiForgeryToken()
+                                @Hide("tab", Model.Tab)@Hide("page", nextPage)
+                                <button class="btn btn-default btn-sm" type="submit">
+                                    <i class="fa @(nextPage < Model.Page ? "fa-chevron-left" : "fa-chevron-right")"></i>
+                                    @localizer[nextPage < Model.Page ? "Previous" : "Next"]
+                                </button>
+                            </form>
+                        }
+                        <span class="text-muted">@(Model.Page + 1)</span>
+                    </div>
+                }
+
+                @* ── Dialogs ─────────────────────────────────────────────────────── *@
+                @if (Model.CanWrite && Model.Tab == "Vendors")
+                {
+                    <div class="modal fade rgw-modal" id="m4-new-vendor" tabindex="-1" role="dialog" aria-labelledby="m4-new-vendor-title">
+                        <div class="modal-dialog" role="document">
+                            <div class="modal-content">
+                                <div class="modal-header">
+                                    <button type="button" class="close" data-dismiss="modal" aria-label="@localizer["Close"]"><span aria-hidden="true">&times;</span></button>
+                                    <h4 class="modal-title" id="m4-new-vendor-title">@localizer["M4NewVendor"]</h4>
+                                </div>
+                                <div class="modal-body">
+                                    <div class="alert rgw-modal-message" role="status"></div>
+                                    <p class="text-muted">@localizer["M4NewVendorHint"]</p>
+                                    <form asp-action="SaveVendor" method="post" class="inventory-command">
+                                        @Html.AntiForgeryToken()
+                                        @Hide("Revision", 0)
+                                        <div class="rgw-grid">
+                                            @Field("ContactId", "M4CompanyContact", null, options: contactOptions, required: true, help: "M4CompanyContactHelp", wide: true)
+                                            @Field("Details.AccountNumber", "M4AccountNumber", null, help: "M4AccountNumberHelp", maxLength: 250, wide: true)
+                                            @Field("Details.Note", "Note", null, "textarea", wide: true)
+                                        </div>
+                                        <div class="rgw-wizard-actions">
+                                            <div class="rgw-wizard-spacer"></div>
+                                            <button type="button" class="btn btn-white" data-dismiss="modal">@localizer["Close"]</button>
+                                            <button type="submit" class="btn btn-primary">@localizer["Save"]</button>
+                                        </div>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    foreach (var vendor in Model.Rows.OfType<InventoryVendor>())
+                    {
+                        var details = InventoryWorkspaceView.Details<InventoryVendorContent>(vendor);
+                        <div class="modal fade rgw-modal" id="m4-vendor-@vendor.Id" tabindex="-1" role="dialog" aria-labelledby="m4-vendor-@(vendor.Id)-title">
+                            <div class="modal-dialog" role="document">
+                                <div class="modal-content">
+                                    <div class="modal-header">
+                                        <button type="button" class="close" data-dismiss="modal" aria-label="@localizer["Close"]"><span aria-hidden="true">&times;</span></button>
+                                        <h4 class="modal-title" id="m4-vendor-@(vendor.Id)-title">@localizer["Edit"] · @ContactName(vendor.ContactId)</h4>
+                                    </div>
+                                    <div class="modal-body">
+                                        <div class="alert rgw-modal-message" role="status"></div>
+                                        <form asp-action="SaveVendor" method="post" class="inventory-command">
+                                            @Html.AntiForgeryToken()
+                                            @Hide("Id", vendor.Id)@Hide("Revision", vendor.Revision)@Hide("ContactId", vendor.ContactId)
+                                            <p class="text-muted">@localizer["M4CompanyContact"]: @ContactName(vendor.ContactId)</p>
+                                            <div class="rgw-grid">
+                                                @Field("Details.AccountNumber", "M4AccountNumber", details.AccountNumber, help: "M4AccountNumberHelp", maxLength: 250, wide: true)
+                                                @Field("Details.Note", "Note", details.Note, "textarea", wide: true)
+                                            </div>
+                                            <div class="rgw-wizard-actions">
+                                                <div class="rgw-wizard-spacer"></div>
+                                                <button type="button" class="btn btn-white" data-dismiss="modal">@localizer["Close"]</button>
+                                                <button type="submit" class="btn btn-primary">@localizer["Save"]</button>
+                                            </div>
+                                        </form>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    }
+                }
+
+                @if (Model.CanWrite && Model.Tab == "PurchaseOrders" && (order == null || order.Status == (int)InventoryPurchaseOrderStatus.Draft))
+                {
+                    var draftLines = detail?.Lines.OrderBy(x => x.LineNumber).ToList() ?? new List<InventoryPurchaseOrderItem>();
+                    <div class="modal fade rgw-modal" id="m4-new-order" tabindex="-1" role="dialog" aria-labelledby="m4-new-order-title">
+                        <div class="modal-dialog modal-lg" role="document">
+                            <div class="modal-content">
+                                <div class="modal-header">
+                                    <button type="button" class="close" data-dismiss="modal" aria-label="@localizer["Close"]"><span aria-hidden="true">&times;</span></button>
+                                    <h4 class="modal-title" id="m4-new-order-title">@localizer[order == null ? "M4NewPurchaseOrder" : "Edit"]</h4>
+                                </div>
+                                <div class="modal-body">
+                                    <div class="alert rgw-modal-message" role="status"></div>
+                                    <form asp-action="SavePurchaseOrder" method="post" class="inventory-command m4-lines-form rgw-wizard">
+                                        @Html.AntiForgeryToken()
+                                        @Hide("Id", order?.Id ?? Guid.NewGuid().ToString("D"))
+                                        @Hide("Revision", order?.Revision ?? 0)
+                                        <ol class="rgw-steps"></ol>
+
+                                        <div class="rgw-step" data-title="@localizer["M4StepOrderHeader"]">
+                                            <h4>@localizer["M4StepOrderHeader"]</h4>
+                                            <p class="text-muted">@localizer["M4StepOrderHeaderHint"]</p>
+                                            <div class="rgw-grid">
+                                                @Field("Number", "M4PurchaseOrderNumber", orderContent.Number, required: true, help: "M4PurchaseOrderNumberHelp", maxLength: 80)
+                                                @Field("VendorId", "M4Supplier", order?.VendorId, options: vendorOptions, required: true)
+                                                @Field("CurrencyCode", "M4Currency", order?.CurrencyCode, required: true, help: "HelpFieldCurrency", maxLength: 3)
+                                                @Field("Note", "Note", orderContent.Note, "textarea", help: "HelpFieldNote", wide: true)
+                                            </div>
+                                        </div>
+
+                                        <div class="rgw-step" data-title="@localizer["M4StepOrderLines"]">
+                                            <h4>@localizer["M4StepOrderLines"]</h4>
+                                            <p class="text-muted">@localizer["M4StepOrderLinesHint"]</p>
+                                            <div class="m4-lines">
+                                                @{ var draftIndex = 0; }
+                                                @foreach (var line in draftLines.DefaultIfEmpty(new InventoryPurchaseOrderItem { QuantityOrdered = 1 }))
+                                                {
+                                                    var prefix = "Lines[" + draftIndex++ + "].";
+                                                    var content = InventoryWorkspaceView.Details<InventoryPurchaseOrderItemContent>(line);
+                                                    <div class="panel panel-default rgw-line m4-line">
+                                                        <div class="panel-heading">@localizer["Items"]</div>
+                                                        <div class="panel-body">
+                                                        @Hide(prefix + "Id", draftLines.Contains(line) ? line.Id : null)
+                                                        <div class="rgw-grid">
+                                                            @Field(prefix + "ItemId", "Items", line.ItemId, options: itemOptions, required: true)
+                                                            @Field(prefix + "QuantityOrdered", "M4QuantityOrdered", line.QuantityOrdered, "number", required: true, min: "0.000001")
+                                                            @Field(prefix + "UnitCost", "UnitCost", content.UnitCost, "number", required: true, help: "HelpFieldUnitCost", min: "0")
+                                                            @Field(prefix + "Note", "Note", content.Note)
+                                                        </div>
+                                                        <div class="rgw-line-actions">
+                                                            <button class="btn btn-xs btn-danger m4-remove-line" type="button"><i class="fa fa-trash-o"></i> @localizer["M4RemoveLine"]</button>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                                }
+                                            </div>
+                                            <button class="btn btn-default m4-add-line" type="button"><i class="fa fa-plus"></i> @localizer["AddLine"]</button>
+                                        </div>
+
+                                        <div class="rgw-step" data-title="@localizer["Review"]">
+                                            <h4>@localizer["Review"]</h4>
+                                            <p class="text-muted">@localizer["ReviewHint"]</p>
+                                            <dl class="rgw-review"></dl>
+                                        </div>
+
+                                        <div class="rgw-wizard-actions">
+                                            <button type="button" class="btn btn-white rgw-step-prev">@localizer["Back"]</button>
+                                            <div class="rgw-wizard-spacer"></div>
+                                            <button type="button" class="btn btn-white" data-dismiss="modal">@localizer["Close"]</button>
+                                            <button type="button" class="btn btn-primary rgw-step-next">@localizer["Continue"]</button>
+                                            <button type="submit" class="btn btn-primary rgw-step-submit">@localizer["Save"]</button>
+                                        </div>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                }
+
+                @if (Model.CanWrite && order != null && order.Status is 1 or 2 && detail.Lines.Any(x => x.QuantityOrdered > x.QuantityReceived))
+                {
+                    <div class="modal fade rgw-modal" id="m4-receive" tabindex="-1" role="dialog" aria-labelledby="m4-receive-title">
+                        <div class="modal-dialog modal-lg" role="document">
+                            <div class="modal-content">
+                                <div class="modal-header">
+                                    <button type="button" class="close" data-dismiss="modal" aria-label="@localizer["Close"]"><span aria-hidden="true">&times;</span></button>
+                                    <h4 class="modal-title" id="m4-receive-title">@localizer["M4Receive"] · @orderContent.Number</h4>
+                                </div>
+                                <div class="modal-body">
+                                    <div class="alert rgw-modal-message" role="status"></div>
+                                    <div class="alert alert-info">
+                                        <i class="fa fa-info-circle"></i>@localizer["M4ReceiptHelp"]
+                                        <p>@localizer["M4SerializedReceiptHelp"]</p>
+                                    </div>
+                                    <form asp-action="ReceivePurchaseOrder" method="post" class="inventory-command m4-lines-form" data-receipt="true">
+                                        @Html.AntiForgeryToken()
+                                        @Hide("PurchaseOrderId", order.Id)@Hide("Revision", order.Revision)@Hide("RequestId", Guid.NewGuid().ToString("D"))
+                                        <div class="m4-lines">
+                                            @{ var receiptIndex = 0; }
+                                            @foreach (var line in detail.Lines.Where(x => x.QuantityOrdered > x.QuantityReceived).OrderBy(x => x.LineNumber))
+                                            {
+                                                var content = InventoryWorkspaceView.Details<InventoryPurchaseOrderItemContent>(line);
+                                                var item = Model.Items.FirstOrDefault(x => x.Id == line.ItemId);
+                                                var serialized = item?.TrackingMode == (int)InventoryTrackingMode.Serialized;
+                                                var prefix = "Lines[" + receiptIndex++ + "].";
+                                                var lotOptions = Choice(Model.Lots.Where(x => x.ItemId == line.ItemId).Select(x => new InventoryChoice { Id = x.Id, Name = InventoryWorkspaceView.Details<InventoryLotContent>(x).LotNumber }));
+                                                <div class="panel panel-default rgw-line m4-line">
+                                                    <div class="panel-heading">@content.ItemName · @localizer["M4Remaining"]: @((line.QuantityOrdered - line.QuantityReceived).ToString(CultureInfo.CurrentCulture)) @content.UnitOfMeasure</div>
+                                                    <div class="panel-body">
+                                                    @Hide(prefix + "PurchaseOrderItemId", line.Id)
+                                                    <div class="rgw-grid">
+                                                        @Field(prefix + "Quantity", "M4ReceiveQuantity", serialized ? 1m : line.QuantityOrdered - line.QuantityReceived, "number", required: true, readOnly: serialized, min: "0.000001")
+                                                        @Field(prefix + "LocationId", "ToLocation", null, options: locationOptions, required: true, help: "HelpFieldToLocation")
+                                                        @Field(prefix + "LotId", "Batch", null, options: lotOptions, required: item?.RequiresLotTracking == true, help: "HelpFieldLot")
+                                                        @if (serialized)
+                                                        {
+                                                            @Field(prefix + "Asset.SerialNumber", "SerialNumber", null, required: true, help: "HelpFieldSerialNumber", maxLength: 250)
+                                                            @Field(prefix + "Asset.AssetTag", "AssetTag", null, maxLength: 250)
+                                                            @Field(prefix + "Asset.Barcode", "Barcode", null, maxLength: 250)
+                                                            @Field(prefix + "Asset.ExpiresOn", "Expiration", null, "date", required: item?.RequiresExpiration == true, help: "HelpFieldExpiration")
+                                                        }
+                                                    </div>
+                                                    <div class="rgw-line-actions">
+                                                        <button class="btn btn-xs btn-default m4-copy-line" type="button"><i class="fa fa-clone"></i> @localizer["AddLine"]</button>
+                                                        <button class="btn btn-xs btn-danger m4-remove-line" type="button"><i class="fa fa-trash-o"></i> @localizer["M4RemoveLine"]</button>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            }
+                                        </div>
+                                        <div class="rgw-wizard-actions">
+                                            <div class="rgw-wizard-spacer"></div>
+                                            <button type="button" class="btn btn-white" data-dismiss="modal">@localizer["Close"]</button>
+                                            <button type="submit" class="btn btn-primary">@localizer["M4Receive"]</button>
+                                        </div>
+                                    </form>
+                                    <form asp-action="Reopen" method="post" class="inventory-navigation m-t-sm">
+                                        @Html.AntiForgeryToken()
+                                        @Hide("tab", "History")
+                                        <button class="btn btn-default btn-sm" type="submit">@localizer["Witness"]</button>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                }
             }
-        }
-    }
-</div></div></div>
+        </div>
+    </div>
+</div>
+
+@section Styles {
+    <link rel="stylesheet" href="~/css/workspace.css" asp-append-version="true" />
+}
+
 @section Scripts {
-<script id="inventory-settings" type="application/json">@Html.Raw(JsonConvert.SerializeObject(new { protectedData, grant = (string)ViewBag.ProtectedGrant, expiry = (DateTime?)ViewBag.GrantExpiresOn, index = Url.Action("Purchasing", new { tab = Model.Tab, id = Model.Id, page = Model.Page, locationId = Model.LocationId }), failed = localizer["UnableToComplete"].Value, witness = localizer["WitnessPending"].Value }, new JsonSerializerSettings { StringEscapeHandling = StringEscapeHandling.EscapeHtml }))</script>
-<script src="~/js/app/internal/inventory/inventory-modern.js" asp-append-version="true"></script>
-<script src="~/js/app/internal/inventory/inventory-purchasing.js" asp-append-version="true"></script>
-@if (protectedData) { @await Html.PartialAsync("_AdpRevealScripts", new AdpRevealView { BannerTitle = localizer["ProtectedDataRequired"].Value, GrantExpiresOnUtc = (DateTime?)ViewBag.GrantExpiresOn, BindForms = new List<string> { "form.inventory-navigation", "form.inventory-command" } }) }
+    <script id="inventory-settings" type="application/json">@Html.Raw(JsonConvert.SerializeObject(new { protectedData, grant = (string)ViewBag.ProtectedGrant, expiry = (DateTime?)ViewBag.GrantExpiresOn, index = Url.Action("Purchasing", new { tab = Model.Tab, id = Model.Id, page = Model.Page, locationId = Model.LocationId }), failed = localizer["UnableToComplete"].Value, witness = localizer["WitnessPending"].Value }, new JsonSerializerSettings { StringEscapeHandling = StringEscapeHandling.EscapeHtml }))</script>
+    <script id="workspace-settings" type="application/json">@Html.Raw(JsonConvert.SerializeObject(new { required = localizer["RequiredFieldsMissing"].Value, nothingEntered = localizer["NoRows"].Value, yes = localizer["Yes"].Value, no = localizer["No"].Value }, new JsonSerializerSettings { StringEscapeHandling = StringEscapeHandling.EscapeHtml }))</script>
+    <script src="~/js/app/internal/inventory/inventory-modern.js" asp-append-version="true"></script>
+    <script src="~/js/app/internal/inventory/inventory-purchasing.js" asp-append-version="true"></script>
+    <script src="~/js/app/common/workspace/resgrid.common.workspace.js" asp-append-version="true"></script>
+    @if (protectedData)
+    {
+        @await Html.PartialAsync("_AdpRevealScripts", new AdpRevealView { BannerTitle = localizer["ProtectedDataRequired"].Value, GrantExpiresOnUtc = (DateTime?)ViewBag.GrantExpiresOn, BindForms = new List<string> { "form.inventory-navigation", "form.inventory-command" } })
+    }
 }

--- a/Web/Resgrid.Web/Areas/User/Views/Inventory/Workspace.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Inventory/Workspace.cshtml
@@ -6,159 +6,1416 @@
 @using Resgrid.Model.Inventories
 @using Resgrid.Web.Areas.User.Models
 @using Resgrid.Web.Areas.User.Models.Inventory
+@using Resgrid.Web.Helpers
 @model InventoryWorkspaceView
 @inject IStringLocalizer<Resgrid.Localization.Areas.User.Inventory.Inventory> localizer
+@*
+    Catalog and stock. One tab per kind of record; every list is a table with columns that
+    suit that record, and every piece of data entry that needs more than two or three
+    answers is a step wizard in a modal rather than one long column of inputs.
+
+    All navigation and all commands are POSTs: under Advanced Data Protection the reveal
+    grant rides on those forms (see inventory-modern.js), so they must not become links.
+*@
 @functions {
-    IHtmlContent Field(string name, string label, object value = null, string type = "text", IEnumerable<SelectListItem> options = null) {
-        var wrap = new TagBuilder("div"); wrap.AddCssClass("form-group");
-        var caption = new TagBuilder("label"); var identity = "inv-" + Guid.NewGuid().ToString("N"); caption.Attributes["for"] = identity; caption.InnerHtml.Append(localizer[label].Value); wrap.InnerHtml.AppendHtml(caption);
-        var element = new TagBuilder(options == null ? "input" : "select"); element.AddCssClass("form-control"); element.Attributes["name"] = name; element.Attributes["id"] = identity;
-        var text = Convert.ToString(value, CultureInfo.InvariantCulture) ?? "";
-        if (options == null) { element.Attributes["type"] = type; element.Attributes["value"] = text; element.Attributes["maxlength"] = "16000"; if (type == "number") element.Attributes["step"] = "0.000001"; }
-        else foreach (var option in options) { var item = new TagBuilder("option"); item.Attributes["value"] = option.Value ?? ""; if ((option.Value ?? "") == text) item.Attributes["selected"] = "selected"; item.InnerHtml.Append(option.Text); element.InnerHtml.AppendHtml(item); }
-        wrap.InnerHtml.AppendHtml(element); return wrap;
-    }
-    IEnumerable<SelectListItem> Choice(IEnumerable<InventoryChoice> list) => new[] { new SelectListItem { Value = "", Text = "—" } }.Concat(list.Select(x => new SelectListItem { Value = x.Id, Text = x.Name }));
-    IEnumerable<SelectListItem> Codes(string prefix, params int[] values) => values.Select(x => new SelectListItem { Value = x.ToString(), Text = localizer[prefix + x].Value });
+    IHtmlContent Field(string name, string label, object value = null, string type = "text",
+        IEnumerable<SelectListItem> options = null, string help = null, bool required = false,
+        bool wide = false, int maxLength = 16000, string min = null, bool readOnly = false)
+        => WorkspaceFormHelper.Field(localizer, name, label, value, type, options, help, required, readOnly, wide, maxLength, null, min);
+
+    IHtmlContent Hide(string name, object value) => WorkspaceFormHelper.Hidden(name, value);
+
+    IEnumerable<SelectListItem> Choice(IEnumerable<InventoryChoice> list) => WorkspaceFormHelper.Choices(list.Select(x => (x.Id, x.Name)));
+
+    IEnumerable<SelectListItem> Codes(string prefix, params int[] values) => WorkspaceFormHelper.Codes(localizer, prefix, values);
+
+    string ItemName(string id) => Model.Items.FirstOrDefault(i => i.Id == id) is { } item
+        ? InventoryWorkspaceView.Details<InventoryItemContent>(item).Name
+        : id;
+
+    string LocationName(string id) => string.IsNullOrEmpty(id)
+        ? ""
+        : Model.Locations.FirstOrDefault(l => l.Id == id) is { } location
+            ? InventoryWorkspaceView.Details<InventoryLabel>(location).Name
+            : id;
+
+    string CategoryName(string id) => string.IsNullOrEmpty(id)
+        ? ""
+        : Model.Categories.FirstOrDefault(c => c.Id == id) is { } category
+            ? InventoryWorkspaceView.Details<InventoryLabel>(category).Name
+            : id;
+
+    // Theme label colours: in service reads well, anything sitting in a repair shop or
+    // written off should not. A bare "label" is the theme's neutral grey.
+    string AssetPill(int status) => status switch
+    {
+        0 => "label-success",
+        1 => "label-info",
+        2 or 3 => "label-warning",
+        4 or 5 or 6 => "label-danger",
+        _ => ""
+    };
+
+    string IssuancePill(int status) => status switch
+    {
+        0 => "label-warning",
+        1 => "label-success",
+        2 => "label-warning",
+        _ => "label-danger"
+    };
 }
 @{
     ViewBag.Title = "Resgrid | " + localizer["Inventory"];
     var protectedData = ViewBag.ProtectionEnforced == true;
+
     var itemOptions = Choice(Model.Items.Select(x => new InventoryChoice { Id = x.Id, Name = InventoryWorkspaceView.Details<InventoryItemContent>(x).Name }));
     var locationOptions = Choice(Model.Locations.Select(x => new InventoryChoice { Id = x.Id, Name = InventoryWorkspaceView.Details<InventoryLabel>(x).Name }));
     var categoryOptions = Choice(Model.Categories.Select(x => new InventoryChoice { Id = x.Id, Name = InventoryWorkspaceView.Details<InventoryLabel>(x).Name }));
     var assetOptions = Choice(Model.Assets.Select(x => new InventoryChoice { Id = x.Id, Name = InventoryWorkspaceView.Details<InventoryAssetContent>(x).SerialNumber + " · " + InventoryWorkspaceView.Details<InventoryAssetContent>(x).AssetTag }));
     var lotOptions = Choice(Model.Lots.Select(x => new InventoryChoice { Id = x.Id, Name = InventoryWorkspaceView.Details<InventoryLotContent>(x).LotNumber }));
     var vendorOptions = Choice(Model.Vendors.Select(x => new InventoryChoice { Id = x.Id, Name = Model.VendorContacts.FirstOrDefault(c => c.Id == x.ContactId)?.Name ?? x.ContactId }));
-    string ItemName(string id) => Model.Items.FirstOrDefault(i => i.Id == id) is { } item ? InventoryWorkspaceView.Details<InventoryItemContent>(item).Name : id;
-    string LocationName(string id) => Model.Locations.FirstOrDefault(i => i.Id == id) is { } location ? InventoryWorkspaceView.Details<InventoryLabel>(location).Name : id;
+
+    // Tab strip. Contextual views (a single asset, a single ledger entry, a holder's kit)
+    // are reached from a row and are not tabs of their own.
+    var tabs = new (string Key, string Icon)[]
+    {
+        ("OnHand", "fa-cubes"), ("Items", "fa-list-ul"), ("Categories", "fa-folder-open-o"),
+        ("Locations", "fa-map-marker"), ("Lots", "fa-barcode"), ("Assets", "fa-tag"),
+        ("Issuances", "fa-hand-paper-o"), ("Kits", "fa-briefcase"), ("Transfers", "fa-exchange"),
+        ("History", "fa-history")
+    };
+    var contextual = new[] { "AssetDetail", "Transaction", "UnitEquipment", "PersonnelGear" };
+    var isContextual = contextual.Contains(Model.Tab);
+
+    ViewData["Module"] = "Inventory";
+    ViewData["Intro"] = localizer["WorkspaceIntro"].Value;
 }
-<div class="wrapper wrapper-content"><div class="ibox"><div class="ibox-title"><h2>@localizer["Inventory"]</h2></div><div class="ibox-content">
-    @if (ViewBag.ProtectionEnforced == true) { @await Html.PartialAsync("_AdpRevealBanner", new AdpRevealView { BannerTitle = localizer["ProtectedDataRequired"].Value }) }
-    <div id="inventory-message" class="alert alert-info" role="status" hidden></div>
-    <form id="inventory-page" asp-action="Reopen" method="post" class="inventory-navigation">
-        @Html.AntiForgeryToken()<input type="hidden" name="tab" value="@Model.Tab"/><input type="hidden" name="page" value="@Model.Page"/><input type="hidden" name="id" value="@Model.Id"/><input type="hidden" name="unitId" value="@Model.UnitId"/><input type="hidden" name="userId" value="@Model.UserId"/><input type="hidden" name="itemId" value="@Model.ItemId"/><input type="hidden" name="locationId" value="@Model.LocationId"/>
-        @if (Model.Locked) { <button type="submit" class="btn btn-primary">@localizer["Unlock"]</button> }
-    </form>
-    @if (!Model.Locked && !Model.Migrated) {
-        <p>@localizer["InitializeDescription"]</p>
-        @if (Model.CanWrite) { <form asp-action="Initialize" method="post" class="inventory-command">@Html.AntiForgeryToken()<button type="submit" class="btn btn-primary">@localizer["Initialize"]</button></form> }
-    }
-    @if (!Model.Locked && Model.Migrated) {
-        <nav class="btn-toolbar" aria-label="@localizer["Inventory"]">
-        @foreach (var tab in new[] { "OnHand", "Items", "Categories", "Locations", "Lots", "Assets", "Issuances", "Kits", "Transfers", "History" }) {
-            <form asp-action="Reopen" method="post" class="inventory-navigation" style="display:inline-block">@Html.AntiForgeryToken()<input type="hidden" name="tab" value="@tab"/><input type="hidden" name="itemId" value="@Model.ItemId"/><input type="hidden" name="locationId" value="@Model.LocationId"/><button class="btn @(Model.Tab == tab ? "btn-primary" : "btn-default")" type="submit">@localizer[tab]</button></form>
-        }
-            <form asp-action="ReopenPurchasing" method="post" class="inventory-navigation" style="display:inline-block">@Html.AntiForgeryToken()<button class="btn btn-default" type="submit">@localizer["M4Purchasing"]</button></form>
-            <form asp-action="ReopenOperations" method="post" class="inventory-navigation" style="display:inline-block">@Html.AntiForgeryToken()<button class="btn btn-default" type="submit">@localizer["M5Operations"]</button></form>
-        </nav><hr/><h3>@localizer[Model.Tab]</h3>
-        @if (Model.ChoicesHaveMore) { <p class="alert alert-info">@localizer["MoreChoices"]</p> }
-        @if (Model.Tab is "OnHand" or "History") {
-            <form asp-action="@(protectedData ? "Reopen" : "Index")" method="@(protectedData ? "post" : "get")" class="@(protectedData ? "inventory-navigation" : "inventory-filter")">
-                @if (protectedData) { @Html.AntiForgeryToken() }
-                <input type="hidden" name="tab" value="@Model.Tab"/><input type="hidden" name="page" value="0"/>
-                @Field("itemId", "Items", Model.ItemId, options: itemOptions)@Field("locationId", "Location", Model.LocationId, options: locationOptions)
-                <button class="btn btn-default" type="submit">@localizer[Model.Tab == "History" ? "ViewHistory" : "OnHand"]</button>
+
+@await Html.PartialAsync("_Shell", Model)
+
+<div class="wrapper wrapper-content">
+    <div class="ibox float-e-margins">
+        <div class="ibox-title">
+            <h5>@localizer[Model.Locked || !Model.Migrated ? "Inventory" : Model.Tab]</h5>
+        </div>
+        <div class="ibox-content">
+
+            @if (protectedData)
+            {
+                @await Html.PartialAsync("_AdpRevealBanner", new AdpRevealView { BannerTitle = localizer["ProtectedDataRequired"].Value })
+            }
+
+            <div id="inventory-message" class="alert alert-info" role="status" hidden></div>
+
+            @* Carries the current page position; commands re-submit it to refresh the screen. *@
+            <form id="inventory-page" asp-action="Reopen" method="post" class="inventory-navigation">
+                @Html.AntiForgeryToken()
+                @Hide("tab", Model.Tab)@Hide("page", Model.Page)@Hide("id", Model.Id)
+                @Hide("unitId", Model.UnitId)@Hide("userId", Model.UserId)
+                @Hide("itemId", Model.ItemId)@Hide("locationId", Model.LocationId)
+                @if (Model.Locked)
+                {
+                    <div class="text-center m-t-lg m-b-lg">
+                        <i class="fa fa-lock fa-3x text-muted"></i>
+                        <h4 class="m-t-sm">@localizer["ProtectedDataRequired"]</h4>
+                        <p>@commonLocalizer["AdpProtectedBannerDescription"]</p>
+                        <button type="submit" class="btn btn-primary m-t">@localizer["Unlock"]</button>
+                    </div>
+                }
             </form>
-        }
-        @if (Model.Tab == "OnHand") {
-            <form asp-action="Reopen" method="post" class="inventory-navigation">@Html.AntiForgeryToken()<input type="hidden" name="tab" value="UnitEquipment"/>@Field("unitId", "Unit", null, options: Choice(Model.Units))<button class="btn btn-default" type="submit">@localizer["UnitEquipment"]</button></form>
-            <form asp-action="Reopen" method="post" class="inventory-navigation">@Html.AntiForgeryToken()<input type="hidden" name="tab" value="PersonnelGear"/>@Field("userId", "Person", null, options: Choice(Model.People))<button class="btn btn-default" type="submit">@localizer["PersonnelGear"]</button></form>
-        }
-        <div class="table-responsive"><table class="table table-striped"><thead><tr><th>@localizer["Name"]</th><th>@localizer["Location"]</th><th>@localizer["Amount"]</th><th>@localizer["Status"]</th><th>@localizer["Actions"]</th></tr></thead><tbody>
-        @foreach (var row in Model.Rows) {
-            var title = row switch { InventoryItem i => InventoryWorkspaceView.Details<InventoryItemContent>(i).Name, InventoryAsset a => ItemName(a.ItemId) + " · " + InventoryWorkspaceView.Details<InventoryAssetContent>(a).SerialNumber, InventoryStock s => ItemName(s.ItemId), InventoryIssuance i => ItemName(i.ItemId), InventoryLot l => InventoryWorkspaceView.Details<InventoryLotContent>(l).LotNumber, InventoryTransaction t => ItemName(t.ItemId) + " · " + localizer["Movement" + t.TransactionType].Value, _ => InventoryWorkspaceView.Details<InventoryLabel>(row).Name ?? row.Id };
-            var location = row switch { InventoryAsset a => LocationName(a.CurrentLocationId), InventoryStock s => LocationName(s.LocationId), InventoryIssuance i => LocationName(i.LocationId), InventoryTransaction t => LocationName(t.FromLocationId) + " → " + LocationName(t.ToLocationId), InventoryTransfer t => LocationName(t.FromLocationId) + " → " + LocationName(t.ToLocationId), _ => "" };
-            var amount = row switch { InventoryStock s => s.Quantity.ToString(CultureInfo.CurrentCulture), InventoryIssuance i => (i.Quantity - i.ReturnedQuantity).ToString(CultureInfo.CurrentCulture), InventoryTransaction t => t.Quantity.ToString(CultureInfo.CurrentCulture), _ => "" };
-            <tr><td>@title<small class="text-muted" style="display:block">@row.Id</small></td><td>@location</td><td>@amount</td><td>@(row is InventoryAsset asset ? localizer["Status" + asset.Status] : row is InventoryIssuance issued ? localizer["IssuanceStatus" + issued.Status] : "")</td><td>
-                @if (row is InventoryAsset) { <form asp-action="Reopen" method="post" class="inventory-navigation">@Html.AntiForgeryToken()<input type="hidden" name="tab" value="AssetDetail"/><input type="hidden" name="id" value="@row.Id"/><button class="btn btn-default btn-xs" type="submit">@localizer["ViewHistory"]</button></form> }
-                @if (row is InventoryTransaction txn) { <time>@txn.OccurredOn.ToString("u")</time><details><summary>@localizer["Details"]</summary><p>@(InventoryWorkspaceView.Details<InventoryLabel>(txn).Note)</p><p>@localizer["Reference"]: @txn.ReferenceType / @txn.ReferenceId
-                @if (txn.ReferenceType == (int)InventoryReferenceType.WorkOrder && int.TryParse(txn.ReferenceId, out var orderId) && orderId > 0) { <a asp-controller="WorkOrders" asp-action="Detail" asp-route-id="@orderId">@localizer["Details"]</a> }
-                </p></details> }
-                @if (Model.CanWrite && Model.Tab is "Items" or "Categories" or "Locations" or "Kits") { <form asp-action="Archive" method="post" class="inventory-command">@Html.AntiForgeryToken()<input type="hidden" name="kind" value="@Model.Tab"/><input type="hidden" name="id" value="@row.Id"/><input type="hidden" name="revision" value="@row.Revision"/><button class="btn btn-default btn-xs" type="submit">@localizer["Archive"]</button></form> }
-                @if (Model.CanIssue && row is InventoryIssuance outstanding && outstanding.Status is 0 or 2) {
-                    <details><summary>@localizer["Return"]</summary><form asp-action="Return" method="post" class="inventory-command">@Html.AntiForgeryToken()<input type="hidden" name="RequestId" value="@Guid.NewGuid().ToString("D")"/><input type="hidden" name="IssuanceId" value="@row.Id"/><input type="hidden" name="Revision" value="@row.Revision"/>@Field("ToLocationId", "ToLocation", null, options: locationOptions)@Field("Quantity", "Amount", outstanding.Quantity - outstanding.ReturnedQuantity, "number")@Field("Condition", "Status", 0, options: Codes("Status", 0, 2, 3))@Field("Note", "Note")<button class="btn btn-primary" type="submit">@localizer["Return"]</button></form></details>
-                }
-                @if (Model.CanWrite && row is InventoryCategory category) {
-                    <details><summary>@localizer["Edit"]</summary><form asp-action="SaveCategory" method="post" class="inventory-command">@Html.AntiForgeryToken()<input type="hidden" name="id" value="@category.Id"/><input type="hidden" name="revision" value="@category.Revision"/>@Field("name", "Name", InventoryWorkspaceView.Details<InventoryLabel>(category).Name)@Field("parentId", "Parent", category.ParentCategoryId, options: categoryOptions)<button class="btn btn-primary" type="submit">@localizer["Save"]</button></form></details>
-                }
-                @if (Model.CanWrite && row is InventoryLocation place) {
-                    <details><summary>@localizer["Edit"]</summary><form asp-action="SaveLocation" method="post" class="inventory-command">@Html.AntiForgeryToken()<input type="hidden" name="Id" value="@place.Id"/><input type="hidden" name="Revision" value="@place.Revision"/><input type="hidden" name="Type" value="@place.LocationType"/><input type="hidden" name="GroupId" value="@place.GroupId"/><input type="hidden" name="UnitId" value="@place.UnitId"/><input type="hidden" name="UserId" value="@place.UserId"/><input type="hidden" name="ContainerAssetId" value="@place.ContainerAssetId"/><input type="hidden" name="ParentLocationId" value="@place.ParentLocationId"/><input type="hidden" name="IsDefault" value="@place.IsDefault.ToString().ToLowerInvariant()"/>@Field("Name", "Name", InventoryWorkspaceView.Details<InventoryLabel>(place).Name)<button class="btn btn-primary" type="submit">@localizer["Save"]</button></form></details>
-                }
-                @if (Model.CanWrite && row is InventoryKit editableKit) {
-                    <details><summary>@localizer["Edit"]</summary><form asp-action="SaveKit" method="post" class="inventory-command inventory-kit">
-                    @Html.AntiForgeryToken()<input type="hidden" name="Id" value="@editableKit.Id"/><input type="hidden" name="Revision" value="@editableKit.Revision"/>@Field("Name", "Name", InventoryWorkspaceView.Details<InventoryLabel>(editableKit).Name)
-                    <div class="inventory-kit-lines">
-                    @{ var editLines = Model.KitContents.Where(k => k.KitId == editableKit.Id && !k.IsDeleted).ToList(); var editIndex = 0; }
-                    @foreach (var kitLine in editLines.DefaultIfEmpty(new InventoryKitItem { Quantity = 1 })) {
-                        var prefix = "Lines[" + editIndex++ + "].";
-                        <div class="inventory-kit-line">@Field(prefix + "ItemId", "Items", kitLine.ItemId, options: itemOptions)@Field(prefix + "Quantity", "Amount", kitLine.Quantity, "number")<button class="btn btn-default inventory-remove-line" type="button">@localizer["Archive"]</button></div>
+
+            @if (!Model.Locked && !Model.Migrated)
+            {
+                <div class="text-center m-t-lg m-b-lg">
+                    <i class="fa fa-cubes fa-3x text-muted"></i>
+                    <h4 class="m-t-sm">@localizer["Initialize"]</h4>
+                    <p>@localizer["InitializeDescription"]</p>
+                    @if (Model.CanWrite)
+                    {
+                        <form asp-action="Initialize" method="post" class="inventory-command m-t">
+                            @Html.AntiForgeryToken()
+                            <button type="submit" class="btn btn-primary">@localizer["Initialize"]</button>
+                        </form>
                     }
-                    </div><button class="btn btn-default inventory-add-line" type="button">@localizer["AddLine"]</button><button class="btn btn-primary" type="submit">@localizer["Save"]</button></form></details>
+                </div>
+            }
+
+            @if (!Model.Locked && Model.Migrated)
+            {
+                <ul class="nav nav-tabs" role="tablist" aria-label="@localizer["Inventory"]">
+                    @foreach (var tab in tabs)
+                    {
+                        <li class="nav-item @(Model.Tab == tab.Key ? "active" : null)">
+                            <form asp-action="Reopen" method="post" class="inventory-navigation">
+                                @Html.AntiForgeryToken()
+                                @Hide("tab", tab.Key)@Hide("itemId", Model.ItemId)@Hide("locationId", Model.LocationId)
+                                <button type="submit" aria-current="@(Model.Tab == tab.Key ? "page" : "false")">
+                                    <i class="fa @tab.Icon"></i> @localizer[tab.Key]
+                                </button>
+                            </form>
+                        </li>
+                    }
+                </ul>
+
+                @if (isContextual)
+                {
+                    @* Contextual views get a way back to the list they came from. *@
+                    <div class="rgw-toolbar">
+                        <form asp-action="Reopen" method="post" class="inventory-navigation">
+                            @Html.AntiForgeryToken()
+                            @Hide("tab", Model.Tab == "AssetDetail" ? "Assets" : Model.Tab == "Transaction" ? "History" : "OnHand")
+                            <button class="btn btn-default btn-sm" type="submit"><i class="fa fa-arrow-left"></i> @localizer["Back"]</button>
+                        </form>
+                    </div>
                 }
-                @if (Model.CanIssue && row is InventoryKit kit && Model.KitContents.Any(k => k.KitId == kit.Id && !k.IsDeleted)) {
-                    var kitLines = Model.KitContents.Where(k => k.KitId == kit.Id && !k.IsDeleted).ToList();
-                    var issueCount = kitLines.Sum(k => Model.Items.FirstOrDefault(i => i.Id == k.ItemId)?.TrackingMode == (int)InventoryTrackingMode.Serialized ? k.Quantity : 1);
-                    if (issueCount <= 100 && kitLines.All(k => Model.Items.Any(i => i.Id == k.ItemId))) {
-                        <details><summary>@localizer["Issue"]</summary><form asp-action="IssueKit" method="post" class="inventory-command inventory-kit-issue">@Html.AntiForgeryToken()<input type="hidden" name="KitId" value="@kit.Id"/><input type="hidden" name="RequestId" value="@Guid.NewGuid().ToString("D")"/>@Field("userId", "Person", null, options: Choice(Model.People))@Field("unitId", "Unit", null, options: Choice(Model.Units))
-                        @{ var lineIndex = 0; }
-                        @foreach (var kitLine in kitLines) {
-                            var serialized = Model.Items.First(i => i.Id == kitLine.ItemId).TrackingMode == (int)InventoryTrackingMode.Serialized;
-                            var quantity = serialized ? 1 : kitLine.Quantity;
-                            foreach (var component in Enumerable.Range(0, serialized ? (int)kitLine.Quantity : 1)) {
-                                var prefix = "Lines[" + lineIndex++ + "].";
-                                <fieldset><legend>@ItemName(kitLine.ItemId) @(serialized ? (component + 1).ToString(CultureInfo.CurrentCulture) : "")</legend><input type="hidden" name="@(prefix + "ItemId")" value="@kitLine.ItemId"/><input type="hidden" name="@(prefix + "Quantity")" value="@quantity.ToString(CultureInfo.InvariantCulture)"/><p>@localizer["Amount"]: @quantity.ToString(CultureInfo.CurrentCulture)</p>
-                                @if (serialized) { @Field(prefix + "AssetId", "AssetId", null, options: Choice(Model.Assets.Where(a => a.ItemId == kitLine.ItemId && a.Status == (int)InventoryAssetStatus.InService && a.CurrentLocationId != null).Select(a => new InventoryChoice { Id = a.Id, Name = InventoryWorkspaceView.Details<InventoryAssetContent>(a).SerialNumber + " · " + InventoryWorkspaceView.Details<InventoryAssetContent>(a).AssetTag }))) }
-                                @Field(prefix + "LotId", "LotId", null, options: Choice(Model.Lots.Where(l => l.ItemId == kitLine.ItemId).Select(l => new InventoryChoice { Id = l.Id, Name = InventoryWorkspaceView.Details<InventoryLotContent>(l).LotNumber })))@Field(prefix + "FromLocationId", "FromLocation", null, options: locationOptions)</fieldset>
+
+                @* Every tab opens with a sentence explaining what the records on it are for. *@
+                <div class="alert alert-info">
+                    <i class="fa fa-info-circle"></i>@localizer["Help" + Model.Tab]
+                </div>
+
+                @if (Model.ChoicesHaveMore)
+                {
+                    <div class="alert alert-warning">@localizer["MoreChoices"]</div>
+                }
+
+                @* ── Filters and lookups ─────────────────────────────────────────── *@
+                @if (Model.Tab is "OnHand" or "History")
+                {
+                    <div class="rgw-filter">
+                        <form asp-action="@(protectedData ? "Reopen" : "Index")" method="@(protectedData ? "post" : "get")"
+                              class="@(protectedData ? "inventory-navigation" : "inventory-filter")">
+                            @if (protectedData)
+                            {
+                                @Html.AntiForgeryToken()
+                            }
+                            @Hide("tab", Model.Tab)@Hide("page", 0)
+                            <div class="rgw-grid">
+                                @Field("itemId", "Items", Model.ItemId, options: itemOptions)
+                                @Field("locationId", "Location", Model.LocationId, options: locationOptions)
+                            </div>
+                            <div class="rgw-filter-actions">
+                                <button class="btn btn-primary" type="submit"><i class="fa fa-filter"></i> @localizer["Filter"]</button>
+                            </div>
+                        </form>
+
+                        @* The holder lookups share the filter panel so the tab opens with one
+                           block of controls rather than two competing grey boxes. *@
+                        @if (Model.Tab == "OnHand")
+                        {
+                            <div class="rgw-filter-split">
+                                <p class="text-muted m-b-sm">@localizer["HelpHolderLookup"]</p>
+                                <div class="rgw-lookup">
+                                    <form asp-action="Reopen" method="post" class="inventory-navigation">
+                                        @Html.AntiForgeryToken()
+                                        @Hide("tab", "UnitEquipment")
+                                        @Field("unitId", "Unit", null, options: Choice(Model.Units))
+                                        <div class="rgw-filter-actions">
+                                            <button class="btn btn-default" type="submit"><i class="fa fa-truck"></i> @localizer["UnitEquipment"]</button>
+                                        </div>
+                                    </form>
+                                    <form asp-action="Reopen" method="post" class="inventory-navigation">
+                                        @Html.AntiForgeryToken()
+                                        @Hide("tab", "PersonnelGear")
+                                        @Field("userId", "Person", null, options: Choice(Model.People))
+                                        <div class="rgw-filter-actions">
+                                            <button class="btn btn-default" type="submit"><i class="fa fa-user"></i> @localizer["PersonnelGear"]</button>
+                                        </div>
+                                    </form>
+                                </div>
+                            </div>
+                        }
+                    </div>
+                }
+
+                @* ── Primary action for the current tab ──────────────── *@
+                // The toolbar only appears when this tab actually offers an action.
+                var hasActions = (Model.CanWrite && Model.Tab is "Items" or "Categories" or "Locations" or "Lots" or "Assets" or "Kits" or "OnHand" or "History")
+                    || (Model.CanTransfer && Model.Tab == "Transfers")
+                    || (Model.CanIssue && Model.Tab == "Issuances")
+                    || (Model.CanWitness && Model.Tab == "History")
+                    || (Model.CanWrite && Model.Tab == "AssetDetail" && Model.Rows.OfType<InventoryAsset>().Any());
+                @if (hasActions)
+                {
+                    <div class="rgw-toolbar">
+                        <div class="rgw-toolbar-spacer"></div>
+                        @if (Model.CanWrite && Model.Tab == "Items")
+                        {
+                            <button class="btn btn-primary" type="button" data-toggle="modal" data-target="#rgw-new-item"><i class="fa fa-plus"></i> @localizer["NewItem"]</button>
+                        }
+                        @if (Model.CanWrite && Model.Tab == "Categories")
+                        {
+                            <button class="btn btn-primary" type="button" data-toggle="modal" data-target="#rgw-new-category"><i class="fa fa-plus"></i> @localizer["NewCategory"]</button>
+                        }
+                        @if (Model.CanWrite && Model.Tab == "Locations")
+                        {
+                            <button class="btn btn-primary" type="button" data-toggle="modal" data-target="#rgw-new-location"><i class="fa fa-plus"></i> @localizer["NewLocation"]</button>
+                        }
+                        @if (Model.CanWrite && Model.Tab == "Lots")
+                        {
+                            <button class="btn btn-primary" type="button" data-toggle="modal" data-target="#rgw-new-lot"><i class="fa fa-plus"></i> @localizer["NewLot"]</button>
+                        }
+                        @if (Model.CanWrite && Model.Tab == "Assets")
+                        {
+                            <button class="btn btn-primary" type="button" data-toggle="modal" data-target="#rgw-new-asset"><i class="fa fa-plus"></i> @localizer["NewAsset"]</button>
+                        }
+                        @if (Model.CanWrite && Model.Tab == "Kits")
+                        {
+                            <button class="btn btn-primary" type="button" data-toggle="modal" data-target="#rgw-new-kit"><i class="fa fa-plus"></i> @localizer["NewKit"]</button>
+                        }
+                        @if (Model.CanWrite && Model.Tab == "OnHand")
+                        {
+                            <button class="btn btn-primary" type="button" data-toggle="modal" data-target="#rgw-post-movement"><i class="fa fa-sliders"></i> @localizer["AdjustStock"]</button>
+                        }
+                        @if (Model.CanTransfer && Model.Tab == "Transfers")
+                        {
+                            <button class="btn btn-primary" type="button" data-toggle="modal" data-target="#rgw-post-movement"><i class="fa fa-exchange"></i> @localizer["NewTransfer"]</button>
+                        }
+                        @if (Model.CanIssue && Model.Tab == "Issuances")
+                        {
+                            <button class="btn btn-primary" type="button" data-toggle="modal" data-target="#rgw-issue"><i class="fa fa-hand-paper-o"></i> @localizer["IssueEquipment"]</button>
+                        }
+                        @if (Model.Tab == "History")
+                        {
+                            @if (Model.CanWitness)
+                            {
+                                <button class="btn btn-default" type="button" data-toggle="modal" data-target="#rgw-witness"><i class="fa fa-check-square-o"></i> @localizer["Witness"]</button>
+                            }
+                            @if (Model.CanWrite)
+                            {
+                                <form asp-action="Rebuild" method="post" class="inventory-command">
+                                    @Html.AntiForgeryToken()
+                                    <button class="btn btn-default" type="submit"><i class="fa fa-refresh"></i> @localizer["Rebuild"]</button>
+                                </form>
                             }
                         }
-                        <button class="btn btn-primary" type="submit">@localizer["Issue"]</button></form></details>
-                    } else { <p class="text-muted">@localizer["UnableToComplete"]</p> }
+                        @if (Model.CanWrite && Model.Tab == "AssetDetail" && Model.Rows.OfType<InventoryAsset>().Any())
+                        {
+                            <button class="btn btn-default" type="button" data-toggle="modal" data-target="#rgw-asset-status"><i class="fa fa-flag"></i> @localizer["Status"]</button>
+                        }
+                    </div>
                 }
-            </td></tr>
-        }
-        </tbody></table></div>
-        @if (Model.Rows.Count == 0) { <p>@localizer["NoRows"]</p> }
-        @foreach (var nextPage in new[] { Model.Page - 1, Model.Page + 1 }.Where(p => p >= 0 && (p < Model.Page || Model.HasMore))) { <form asp-action="Reopen" method="post" class="inventory-navigation" style="display:inline-block">@Html.AntiForgeryToken()<input type="hidden" name="tab" value="@Model.Tab"/><input type="hidden" name="page" value="@nextPage"/><input type="hidden" name="id" value="@Model.Id"/><input type="hidden" name="unitId" value="@Model.UnitId"/><input type="hidden" name="userId" value="@Model.UserId"/><input type="hidden" name="itemId" value="@Model.ItemId"/><input type="hidden" name="locationId" value="@Model.LocationId"/><button class="btn btn-default" type="submit">@localizer[nextPage < Model.Page ? "Previous" : "Next"]</button></form> }
-        @if (Model.Tab == "AssetDetail") {
-            <p><a asp-controller="Checklists" asp-action="Index">@localizer["Checklists"]</a> · <a asp-controller="WorkOrders" asp-action="Index" asp-route-AssetId="@Model.Id">@localizer["WorkOrders"]</a></p>
-        }
-        @if (Model.CanWrite || Model.CanTransfer || Model.CanIssue || Model.CanWitness) {
-            <hr/>
-            @if (Model.CanWrite && Model.Tab == "Items") {
-                foreach (var item in new[] { new InventoryItem() }.Concat(Model.Rows.OfType<InventoryItem>())) {
-                    var details = InventoryWorkspaceView.Details<InventoryItemContent>(item); var isNew = !Model.Rows.Contains(item);
-                    <details><summary>@localizer[isNew ? "NewItem" : "Edit"] @details.Name</summary><form asp-action="SaveItem" method="post" class="inventory-command">
-                    @Html.AntiForgeryToken()<input type="hidden" name="Id" value="@(isNew ? null : item.Id)"/><input type="hidden" name="Revision" value="@item.Revision"/>
-                    @Field("Details.Name", "Name", details.Name)@Field("Details.Description", "Description", details.Description)@Field("Details.UnitOfMeasure", "UnitOfMeasure", details.UnitOfMeasure)@Field("Details.Code", "Code", details.Code)@Field("Details.Barcode", "Barcode", details.Barcode)
-                    @Field("CategoryId", "Categories", item.CategoryId, options: categoryOptions)@Field("TrackingMode", "TrackingMode", item.TrackingMode, options: Codes("Tracking", 0, 1))
-                    @foreach (var flag in new[] { ("IsKit", item.IsKit), ("RequiresLotTracking", item.RequiresLotTracking), ("RequiresExpiration", item.RequiresExpiration), ("IsControlledSubstance", item.IsControlledSubstance), ("IsActive", item.IsActive) }) { @Field(flag.Item1, flag.Item1, flag.Item2.ToString().ToLowerInvariant(), options: new[] { new SelectListItem { Value = "false", Text = localizer["No"] }, new SelectListItem { Value = "true", Text = localizer["Yes"] } }) }
-                    @Field("Details.MinLevel", "Minimum", details.MinLevel, "number")@Field("Details.ReorderPoint", "ReorderPoint", details.ReorderPoint, "number")@Field("Details.DefaultUnitCost", "UnitCost", details.DefaultUnitCost, "number")
-                    @Field("Details.CurrencyCode", "M4Currency", details.CurrencyCode)<p>@localizer["M4CurrencyHelp"]</p>
-                    <p>@localizer["M4AverageUnitCost"]: @(details.AverageUnitCost?.ToString(CultureInfo.CurrentCulture) ?? localizer["M4UnknownCost"].Value)</p>
-                    @if (Model.CanChooseVendors) { @Field("Details.PreferredVendorId", "M4PreferredVendor", details.PreferredVendorId, options: vendorOptions) }
-                    else { <input type="hidden" name="Details.PreferredVendorId" value="@details.PreferredVendorId"/> }
-                    <input type="hidden" name="Details.MaxLevel" value="@details.MaxLevel?.ToString(CultureInfo.InvariantCulture)"/><input type="hidden" name="Details.ReorderQuantity" value="@details.ReorderQuantity?.ToString(CultureInfo.InvariantCulture)"/><input type="hidden" name="Details.DeaSchedule" value="@details.DeaSchedule"/><input type="hidden" name="Details.DefaultExpirationDays" value="@details.DefaultExpirationDays"/>
-                    <button class="btn btn-primary" type="submit">@localizer["Save"]</button></form></details>
+
+                @* ── Lists ───────────────────────────────────────────────────────── *@
+                @if (Model.Rows.Count == 0)
+                {
+                    <div class="text-center m-t-lg m-b-lg">
+                        <i class="fa fa-inbox fa-3x text-muted"></i>
+                        <h4 class="m-t-sm">@localizer["NoRows"]</h4>
+                        <p>@localizer["NoRowsHelp"]</p>
+                    </div>
+                }
+                else
+                {
+                    <div class="table-responsive">
+                        <table class="table table-striped rgw-table">
+                            @switch (Model.Tab)
+                            {
+                                case "OnHand":
+                                case "UnitEquipment":
+                                    <thead><tr><th>@localizer["Item"]</th><th>@localizer["Location"]</th><th class="text-right">@localizer["Quantity"]</th><th>@localizer["Status"]</th></tr></thead>
+                                    <tbody>
+                                        @foreach (var row in Model.Rows)
+                                        {
+                                            var stock = row as InventoryStock;
+                                            var held = row as InventoryAsset;
+                                            var content = held == null ? null : InventoryWorkspaceView.Details<InventoryAssetContent>(held);
+                                            <tr>
+                                                <td>
+                                                    @ItemName(stock?.ItemId ?? held?.ItemId)
+                                                    @if (content != null)
+                                                    {
+                                                        <small class="text-muted rgw-sub">@content.SerialNumber @content.AssetTag</small>
+                                                    }
+                                                </td>
+                                                <td>@LocationName(stock?.LocationId ?? held?.CurrentLocationId)</td>
+                                                <td class="text-right">@(stock != null ? stock.Quantity.ToString(CultureInfo.CurrentCulture) : "1")</td>
+                                                <td>
+                                                    @if (held != null)
+                                                    {
+                                                        <span class="label @AssetPill(held.Status)">@localizer["Status" + held.Status]</span>
+                                                    }
+                                                </td>
+                                            </tr>
+                                        }
+                                    </tbody>
+                                    break;
+
+                                case "Items":
+                                    <thead><tr><th>@localizer["Name"]</th><th>@localizer["Code"]</th><th>@localizer["Category"]</th><th>@localizer["TrackingMode"]</th><th>@localizer["Status"]</th><th class="rgw-row-actions">@localizer["Actions"]</th></tr></thead>
+                                    <tbody>
+                                        @foreach (var item in Model.Rows.OfType<InventoryItem>())
+                                        {
+                                            var details = InventoryWorkspaceView.Details<InventoryItemContent>(item);
+                                            <tr>
+                                                <td>
+                                                    @details.Name
+                                                    @if (!string.IsNullOrEmpty(details.UnitOfMeasure))
+                                                    {
+                                                        <small class="text-muted rgw-sub">@details.UnitOfMeasure</small>
+                                                    }
+                                                </td>
+                                                <td>@details.Code</td>
+                                                <td>@CategoryName(item.CategoryId)</td>
+                                                <td>
+                                                    <span class="label">@localizer["Tracking" + item.TrackingMode]</span>
+                                                    @if (item.IsControlledSubstance)
+                                                    {
+                                                        <span class="label label-warning">@localizer["IsControlledSubstance"]</span>
+                                                    }
+                                                </td>
+                                                <td><span class="label @(item.IsActive ? "label-success" : "")">@localizer[item.IsActive ? "Active" : "Inactive"]</span></td>
+                                                <td class="rgw-row-actions">
+                                                    @if (Model.CanWrite)
+                                                    {
+                                                        <button class="btn btn-xs btn-primary" type="button" data-toggle="modal" data-target="#rgw-item-@item.Id">@localizer["Edit"]</button>
+                                                        <form asp-action="Archive" method="post" class="inventory-command">
+                                                            @Html.AntiForgeryToken()
+                                                            @Hide("kind", "Items")@Hide("id", item.Id)@Hide("revision", item.Revision)
+                                                            <button class="btn btn-xs btn-danger" type="submit">@localizer["Archive"]</button>
+                                                        </form>
+                                                    }
+                                                </td>
+                                            </tr>
+                                        }
+                                    </tbody>
+                                    break;
+
+                                case "Categories":
+                                    <thead><tr><th>@localizer["Name"]</th><th>@localizer["Parent"]</th><th class="rgw-row-actions">@localizer["Actions"]</th></tr></thead>
+                                    <tbody>
+                                        @foreach (var category in Model.Rows.OfType<InventoryCategory>())
+                                        {
+                                            <tr>
+                                                <td>@(InventoryWorkspaceView.Details<InventoryLabel>(category).Name)</td>
+                                                <td>@CategoryName(category.ParentCategoryId)</td>
+                                                <td class="rgw-row-actions">
+                                                    @if (Model.CanWrite)
+                                                    {
+                                                        <button class="btn btn-xs btn-primary" type="button" data-toggle="modal" data-target="#rgw-category-@category.Id">@localizer["Edit"]</button>
+                                                        <form asp-action="Archive" method="post" class="inventory-command">
+                                                            @Html.AntiForgeryToken()
+                                                            @Hide("kind", "Categories")@Hide("id", category.Id)@Hide("revision", category.Revision)
+                                                            <button class="btn btn-xs btn-danger" type="submit">@localizer["Archive"]</button>
+                                                        </form>
+                                                    }
+                                                </td>
+                                            </tr>
+                                        }
+                                    </tbody>
+                                    break;
+
+                                case "Locations":
+                                    <thead><tr><th>@localizer["Name"]</th><th>@localizer["Type"]</th><th>@localizer["Parent"]</th><th>@localizer["DefaultLocation"]</th><th class="rgw-row-actions">@localizer["Actions"]</th></tr></thead>
+                                    <tbody>
+                                        @foreach (var place in Model.Rows.OfType<InventoryLocation>())
+                                        {
+                                            <tr>
+                                                <td>@(InventoryWorkspaceView.Details<InventoryLabel>(place).Name)</td>
+                                                <td><span class="label">@localizer["LocationType" + place.LocationType]</span></td>
+                                                <td>@LocationName(place.ParentLocationId)</td>
+                                                <td>@(place.IsDefault ? localizer["Yes"].Value : "")</td>
+                                                <td class="rgw-row-actions">
+                                                    @if (Model.CanWrite)
+                                                    {
+                                                        <button class="btn btn-xs btn-primary" type="button" data-toggle="modal" data-target="#rgw-location-@place.Id">@localizer["Edit"]</button>
+                                                        <form asp-action="Archive" method="post" class="inventory-command">
+                                                            @Html.AntiForgeryToken()
+                                                            @Hide("kind", "Locations")@Hide("id", place.Id)@Hide("revision", place.Revision)
+                                                            <button class="btn btn-xs btn-danger" type="submit">@localizer["Archive"]</button>
+                                                        </form>
+                                                    }
+                                                </td>
+                                            </tr>
+                                        }
+                                    </tbody>
+                                    break;
+
+                                case "Lots":
+                                    <thead><tr><th>@localizer["Batch"]</th><th>@localizer["Item"]</th><th>@localizer["Expires"]</th></tr></thead>
+                                    <tbody>
+                                        @foreach (var lot in Model.Rows.OfType<InventoryLot>())
+                                        {
+                                            var expired = lot.ExpiresOn.HasValue && lot.ExpiresOn.Value < DateTime.UtcNow;
+                                            <tr>
+                                                <td>@(InventoryWorkspaceView.Details<InventoryLotContent>(lot).LotNumber)</td>
+                                                <td>@ItemName(lot.ItemId)</td>
+                                                <td>
+                                                    @if (lot.ExpiresOn.HasValue)
+                                                    {
+                                                        <span class="label @(expired ? "label-danger" : "label-success")">@lot.ExpiresOn.Value.ToString("d", CultureInfo.CurrentCulture)</span>
+                                                    }
+                                                    else
+                                                    {
+                                                        <span class="label">@localizer["ForItemsNoExpiry"]</span>
+                                                    }
+                                                </td>
+                                            </tr>
+                                        }
+                                    </tbody>
+                                    break;
+
+                                case "Assets":
+                                    <thead><tr><th>@localizer["SerialNumber"]</th><th>@localizer["Item"]</th><th>@localizer["Location"]</th><th>@localizer["Status"]</th><th class="rgw-row-actions">@localizer["Actions"]</th></tr></thead>
+                                    <tbody>
+                                        @foreach (var asset in Model.Rows.OfType<InventoryAsset>())
+                                        {
+                                            var content = InventoryWorkspaceView.Details<InventoryAssetContent>(asset);
+                                            <tr>
+                                                <td>
+                                                    @content.SerialNumber
+                                                    @if (!string.IsNullOrEmpty(content.AssetTag))
+                                                    {
+                                                        <small class="text-muted rgw-sub">@content.AssetTag</small>
+                                                    }
+                                                </td>
+                                                <td>@ItemName(asset.ItemId)</td>
+                                                <td>@LocationName(asset.CurrentLocationId)</td>
+                                                <td><span class="label @AssetPill(asset.Status)">@localizer["Status" + asset.Status]</span></td>
+                                                <td class="rgw-row-actions">
+                                                    <form asp-action="Reopen" method="post" class="inventory-navigation">
+                                                        @Html.AntiForgeryToken()
+                                                        @Hide("tab", "AssetDetail")@Hide("id", asset.Id)
+                                                        <button class="btn btn-xs btn-info" type="submit">@localizer["ViewHistory"]</button>
+                                                    </form>
+                                                </td>
+                                            </tr>
+                                        }
+                                    </tbody>
+                                    break;
+
+                                case "Issuances":
+                                case "PersonnelGear":
+                                    <thead><tr><th>@localizer["Item"]</th><th>@localizer["Location"]</th><th class="text-right">@localizer["Outstanding"]</th><th>@localizer["ExpectedReturn"]</th><th>@localizer["Status"]</th><th class="rgw-row-actions">@localizer["Actions"]</th></tr></thead>
+                                    <tbody>
+                                        @foreach (var issued in Model.Rows.OfType<InventoryIssuance>())
+                                        {
+                                            var overdue = issued.ExpectedReturnOn.HasValue && issued.ExpectedReturnOn.Value < DateTime.UtcNow && issued.Status is 0 or 2;
+                                            <tr>
+                                                <td>@ItemName(issued.ItemId)</td>
+                                                <td>@LocationName(issued.LocationId)</td>
+                                                <td class="text-right">@((issued.Quantity - issued.ReturnedQuantity).ToString(CultureInfo.CurrentCulture))</td>
+                                                <td>
+                                                    @if (issued.ExpectedReturnOn.HasValue)
+                                                    {
+                                                        <span class="label @(overdue ? "label-danger" : "label-default")">@issued.ExpectedReturnOn.Value.ToString("d", CultureInfo.CurrentCulture)</span>
+                                                    }
+                                                </td>
+                                                <td><span class="label @IssuancePill(issued.Status)">@localizer["IssuanceStatus" + issued.Status]</span></td>
+                                                <td class="rgw-row-actions">
+                                                    @if (Model.CanIssue && issued.Status is 0 or 2)
+                                                    {
+                                                        <button class="btn btn-xs btn-primary" type="button" data-toggle="modal" data-target="#rgw-return-@issued.Id">@localizer["Return"]</button>
+                                                    }
+                                                </td>
+                                            </tr>
+                                        }
+                                    </tbody>
+                                    break;
+
+                                case "Kits":
+                                    <thead><tr><th>@localizer["Name"]</th><th>@localizer["Contents"]</th><th class="rgw-row-actions">@localizer["Actions"]</th></tr></thead>
+                                    <tbody>
+                                        @foreach (var kit in Model.Rows.OfType<InventoryKit>())
+                                        {
+                                            var lines = Model.KitContents.Where(k => k.KitId == kit.Id && !k.IsDeleted).ToList();
+                                            var issueCount = lines.Sum(k => Model.Items.FirstOrDefault(i => i.Id == k.ItemId)?.TrackingMode == (int)InventoryTrackingMode.Serialized ? k.Quantity : 1);
+                                            var issuable = lines.Count > 0 && issueCount <= 100 && lines.All(k => Model.Items.Any(i => i.Id == k.ItemId));
+                                            <tr>
+                                                <td>@(InventoryWorkspaceView.Details<InventoryLabel>(kit).Name)</td>
+                                                <td>
+                                                    @if (lines.Count == 0)
+                                                    {
+                                                        <span class="label">@localizer["NoRows"]</span>
+                                                    }
+                                                    else
+                                                    {
+                                                        @string.Join(", ", lines.Select(k => ItemName(k.ItemId) + " ×" + k.Quantity.ToString(CultureInfo.CurrentCulture)))
+                                                    }
+                                                </td>
+                                                <td class="rgw-row-actions">
+                                                    @if (Model.CanIssue && issuable)
+                                                    {
+                                                        <button class="btn btn-primary btn-xs" type="button" data-toggle="modal" data-target="#rgw-issue-kit-@kit.Id">@localizer["Issue"]</button>
+                                                    }
+                                                    else if (Model.CanIssue && lines.Count > 0)
+                                                    {
+                                                        <span class="label label-warning">@localizer["UnableToComplete"]</span>
+                                                    }
+                                                    @if (Model.CanWrite)
+                                                    {
+                                                        <button class="btn btn-xs btn-primary" type="button" data-toggle="modal" data-target="#rgw-kit-@kit.Id">@localizer["Edit"]</button>
+                                                        <form asp-action="Archive" method="post" class="inventory-command">
+                                                            @Html.AntiForgeryToken()
+                                                            @Hide("kind", "Kits")@Hide("id", kit.Id)@Hide("revision", kit.Revision)
+                                                            <button class="btn btn-xs btn-danger" type="submit">@localizer["Archive"]</button>
+                                                        </form>
+                                                    }
+                                                </td>
+                                            </tr>
+                                        }
+                                    </tbody>
+                                    break;
+
+                                case "Transfers":
+                                    <thead><tr><th>@localizer["FromLocation"]</th><th>@localizer["ToLocation"]</th><th>@localizer["When"]</th></tr></thead>
+                                    <tbody>
+                                        @foreach (var transfer in Model.Rows.OfType<InventoryTransfer>())
+                                        {
+                                            <tr>
+                                                <td>@LocationName(transfer.FromLocationId)</td>
+                                                <td>@LocationName(transfer.ToLocationId)</td>
+                                                <td><time datetime="@transfer.CreatedOn.ToString("u")">@transfer.CreatedOn.ToString("g", CultureInfo.CurrentCulture)</time></td>
+                                            </tr>
+                                        }
+                                    </tbody>
+                                    break;
+
+                                default:
+                                    @* History, AssetDetail and Transaction all show the ledger. *@
+                                    <thead><tr><th>@localizer["When"]</th><th>@localizer["Movement"]</th><th>@localizer["Item"]</th><th>@localizer["Location"]</th><th class="text-right">@localizer["Quantity"]</th><th>@localizer["Details"]</th></tr></thead>
+                                    <tbody>
+                                        @foreach (var row in Model.Rows)
+                                        {
+                                            if (row is InventoryAsset header)
+                                            {
+                                                var content = InventoryWorkspaceView.Details<InventoryAssetContent>(header);
+                                                <tr>
+                                                    <td colspan="6">
+                                                        <h3 class="m-t-none">@ItemName(header.ItemId) · @content.SerialNumber</h3>
+                                                        <span class="label @AssetPill(header.Status)">@localizer["Status" + header.Status]</span>
+                                                        <span class="text-muted">@content.AssetTag &middot; @LocationName(header.CurrentLocationId)</span>
+                                                    </td>
+                                                </tr>
+                                                continue;
+                                            }
+
+                                            var txn = row as InventoryTransaction;
+                                            if (txn == null)
+                                            {
+                                                continue;
+                                            }
+                                            var note = InventoryWorkspaceView.Details<InventoryLabel>(txn).Note;
+                                            <tr>
+                                                <td><time datetime="@txn.OccurredOn.ToString("u")">@txn.OccurredOn.ToString("g", CultureInfo.CurrentCulture)</time></td>
+                                                <td><span class="label">@localizer["Movement" + txn.TransactionType]</span></td>
+                                                <td>@ItemName(txn.ItemId)</td>
+                                                <td class="rgw-flow">
+                                                    @LocationName(txn.FromLocationId)
+                                                    @if (!string.IsNullOrEmpty(txn.FromLocationId) && !string.IsNullOrEmpty(txn.ToLocationId))
+                                                    {
+                                                        <i class="fa fa-long-arrow-right"></i>
+                                                    }
+                                                    @LocationName(txn.ToLocationId)
+                                                </td>
+                                                <td class="text-right">@txn.Quantity.ToString(CultureInfo.CurrentCulture)</td>
+                                                <td>
+                                                    @if (!string.IsNullOrEmpty(note))
+                                                    {
+                                                        <div>@note</div>
+                                                    }
+                                                    <small class="text-muted rgw-sub">@localizer["Reference"]: @txn.ReferenceType / @txn.ReferenceId</small>
+                                                    @if (txn.ReferenceType == (int)InventoryReferenceType.WorkOrder && int.TryParse(txn.ReferenceId, out var orderId) && orderId > 0)
+                                                    {
+                                                        <a asp-controller="WorkOrders" asp-action="Detail" asp-route-id="@orderId">@localizer["WorkOrders"]</a>
+                                                    }
+                                                </td>
+                                            </tr>
+                                        }
+                                    </tbody>
+                                    break;
+                            }
+                        </table>
+                    </div>
+                }
+
+                @if (Model.Tab == "AssetDetail")
+                {
+                    <p class="m-t">
+                        <a asp-controller="Checklists" asp-action="Index">@localizer["Checklists"]</a> ·
+                        <a asp-controller="WorkOrders" asp-action="Index" asp-route-AssetId="@Model.Id">@localizer["WorkOrders"]</a>
+                    </p>
+                }
+
+                @if (Model.Page > 0 || Model.HasMore)
+                {
+                    <div class="rgw-pager">
+                        @foreach (var nextPage in new[] { Model.Page - 1, Model.Page + 1 }.Where(p => p >= 0 && (p < Model.Page || Model.HasMore)))
+                        {
+                            <form asp-action="Reopen" method="post" class="inventory-navigation">
+                                @Html.AntiForgeryToken()
+                                @Hide("tab", Model.Tab)@Hide("page", nextPage)@Hide("id", Model.Id)
+                                @Hide("unitId", Model.UnitId)@Hide("userId", Model.UserId)
+                                @Hide("itemId", Model.ItemId)@Hide("locationId", Model.LocationId)
+                                <button class="btn btn-default btn-sm" type="submit">
+                                    <i class="fa @(nextPage < Model.Page ? "fa-chevron-left" : "fa-chevron-right")"></i>
+                                    @localizer[nextPage < Model.Page ? "Previous" : "Next"]
+                                </button>
+                            </form>
+                        }
+                        <span class="text-muted">@(Model.Page + 1)</span>
+                    </div>
+                }
+
+                @* ── Wizards and dialogs ─────────────────────────────────────────── *@
+
+                @if (Model.CanWrite && Model.Tab == "Items")
+                {
+                    @* One dialog for a brand new item, plus one per item on the page. *@
+                    foreach (var item in new[] { new InventoryItem() }.Concat(Model.Rows.OfType<InventoryItem>()))
+                    {
+                        var details = InventoryWorkspaceView.Details<InventoryItemContent>(item);
+                        var isNew = !Model.Rows.Contains(item);
+                        var dialogId = isNew ? "rgw-new-item" : "rgw-item-" + item.Id;
+                        <div class="modal fade rgw-modal" id="@dialogId" tabindex="-1" role="dialog" aria-labelledby="@(dialogId)-title">
+                            <div class="modal-dialog modal-lg" role="document">
+                                <div class="modal-content">
+                                    <div class="modal-header">
+                                        <button type="button" class="close" data-dismiss="modal" aria-label="@localizer["Close"]"><span aria-hidden="true">&times;</span></button>
+                                        <h4 class="modal-title" id="@(dialogId)-title">@(isNew ? localizer["NewItem"].Value : localizer["EditItem"].Value + " · " + details.Name)</h4>
+                                    </div>
+                                    <div class="modal-body">
+                                        <div class="alert rgw-modal-message" role="status"></div>
+                                        <form asp-action="SaveItem" method="post" class="inventory-command rgw-wizard">
+                                            @Html.AntiForgeryToken()
+                                            @Hide("Id", isNew ? null : item.Id)@Hide("Revision", item.Revision)
+                                            @Hide("Details.MaxLevel", details.MaxLevel?.ToString(CultureInfo.InvariantCulture))
+                                            @Hide("Details.ReorderQuantity", details.ReorderQuantity?.ToString(CultureInfo.InvariantCulture))
+                                            @Hide("Details.DeaSchedule", details.DeaSchedule)
+                                            @Hide("Details.DefaultExpirationDays", details.DefaultExpirationDays)
+                                            @if (!Model.CanChooseVendors)
+                                            {
+                                                @Hide("Details.PreferredVendorId", details.PreferredVendorId)
+                                            }
+
+                                            <ol class="rgw-steps"></ol>
+
+                                            <div class="rgw-step" data-title="@localizer["StepItemBasics"]">
+                                                <h4>@localizer["StepItemBasics"]</h4>
+                                                <p class="text-muted">@localizer["StepItemBasicsHint"]</p>
+                                                <div class="rgw-grid">
+                                                    @Field("Details.Name", "Name", details.Name, required: true, maxLength: 250)
+                                                    @Field("Details.UnitOfMeasure", "UnitOfMeasure", details.UnitOfMeasure, help: "HelpFieldUnitOfMeasure", maxLength: 80)
+                                                    @Field("Details.Code", "Code", details.Code, help: "HelpFieldCode", maxLength: 80)
+                                                    @Field("Details.Barcode", "Barcode", details.Barcode, maxLength: 250)
+                                                    @Field("CategoryId", "Category", item.CategoryId, options: categoryOptions, help: "HelpFieldCategory")
+                                                    @Field("Details.Description", "Description", details.Description, "textarea", wide: true)
+                                                </div>
+                                            </div>
+
+                                            <div class="rgw-step" data-title="@localizer["StepItemTracking"]">
+                                                <h4>@localizer["StepItemTracking"]</h4>
+                                                <p class="text-muted">@localizer["StepItemTrackingHint"]</p>
+                                                <div class="rgw-grid">
+                                                    @Field("TrackingMode", "TrackingMode", item.TrackingMode, options: Codes("Tracking", 0, 1), help: "HelpFieldTrackingMode", wide: true)
+                                                    @Field("RequiresLotTracking", "RequiresLotTracking", item.RequiresLotTracking.ToString().ToLowerInvariant(), "checkbox", help: "HelpFieldRequiresLotTracking")
+                                                    @Field("RequiresExpiration", "RequiresExpiration", item.RequiresExpiration.ToString().ToLowerInvariant(), "checkbox", help: "HelpFieldRequiresExpiration")
+                                                    @Field("IsControlledSubstance", "IsControlledSubstance", item.IsControlledSubstance.ToString().ToLowerInvariant(), "checkbox", help: "HelpFieldIsControlledSubstance")
+                                                    @Field("IsKit", "IsKit", item.IsKit.ToString().ToLowerInvariant(), "checkbox", help: "HelpFieldIsKit")
+                                                    @Field("IsActive", "IsActive", item.IsActive.ToString().ToLowerInvariant(), "checkbox", help: "HelpFieldIsActive")
+                                                </div>
+                                            </div>
+
+                                            <div class="rgw-step" data-title="@localizer["StepItemStock"]">
+                                                <h4>@localizer["StepItemStock"]</h4>
+                                                <p class="text-muted">@localizer["StepItemStockHint"]</p>
+                                                <div class="rgw-grid">
+                                                    @Field("Details.MinLevel", "Minimum", details.MinLevel, "number", help: "HelpFieldMinimum", min: "0")
+                                                    @Field("Details.ReorderPoint", "ReorderPoint", details.ReorderPoint, "number", help: "HelpFieldReorderPoint", min: "0")
+                                                    @Field("Details.DefaultUnitCost", "UnitCost", details.DefaultUnitCost, "number", help: "HelpFieldUnitCost", min: "0")
+                                                    @Field("Details.CurrencyCode", "M4Currency", details.CurrencyCode, help: "HelpFieldCurrency", maxLength: 3)
+                                                    @if (Model.CanChooseVendors)
+                                                    {
+                                                        @Field("Details.PreferredVendorId", "M4PreferredVendor", details.PreferredVendorId, options: vendorOptions)
+                                                    }
+                                                </div>
+                                                <p class="text-muted">@localizer["M4AverageUnitCost"]: @(details.AverageUnitCost?.ToString(CultureInfo.CurrentCulture) ?? localizer["M4UnknownCost"].Value)</p>
+                                            </div>
+
+                                            <div class="rgw-step" data-title="@localizer["Review"]">
+                                                <h4>@localizer["Review"]</h4>
+                                                <p class="text-muted">@localizer["ReviewHint"]</p>
+                                                <dl class="rgw-review"></dl>
+                                            </div>
+
+                                            <div class="rgw-wizard-actions">
+                                                <button type="button" class="btn btn-white rgw-step-prev">@localizer["Back"]</button>
+                                                <div class="rgw-wizard-spacer"></div>
+                                                <button type="button" class="btn btn-white" data-dismiss="modal">@localizer["Close"]</button>
+                                                <button type="button" class="btn btn-primary rgw-step-next">@localizer["Continue"]</button>
+                                                <button type="submit" class="btn btn-primary rgw-step-submit">@localizer["Save"]</button>
+                                            </div>
+                                        </form>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    }
+                }
+
+                @if (Model.CanWrite && Model.Tab == "Categories")
+                {
+                    foreach (var category in new InventoryCategory[] { null }.Concat(Model.Rows.OfType<InventoryCategory>()))
+                    {
+                        var isNew = category == null;
+                        var dialogId = isNew ? "rgw-new-category" : "rgw-category-" + category.Id;
+                        var name = isNew ? null : InventoryWorkspaceView.Details<InventoryLabel>(category).Name;
+                        <div class="modal fade rgw-modal" id="@dialogId" tabindex="-1" role="dialog" aria-labelledby="@(dialogId)-title">
+                            <div class="modal-dialog" role="document">
+                                <div class="modal-content">
+                                    <div class="modal-header">
+                                        <button type="button" class="close" data-dismiss="modal" aria-label="@localizer["Close"]"><span aria-hidden="true">&times;</span></button>
+                                        <h4 class="modal-title" id="@(dialogId)-title">@(isNew ? localizer["NewCategory"].Value : localizer["Edit"].Value + " · " + name)</h4>
+                                    </div>
+                                    <div class="modal-body">
+                                        <div class="alert rgw-modal-message" role="status"></div>
+                                        <p class="text-muted">@localizer["HelpCategories"]</p>
+                                        <form asp-action="SaveCategory" method="post" class="inventory-command">
+                                            @Html.AntiForgeryToken()
+                                            @if (!isNew)
+                                            {
+                                                @Hide("id", category.Id)@Hide("revision", category.Revision)
+                                            }
+                                            <div class="rgw-grid">
+                                                @Field("name", "Name", name, required: true, maxLength: 250, wide: true)
+                                                @Field("parentId", "Parent", isNew ? null : category.ParentCategoryId, options: categoryOptions, help: "HelpFieldParent", wide: true)
+                                            </div>
+                                            <div class="rgw-wizard-actions">
+                                                <div class="rgw-wizard-spacer"></div>
+                                                <button type="button" class="btn btn-white" data-dismiss="modal">@localizer["Close"]</button>
+                                                <button type="submit" class="btn btn-primary">@localizer["Save"]</button>
+                                            </div>
+                                        </form>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    }
+                }
+
+                @if (Model.CanWrite && Model.Tab == "Locations")
+                {
+                    @* New locations get the full wizard; editing an existing one only renames it,
+                       because the placement fields are carried through unchanged. *@
+                    <div class="modal fade rgw-modal" id="rgw-new-location" tabindex="-1" role="dialog" aria-labelledby="rgw-new-location-title">
+                        <div class="modal-dialog modal-lg" role="document">
+                            <div class="modal-content">
+                                <div class="modal-header">
+                                    <button type="button" class="close" data-dismiss="modal" aria-label="@localizer["Close"]"><span aria-hidden="true">&times;</span></button>
+                                    <h4 class="modal-title" id="rgw-new-location-title">@localizer["NewLocation"]</h4>
+                                </div>
+                                <div class="modal-body">
+                                    <div class="alert rgw-modal-message" role="status"></div>
+                                    <form asp-action="SaveLocation" method="post" class="inventory-command rgw-wizard">
+                                        @Html.AntiForgeryToken()
+                                        <ol class="rgw-steps"></ol>
+
+                                        <div class="rgw-step" data-title="@localizer["StepLocationBasics"]">
+                                            <h4>@localizer["StepLocationBasics"]</h4>
+                                            <p class="text-muted">@localizer["StepLocationBasicsHint"]</p>
+                                            <div class="rgw-grid">
+                                                @Field("Name", "Name", null, required: true, maxLength: 250)
+                                                @Field("Type", "LocationType", 0, options: Codes("LocationType", 0, 1, 2, 3, 4, 5), help: "HelpFieldLocationType")
+                                            </div>
+                                        </div>
+
+                                        <div class="rgw-step" data-title="@localizer["StepLocationScope"]">
+                                            <h4>@localizer["StepLocationScope"]</h4>
+                                            <p class="text-muted">@localizer["StepLocationScopeHint"]</p>
+                                            <div class="rgw-grid">
+                                                @Field("GroupId", "Station", null, options: Choice(Model.Groups))
+                                                @Field("UnitId", "Unit", null, options: Choice(Model.Units))
+                                                @Field("UserId", "Person", null, options: Choice(Model.People))
+                                                @Field("ContainerAssetId", "ContainerAsset", null, options: assetOptions)
+                                                @Field("ParentLocationId", "Parent", null, options: locationOptions, help: "HelpFieldParent")
+                                                @Field("IsDefault", "DefaultLocation", "false", "checkbox", help: "HelpFieldDefaultLocation")
+                                            </div>
+                                        </div>
+
+                                        <div class="rgw-step" data-title="@localizer["Review"]">
+                                            <h4>@localizer["Review"]</h4>
+                                            <p class="text-muted">@localizer["ReviewHint"]</p>
+                                            <dl class="rgw-review"></dl>
+                                        </div>
+
+                                        <div class="rgw-wizard-actions">
+                                            <button type="button" class="btn btn-white rgw-step-prev">@localizer["Back"]</button>
+                                            <div class="rgw-wizard-spacer"></div>
+                                            <button type="button" class="btn btn-white" data-dismiss="modal">@localizer["Close"]</button>
+                                            <button type="button" class="btn btn-primary rgw-step-next">@localizer["Continue"]</button>
+                                            <button type="submit" class="btn btn-primary rgw-step-submit">@localizer["Save"]</button>
+                                        </div>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    foreach (var place in Model.Rows.OfType<InventoryLocation>())
+                    {
+                        <div class="modal fade rgw-modal" id="rgw-location-@place.Id" tabindex="-1" role="dialog" aria-labelledby="rgw-location-@(place.Id)-title">
+                            <div class="modal-dialog" role="document">
+                                <div class="modal-content">
+                                    <div class="modal-header">
+                                        <button type="button" class="close" data-dismiss="modal" aria-label="@localizer["Close"]"><span aria-hidden="true">&times;</span></button>
+                                        <h4 class="modal-title" id="rgw-location-@(place.Id)-title">@localizer["Edit"] · @(InventoryWorkspaceView.Details<InventoryLabel>(place).Name)</h4>
+                                    </div>
+                                    <div class="modal-body">
+                                        <div class="alert rgw-modal-message" role="status"></div>
+                                        <p class="text-muted">@localizer["HelpLocationRename"]</p>
+                                        <form asp-action="SaveLocation" method="post" class="inventory-command">
+                                            @Html.AntiForgeryToken()
+                                            @Hide("Id", place.Id)@Hide("Revision", place.Revision)@Hide("Type", place.LocationType)
+                                            @Hide("GroupId", place.GroupId)@Hide("UnitId", place.UnitId)@Hide("UserId", place.UserId)
+                                            @Hide("ContainerAssetId", place.ContainerAssetId)@Hide("ParentLocationId", place.ParentLocationId)
+                                            @Hide("IsDefault", place.IsDefault.ToString().ToLowerInvariant())
+                                            <div class="rgw-grid">
+                                                @Field("Name", "Name", InventoryWorkspaceView.Details<InventoryLabel>(place).Name, required: true, maxLength: 250, wide: true)
+                                            </div>
+                                            <div class="rgw-wizard-actions">
+                                                <div class="rgw-wizard-spacer"></div>
+                                                <button type="button" class="btn btn-white" data-dismiss="modal">@localizer["Close"]</button>
+                                                <button type="submit" class="btn btn-primary">@localizer["Save"]</button>
+                                            </div>
+                                        </form>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    }
+                }
+
+                @if (Model.CanWrite && Model.Tab == "Lots")
+                {
+                    <div class="modal fade rgw-modal" id="rgw-new-lot" tabindex="-1" role="dialog" aria-labelledby="rgw-new-lot-title">
+                        <div class="modal-dialog modal-lg" role="document">
+                            <div class="modal-content">
+                                <div class="modal-header">
+                                    <button type="button" class="close" data-dismiss="modal" aria-label="@localizer["Close"]"><span aria-hidden="true">&times;</span></button>
+                                    <h4 class="modal-title" id="rgw-new-lot-title">@localizer["NewLot"]</h4>
+                                </div>
+                                <div class="modal-body">
+                                    <div class="alert rgw-modal-message" role="status"></div>
+                                    <form asp-action="CreateLot" method="post" class="inventory-command rgw-wizard">
+                                        @Html.AntiForgeryToken()
+                                        <ol class="rgw-steps"></ol>
+
+                                        <div class="rgw-step" data-title="@localizer["StepLotItem"]">
+                                            <h4>@localizer["StepLotItem"]</h4>
+                                            <p class="text-muted">@localizer["StepLotItemHint"]</p>
+                                            <div class="rgw-grid">
+                                                @Field("itemId", "Items", null, options: itemOptions, required: true, wide: true)
+                                            </div>
+                                        </div>
+
+                                        <div class="rgw-step" data-title="@localizer["StepLotDetails"]">
+                                            <h4>@localizer["StepLotDetails"]</h4>
+                                            <p class="text-muted">@localizer["StepLotDetailsHint"]</p>
+                                            <div class="rgw-grid">
+                                                @Field("details.LotNumber", "Batch", null, required: true, maxLength: 250)
+                                                @Field("expiresOn", "Expiration", null, "date", help: "HelpFieldExpiration")
+                                                @Field("details.UnitCost", "UnitCost", null, "number", help: "HelpFieldUnitCost", min: "0")
+                                                @if (Model.CanChooseVendors)
+                                                {
+                                                    @Field("details.VendorId", "M4Supplier", null, options: vendorOptions)
+                                                }
+                                            </div>
+                                        </div>
+
+                                        <div class="rgw-step" data-title="@localizer["Review"]">
+                                            <h4>@localizer["Review"]</h4>
+                                            <p class="text-muted">@localizer["ReviewHint"]</p>
+                                            <dl class="rgw-review"></dl>
+                                        </div>
+
+                                        <div class="rgw-wizard-actions">
+                                            <button type="button" class="btn btn-white rgw-step-prev">@localizer["Back"]</button>
+                                            <div class="rgw-wizard-spacer"></div>
+                                            <button type="button" class="btn btn-white" data-dismiss="modal">@localizer["Close"]</button>
+                                            <button type="button" class="btn btn-primary rgw-step-next">@localizer["Continue"]</button>
+                                            <button type="submit" class="btn btn-primary rgw-step-submit">@localizer["Save"]</button>
+                                        </div>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                }
+
+                @if (Model.CanWrite && Model.Tab == "Assets")
+                {
+                    <div class="modal fade rgw-modal" id="rgw-new-asset" tabindex="-1" role="dialog" aria-labelledby="rgw-new-asset-title">
+                        <div class="modal-dialog modal-lg" role="document">
+                            <div class="modal-content">
+                                <div class="modal-header">
+                                    <button type="button" class="close" data-dismiss="modal" aria-label="@localizer["Close"]"><span aria-hidden="true">&times;</span></button>
+                                    <h4 class="modal-title" id="rgw-new-asset-title">@localizer["NewAsset"]</h4>
+                                </div>
+                                <div class="modal-body">
+                                    <div class="alert rgw-modal-message" role="status"></div>
+                                    <form asp-action="CreateAsset" method="post" class="inventory-command rgw-wizard" data-inventory-create-asset="true">
+                                        @Html.AntiForgeryToken()
+                                        @Hide("RequestId", Guid.NewGuid().ToString("D"))
+                                        <ol class="rgw-steps"></ol>
+
+                                        <div class="rgw-step" data-title="@localizer["StepAssetItem"]">
+                                            <h4>@localizer["StepAssetItem"]</h4>
+                                            <p class="text-muted">@localizer["StepAssetItemHint"]</p>
+                                            <div class="rgw-grid">
+                                                @Field("ItemId", "Items", null, options: itemOptions, required: true)
+                                                @Field("LocationId", "Location", null, options: locationOptions, required: true)
+                                                @Field("LotId", "LotId", null, options: lotOptions, help: "HelpFieldLot")
+                                            </div>
+                                        </div>
+
+                                        <div class="rgw-step" data-title="@localizer["StepAssetIdentity"]">
+                                            <h4>@localizer["StepAssetIdentity"]</h4>
+                                            <p class="text-muted">@localizer["StepAssetIdentityHint"]</p>
+                                            <div class="rgw-grid">
+                                                @Field("Details.SerialNumber", "SerialNumber", null, required: true, help: "HelpFieldSerialNumber", maxLength: 250)
+                                                @Field("Details.AssetTag", "AssetTag", null, maxLength: 250)
+                                                @Field("Details.Barcode", "Barcode", null, maxLength: 250)
+                                                @Field("Details.AcquisitionCost", "UnitCost", null, "number", help: "HelpFieldUnitCost", min: "0")
+                                                @Field("ExpiresOn", "Expiration", null, "date", help: "HelpFieldExpiration")
+                                            </div>
+                                        </div>
+
+                                        <div class="rgw-step" data-title="@localizer["Review"]">
+                                            <h4>@localizer["Review"]</h4>
+                                            <p class="text-muted">@localizer["ReviewHint"]</p>
+                                            <dl class="rgw-review"></dl>
+                                        </div>
+
+                                        <div class="rgw-wizard-actions">
+                                            <button type="button" class="btn btn-white rgw-step-prev">@localizer["Back"]</button>
+                                            <div class="rgw-wizard-spacer"></div>
+                                            <button type="button" class="btn btn-white" data-dismiss="modal">@localizer["Close"]</button>
+                                            <button type="button" class="btn btn-primary rgw-step-next">@localizer["Continue"]</button>
+                                            <button type="submit" class="btn btn-primary rgw-step-submit">@localizer["NewAsset"]</button>
+                                        </div>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                }
+
+                @if ((Model.CanWrite && Model.Tab == "OnHand") || (Model.CanTransfer && Model.Tab == "Transfers"))
+                {
+                    var isTransfer = Model.Tab == "Transfers";
+                    <div class="modal fade rgw-modal" id="rgw-post-movement" tabindex="-1" role="dialog" aria-labelledby="rgw-post-movement-title">
+                        <div class="modal-dialog modal-lg" role="document">
+                            <div class="modal-content">
+                                <div class="modal-header">
+                                    <button type="button" class="close" data-dismiss="modal" aria-label="@localizer["Close"]"><span aria-hidden="true">&times;</span></button>
+                                    <h4 class="modal-title" id="rgw-post-movement-title">@localizer[isTransfer ? "NewTransfer" : "AdjustStock"]</h4>
+                                </div>
+                                <div class="modal-body">
+                                    <div class="alert rgw-modal-message" role="status"></div>
+                                    <form asp-action="@(isTransfer ? "Transfer" : "Post")" method="post" class="inventory-command rgw-wizard">
+                                        @Html.AntiForgeryToken()
+                                        @Hide("RequestId", Guid.NewGuid().ToString("D"))
+                                        <ol class="rgw-steps"></ol>
+
+                                        <div class="rgw-step" data-title="@localizer["StepMovementWhat"]">
+                                            <h4>@localizer["StepMovementWhat"]</h4>
+                                            <p class="text-muted">@localizer["StepMovementWhatHint"]</p>
+                                            <div class="rgw-grid">
+                                                @Field("Lines[0].Type", "Movement", isTransfer ? 3 : 1, options: isTransfer ? Codes("Movement", 3) : Codes("Movement", 1, 2, 6, 8), help: "MovementHelp", wide: true)
+                                                @Field("Lines[0].ItemId", "Items", null, options: itemOptions, required: true)
+                                                @Field("Lines[0].AssetId", "AssetId", null, options: assetOptions, help: "HelpFieldAsset")
+                                                @Field("Lines[0].LotId", "LotId", null, options: lotOptions, help: "HelpFieldLot")
+                                            </div>
+                                        </div>
+
+                                        <div class="rgw-step" data-title="@localizer["StepMovementWhere"]">
+                                            <h4>@localizer["StepMovementWhere"]</h4>
+                                            <p class="text-muted">@localizer["StepMovementWhereHint"]</p>
+                                            <div class="rgw-grid">
+                                                @Field("Lines[0].FromLocationId", "FromLocation", null, options: locationOptions, help: "HelpFieldFromLocation")
+                                                @Field("Lines[0].ToLocationId", "ToLocation", null, options: locationOptions, help: "HelpFieldToLocation")
+                                            </div>
+                                        </div>
+
+                                        <div class="rgw-step" data-title="@localizer["StepMovementAmount"]">
+                                            <h4>@localizer["StepMovementAmount"]</h4>
+                                            <p class="text-muted">@localizer["StepMovementAmountHint"]</p>
+                                            <div class="rgw-grid">
+                                                @Field("Lines[0].Quantity", "Amount", null, "number", help: "HelpFieldAmount", required: true, min: "0")
+                                                @if (!isTransfer)
+                                                {
+                                                    @Field("Lines[0].UnitCost", "UnitCost", null, "number", help: "HelpFieldUnitCost", min: "0")
+                                                }
+                                                @Field("Lines[0].Note", "Note", null, "textarea", help: "HelpFieldNote", wide: true)
+                                            </div>
+                                        </div>
+
+                                        <div class="rgw-step" data-title="@localizer["Review"]">
+                                            <h4>@localizer["Review"]</h4>
+                                            <p class="text-muted">@localizer["ReviewHint"]</p>
+                                            <dl class="rgw-review"></dl>
+                                        </div>
+
+                                        <div class="rgw-wizard-actions">
+                                            <button type="button" class="btn btn-white rgw-step-prev">@localizer["Back"]</button>
+                                            <div class="rgw-wizard-spacer"></div>
+                                            <button type="button" class="btn btn-white" data-dismiss="modal">@localizer["Close"]</button>
+                                            <button type="button" class="btn btn-primary rgw-step-next">@localizer["Continue"]</button>
+                                            <button type="submit" class="btn btn-primary rgw-step-submit">@localizer["PostMovement"]</button>
+                                        </div>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                }
+
+                @if (Model.CanIssue && Model.Tab == "Issuances")
+                {
+                    <div class="modal fade rgw-modal" id="rgw-issue" tabindex="-1" role="dialog" aria-labelledby="rgw-issue-title">
+                        <div class="modal-dialog modal-lg" role="document">
+                            <div class="modal-content">
+                                <div class="modal-header">
+                                    <button type="button" class="close" data-dismiss="modal" aria-label="@localizer["Close"]"><span aria-hidden="true">&times;</span></button>
+                                    <h4 class="modal-title" id="rgw-issue-title">@localizer["IssueEquipment"]</h4>
+                                </div>
+                                <div class="modal-body">
+                                    <div class="alert rgw-modal-message" role="status"></div>
+                                    <form asp-action="Issue" method="post" class="inventory-command rgw-wizard">
+                                        @Html.AntiForgeryToken()
+                                        @Hide("RequestId", Guid.NewGuid().ToString("D"))
+                                        <ol class="rgw-steps"></ol>
+
+                                        <div class="rgw-step" data-title="@localizer["StepIssueWhat"]">
+                                            <h4>@localizer["StepIssueWhat"]</h4>
+                                            <p class="text-muted">@localizer["StepIssueWhatHint"]</p>
+                                            <div class="rgw-grid">
+                                                @Field("ItemId", "Items", null, options: itemOptions, required: true)
+                                                @Field("FromLocationId", "FromLocation", null, options: locationOptions, required: true, help: "HelpFieldFromLocation")
+                                                @Field("AssetId", "AssetId", null, options: assetOptions, help: "HelpFieldAsset")
+                                                @Field("LotId", "LotId", null, options: lotOptions, help: "HelpFieldLot")
+                                                @Field("Quantity", "Amount", null, "number", help: "HelpFieldAmount", required: true, min: "0")
+                                            </div>
+                                        </div>
+
+                                        <div class="rgw-step" data-title="@localizer["StepIssueWho"]">
+                                            <h4>@localizer["StepIssueWho"]</h4>
+                                            <p class="text-muted">@localizer["HolderHelp"]</p>
+                                            <div class="rgw-grid">
+                                                @Field("UserId", "Person", null, options: Choice(Model.People), help: "HelpFieldHolder")
+                                                @Field("UnitId", "Unit", null, options: Choice(Model.Units), help: "HelpFieldHolder")
+                                            </div>
+                                        </div>
+
+                                        <div class="rgw-step" data-title="@localizer["StepIssueWhen"]">
+                                            <h4>@localizer["StepIssueWhen"]</h4>
+                                            <p class="text-muted">@localizer["StepIssueWhenHint"]</p>
+                                            <div class="rgw-grid">
+                                                @Field("ExpectedReturnOn", "ExpectedReturn", null, "date", help: "HelpFieldExpectedReturn")
+                                                @Field("Note", "Note", null, "textarea", help: "HelpFieldNote", wide: true)
+                                            </div>
+                                        </div>
+
+                                        <div class="rgw-step" data-title="@localizer["Review"]">
+                                            <h4>@localizer["Review"]</h4>
+                                            <p class="text-muted">@localizer["ReviewHint"]</p>
+                                            <dl class="rgw-review"></dl>
+                                        </div>
+
+                                        <div class="rgw-wizard-actions">
+                                            <button type="button" class="btn btn-white rgw-step-prev">@localizer["Back"]</button>
+                                            <div class="rgw-wizard-spacer"></div>
+                                            <button type="button" class="btn btn-white" data-dismiss="modal">@localizer["Close"]</button>
+                                            <button type="button" class="btn btn-primary rgw-step-next">@localizer["Continue"]</button>
+                                            <button type="submit" class="btn btn-primary rgw-step-submit">@localizer["Issue"]</button>
+                                        </div>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                }
+
+                @if (Model.CanIssue && Model.Tab is "Issuances" or "PersonnelGear")
+                {
+                    foreach (var outstanding in Model.Rows.OfType<InventoryIssuance>().Where(x => x.Status is 0 or 2))
+                    {
+                        <div class="modal fade rgw-modal" id="rgw-return-@outstanding.Id" tabindex="-1" role="dialog" aria-labelledby="rgw-return-@(outstanding.Id)-title">
+                            <div class="modal-dialog" role="document">
+                                <div class="modal-content">
+                                    <div class="modal-header">
+                                        <button type="button" class="close" data-dismiss="modal" aria-label="@localizer["Close"]"><span aria-hidden="true">&times;</span></button>
+                                        <h4 class="modal-title" id="rgw-return-@(outstanding.Id)-title">@localizer["Return"] · @ItemName(outstanding.ItemId)</h4>
+                                    </div>
+                                    <div class="modal-body">
+                                        <div class="alert rgw-modal-message" role="status"></div>
+                                        <p class="text-muted">@localizer["StepReturnHint"]</p>
+                                        <form asp-action="Return" method="post" class="inventory-command">
+                                            @Html.AntiForgeryToken()
+                                            @Hide("RequestId", Guid.NewGuid().ToString("D"))
+                                            @Hide("IssuanceId", outstanding.Id)@Hide("Revision", outstanding.Revision)
+                                            <div class="rgw-grid">
+                                                @Field("Quantity", "Amount", outstanding.Quantity - outstanding.ReturnedQuantity, "number", required: true, min: "0")
+                                                @Field("ToLocationId", "ToLocation", null, options: locationOptions, required: true, help: "HelpFieldToLocation")
+                                                @Field("Condition", "Status", 0, options: Codes("Status", 0, 2, 3), help: "HelpFieldReturnCondition")
+                                                @Field("Note", "Note", null, "textarea", help: "HelpFieldNote", wide: true)
+                                            </div>
+                                            <div class="rgw-wizard-actions">
+                                                <div class="rgw-wizard-spacer"></div>
+                                                <button type="button" class="btn btn-white" data-dismiss="modal">@localizer["Close"]</button>
+                                                <button type="submit" class="btn btn-primary">@localizer["Return"]</button>
+                                            </div>
+                                        </form>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    }
+                }
+
+                @if (Model.Tab == "Kits")
+                {
+                    @if (Model.CanWrite)
+                    {
+                        @* New kit, then one editor per kit on the page. *@
+                        foreach (var kit in new InventoryKit[] { null }.Concat(Model.Rows.OfType<InventoryKit>()))
+                        {
+                            var isNew = kit == null;
+                            var dialogId = isNew ? "rgw-new-kit" : "rgw-kit-" + kit.Id;
+                            var kitName = isNew ? null : InventoryWorkspaceView.Details<InventoryLabel>(kit).Name;
+                            var editLines = isNew
+                                ? new List<InventoryKitItem>()
+                                : Model.KitContents.Where(k => k.KitId == kit.Id && !k.IsDeleted).ToList();
+                            <div class="modal fade rgw-modal" id="@dialogId" tabindex="-1" role="dialog" aria-labelledby="@(dialogId)-title">
+                                <div class="modal-dialog modal-lg" role="document">
+                                    <div class="modal-content">
+                                        <div class="modal-header">
+                                            <button type="button" class="close" data-dismiss="modal" aria-label="@localizer["Close"]"><span aria-hidden="true">&times;</span></button>
+                                            <h4 class="modal-title" id="@(dialogId)-title">@(isNew ? localizer["NewKit"].Value : localizer["Edit"].Value + " · " + kitName)</h4>
+                                        </div>
+                                        <div class="modal-body">
+                                            <div class="alert rgw-modal-message" role="status"></div>
+                                            <form asp-action="SaveKit" method="post" class="inventory-command inventory-kit rgw-wizard">
+                                                @Html.AntiForgeryToken()
+                                                @if (!isNew)
+                                                {
+                                                    @Hide("Id", kit.Id)@Hide("Revision", kit.Revision)
+                                                }
+                                                <ol class="rgw-steps"></ol>
+
+                                                <div class="rgw-step" data-title="@localizer["StepKitBasics"]">
+                                                    <h4>@localizer["StepKitBasics"]</h4>
+                                                    <p class="text-muted">@localizer["StepKitBasicsHint"]</p>
+                                                    <div class="rgw-grid">
+                                                        @Field("Name", "Name", kitName, required: true, maxLength: 250, wide: true)
+                                                    </div>
+                                                </div>
+
+                                                <div class="rgw-step" data-title="@localizer["StepKitContents"]">
+                                                    <h4>@localizer["StepKitContents"]</h4>
+                                                    <p class="text-muted">@localizer["StepKitContentsHint"]</p>
+                                                    <div class="inventory-kit-lines">
+                                                        @{ var editIndex = 0; }
+                                                        @foreach (var kitLine in editLines.DefaultIfEmpty(new InventoryKitItem { Quantity = 1 }))
+                                                        {
+                                                            var prefix = "Lines[" + editIndex++ + "].";
+                                                            <div class="panel panel-default rgw-line inventory-kit-line">
+                                                                <div class="panel-heading">@localizer["Items"]</div>
+                                                                <div class="panel-body">
+                                                                <div class="rgw-grid">
+                                                                    @Field(prefix + "ItemId", "Items", kitLine.ItemId, options: itemOptions, required: true)
+                                                                    @Field(prefix + "Quantity", "Amount", kitLine.Quantity, "number", required: true, min: "0")
+                                                                </div>
+                                                                <div class="rgw-line-actions">
+                                                                    <button class="btn btn-xs btn-danger inventory-remove-line" type="button"><i class="fa fa-trash-o"></i> @localizer["M4RemoveLine"]</button>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                        }
+                                                    </div>
+                                                    <button class="btn btn-default inventory-add-line" type="button"><i class="fa fa-plus"></i> @localizer["AddLine"]</button>
+                                                </div>
+
+                                                <div class="rgw-wizard-actions">
+                                                    <button type="button" class="btn btn-white rgw-step-prev">@localizer["Back"]</button>
+                                                    <div class="rgw-wizard-spacer"></div>
+                                                    <button type="button" class="btn btn-white" data-dismiss="modal">@localizer["Close"]</button>
+                                                    <button type="button" class="btn btn-primary rgw-step-next">@localizer["Continue"]</button>
+                                                    <button type="submit" class="btn btn-primary rgw-step-submit">@localizer["Save"]</button>
+                                                </div>
+                                            </form>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        }
+                    }
+
+                    @if (Model.CanIssue)
+                    {
+                        foreach (var kit in Model.Rows.OfType<InventoryKit>())
+                        {
+                            var kitLines = Model.KitContents.Where(k => k.KitId == kit.Id && !k.IsDeleted).ToList();
+                            var issueCount = kitLines.Sum(k => Model.Items.FirstOrDefault(i => i.Id == k.ItemId)?.TrackingMode == (int)InventoryTrackingMode.Serialized ? k.Quantity : 1);
+                            if (kitLines.Count == 0 || issueCount > 100 || kitLines.Any(k => Model.Items.All(i => i.Id != k.ItemId)))
+                            {
+                                continue;
+                            }
+                            <div class="modal fade rgw-modal" id="rgw-issue-kit-@kit.Id" tabindex="-1" role="dialog" aria-labelledby="rgw-issue-kit-@(kit.Id)-title">
+                                <div class="modal-dialog modal-lg" role="document">
+                                    <div class="modal-content">
+                                        <div class="modal-header">
+                                            <button type="button" class="close" data-dismiss="modal" aria-label="@localizer["Close"]"><span aria-hidden="true">&times;</span></button>
+                                            <h4 class="modal-title" id="rgw-issue-kit-@(kit.Id)-title">@localizer["Issue"] · @(InventoryWorkspaceView.Details<InventoryLabel>(kit).Name)</h4>
+                                        </div>
+                                        <div class="modal-body">
+                                            <div class="alert rgw-modal-message" role="status"></div>
+                                            <form asp-action="IssueKit" method="post" class="inventory-command inventory-kit-issue rgw-wizard">
+                                                @Html.AntiForgeryToken()
+                                                @Hide("KitId", kit.Id)@Hide("RequestId", Guid.NewGuid().ToString("D"))
+                                                <ol class="rgw-steps"></ol>
+
+                                                <div class="rgw-step" data-title="@localizer["StepIssueWho"]">
+                                                    <h4>@localizer["StepIssueWho"]</h4>
+                                                    <p class="text-muted">@localizer["HolderHelp"]</p>
+                                                    <div class="rgw-grid">
+                                                        @Field("userId", "Person", null, options: Choice(Model.People), help: "HelpFieldHolder")
+                                                        @Field("unitId", "Unit", null, options: Choice(Model.Units), help: "HelpFieldHolder")
+                                                    </div>
+                                                </div>
+
+                                                <div class="rgw-step" data-title="@localizer["StepKitContents"]">
+                                                    <h4>@localizer["StepKitContents"]</h4>
+                                                    <p class="text-muted">@localizer["StepKitIssueHint"]</p>
+                                                    @{ var lineIndex = 0; }
+                                                    @foreach (var kitLine in kitLines)
+                                                    {
+                                                        var serialized = Model.Items.First(i => i.Id == kitLine.ItemId).TrackingMode == (int)InventoryTrackingMode.Serialized;
+                                                        var quantity = serialized ? 1 : kitLine.Quantity;
+                                                        foreach (var component in Enumerable.Range(0, serialized ? (int)kitLine.Quantity : 1))
+                                                        {
+                                                            var prefix = "Lines[" + lineIndex++ + "].";
+                                                            <div class="panel panel-default rgw-line">
+                                                                <div class="panel-heading">@ItemName(kitLine.ItemId) @(serialized ? "#" + (component + 1).ToString(CultureInfo.CurrentCulture) : "")</div>
+                                                                <div class="panel-body">
+                                                                @Hide(prefix + "ItemId", kitLine.ItemId)
+                                                                @Hide(prefix + "Quantity", quantity.ToString(CultureInfo.InvariantCulture))
+                                                                <p class="text-muted">@localizer["Amount"]: @quantity.ToString(CultureInfo.CurrentCulture)</p>
+                                                                <div class="rgw-grid">
+                                                                    @if (serialized)
+                                                                    {
+                                                                        @Field(prefix + "AssetId", "AssetId", null, required: true, help: "HelpFieldAsset",
+                                                                            options: Choice(Model.Assets
+                                                                                .Where(a => a.ItemId == kitLine.ItemId && a.Status == (int)InventoryAssetStatus.InService && a.CurrentLocationId != null)
+                                                                                .Select(a => new InventoryChoice { Id = a.Id, Name = InventoryWorkspaceView.Details<InventoryAssetContent>(a).SerialNumber + " · " + InventoryWorkspaceView.Details<InventoryAssetContent>(a).AssetTag })))
+                                                                    }
+                                                                    @Field(prefix + "LotId", "LotId", null, help: "HelpFieldLot",
+                                                                        options: Choice(Model.Lots
+                                                                            .Where(l => l.ItemId == kitLine.ItemId)
+                                                                            .Select(l => new InventoryChoice { Id = l.Id, Name = InventoryWorkspaceView.Details<InventoryLotContent>(l).LotNumber })))
+                                                                    @Field(prefix + "FromLocationId", "FromLocation", null, options: locationOptions, required: true, help: "HelpFieldFromLocation")
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                        }
+                                                    }
+                                                </div>
+
+                                                <div class="rgw-wizard-actions">
+                                                    <button type="button" class="btn btn-white rgw-step-prev">@localizer["Back"]</button>
+                                                    <div class="rgw-wizard-spacer"></div>
+                                                    <button type="button" class="btn btn-white" data-dismiss="modal">@localizer["Close"]</button>
+                                                    <button type="button" class="btn btn-primary rgw-step-next">@localizer["Continue"]</button>
+                                                    <button type="submit" class="btn btn-primary rgw-step-submit">@localizer["Issue"]</button>
+                                                </div>
+                                            </form>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        }
+                    }
+                }
+
+                @if (Model.CanWrite && Model.Tab == "AssetDetail" && Model.Rows.OfType<InventoryAsset>().FirstOrDefault() is { } current)
+                {
+                    <div class="modal fade rgw-modal" id="rgw-asset-status" tabindex="-1" role="dialog" aria-labelledby="rgw-asset-status-title">
+                        <div class="modal-dialog" role="document">
+                            <div class="modal-content">
+                                <div class="modal-header">
+                                    <button type="button" class="close" data-dismiss="modal" aria-label="@localizer["Close"]"><span aria-hidden="true">&times;</span></button>
+                                    <h4 class="modal-title" id="rgw-asset-status-title">@localizer["Status"]</h4>
+                                </div>
+                                <div class="modal-body">
+                                    <div class="alert rgw-modal-message" role="status"></div>
+                                    <p class="text-muted">@localizer["HelpAssetStatus"]</p>
+                                    <form asp-action="Status" method="post" class="inventory-command">
+                                        @Html.AntiForgeryToken()
+                                        @Hide("RequestId", Guid.NewGuid().ToString("D"))
+                                        @Hide("Lines[0].ItemId", current.ItemId)@Hide("Lines[0].AssetId", current.Id)
+                                        @Hide("Lines[0].LotId", current.LotId)@Hide("Lines[0].FromLocationId", current.CurrentLocationId)
+                                        @Hide("Lines[0].ExpectedAssetRevision", current.Revision)@Hide("Lines[0].Type", 9)
+                                        <div class="rgw-grid">
+                                            @Field("Lines[0].Status", "Status", current.Status, options: Codes("Status", 0, 2, 3, 4, 5, 6), wide: true)
+                                            @Field("Lines[0].Note", "Note", null, "textarea", help: "HelpFieldNote", wide: true)
+                                        </div>
+                                        <div class="rgw-wizard-actions">
+                                            <div class="rgw-wizard-spacer"></div>
+                                            <button type="button" class="btn btn-white" data-dismiss="modal">@localizer["Close"]</button>
+                                            <button type="submit" class="btn btn-primary">@localizer["Save"]</button>
+                                        </div>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                }
+
+                @if (Model.CanWitness && Model.Tab == "History")
+                {
+                    <div class="modal fade rgw-modal" id="rgw-witness" tabindex="-1" role="dialog" aria-labelledby="rgw-witness-title">
+                        <div class="modal-dialog" role="document">
+                            <div class="modal-content">
+                                <div class="modal-header">
+                                    <button type="button" class="close" data-dismiss="modal" aria-label="@localizer["Close"]"><span aria-hidden="true">&times;</span></button>
+                                    <h4 class="modal-title" id="rgw-witness-title">@localizer["Witness"]</h4>
+                                </div>
+                                <div class="modal-body">
+                                    <div class="alert rgw-modal-message" role="status"></div>
+                                    <p class="text-muted">@localizer["HelpWitness"]</p>
+                                    <form asp-action="Witness" method="post" class="inventory-command">
+                                        @Html.AntiForgeryToken()
+                                        <div class="rgw-grid">
+                                            @Field("requestId", "WitnessRequest", null, required: true, maxLength: 80, wide: true)
+                                            @Field("attestation", "Attestation", null, "textarea", wide: true)
+                                        </div>
+                                        <div class="rgw-wizard-actions">
+                                            <div class="rgw-wizard-spacer"></div>
+                                            <button type="button" class="btn btn-white" data-dismiss="modal">@localizer["Close"]</button>
+                                            <button type="submit" class="btn btn-primary">@localizer["Witness"]</button>
+                                        </div>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                 }
             }
-            @if (Model.CanWrite && Model.Tab == "Categories") { <form asp-action="SaveCategory" method="post" class="inventory-command">@Html.AntiForgeryToken()@Field("name", "Name")@Field("parentId", "Parent", null, options: categoryOptions)<button class="btn btn-primary" type="submit">@localizer["Save"]</button></form> }
-            @if (Model.CanWrite && Model.Tab == "Locations") { <form asp-action="SaveLocation" method="post" class="inventory-command">@Html.AntiForgeryToken()@Field("Name", "Name")@Field("Type", "LocationType", 0, options: Codes("LocationType", 0, 1, 2, 3, 4, 5))@Field("GroupId", "Station", null, options: Choice(Model.Groups))@Field("UnitId", "Unit", null, options: Choice(Model.Units))@Field("UserId", "Person", null, options: Choice(Model.People))@Field("ContainerAssetId", "ContainerAsset", null, options: assetOptions)@Field("ParentLocationId", "Parent", null, options: locationOptions)@Field("IsDefault", "DefaultLocation", "false", options: new[] { new SelectListItem { Value = "false", Text = localizer["No"] }, new SelectListItem { Value = "true", Text = localizer["Yes"] } })<button class="btn btn-primary" type="submit">@localizer["Save"]</button></form> }
-            @if (Model.CanWrite && Model.Tab == "Lots") { <form asp-action="CreateLot" method="post" class="inventory-command">@Html.AntiForgeryToken()@Field("itemId", "Items", null, options: itemOptions)@Field("details.LotNumber", "Batch")@Field("expiresOn", "Expiration", null, "date")@Field("details.UnitCost", "UnitCost", null, "number")@if (Model.CanChooseVendors) { @Field("details.VendorId", "M4Supplier", options: vendorOptions) }<button class="btn btn-primary" type="submit">@localizer["Save"]</button></form> }
-            @if (Model.CanWrite && Model.Tab == "Assets") { <form asp-action="CreateAsset" method="post" class="inventory-command" data-inventory-create-asset="true">@Html.AntiForgeryToken()<input type="hidden" name="RequestId" value="@Guid.NewGuid().ToString("D")"/>@Field("ItemId", "Items", null, options: itemOptions)@Field("LocationId", "Location", null, options: locationOptions)@Field("LotId", "LotId", null, options: lotOptions)@Field("Details.AcquisitionCost", "UnitCost", null, "number")@Field("Details.SerialNumber", "SerialNumber")@Field("Details.AssetTag", "AssetTag")@Field("Details.Barcode", "Barcode")@Field("ExpiresOn", "Expiration", null, "date")<button class="btn btn-primary" type="submit">@localizer["NewAsset"]</button></form> }
-            @if ((Model.CanWrite && Model.Tab == "OnHand") || (Model.CanTransfer && Model.Tab == "Transfers")) { <form asp-action="@(Model.Tab == "Transfers" ? "Transfer" : "Post")" method="post" class="inventory-command">@Html.AntiForgeryToken()<input type="hidden" name="RequestId" value="@Guid.NewGuid().ToString("D")"/>@Field("Lines[0].Type", "Movement", Model.Tab == "Transfers" ? 3 : 1, options: Model.Tab == "Transfers" ? Codes("Movement", 3) : Codes("Movement", 1, 2, 6, 8))@Field("Lines[0].ItemId", "Items", null, options: itemOptions)@Field("Lines[0].AssetId", "AssetId", null, options: assetOptions)@Field("Lines[0].LotId", "LotId", null, options: lotOptions)@Field("Lines[0].FromLocationId", "FromLocation", null, options: locationOptions)@Field("Lines[0].ToLocationId", "ToLocation", null, options: locationOptions)@Field("Lines[0].Quantity", "Amount", null, "number")@if (Model.Tab == "OnHand") { @Field("Lines[0].UnitCost", "UnitCost", null, "number") }@Field("Lines[0].Note", "Note")<p>@localizer["MovementHelp"]</p><button class="btn btn-primary" type="submit">@localizer["PostMovement"]</button></form> }
-            @if (Model.CanIssue && Model.Tab == "Issuances") { <form asp-action="Issue" method="post" class="inventory-command">@Html.AntiForgeryToken()<input type="hidden" name="RequestId" value="@Guid.NewGuid().ToString("D")"/>@Field("ItemId", "Items", null, options: itemOptions)@Field("AssetId", "AssetId", null, options: assetOptions)@Field("LotId", "LotId", null, options: lotOptions)@Field("FromLocationId", "FromLocation", null, options: locationOptions)@Field("Quantity", "Amount", null, "number")@Field("UserId", "Person", null, options: Choice(Model.People))@Field("UnitId", "Unit", null, options: Choice(Model.Units))@Field("ExpectedReturnOn", "ExpectedReturn", null, "date")@Field("Note", "Note")<p>@localizer["HolderHelp"]</p><button class="btn btn-primary" type="submit">@localizer["Issue"]</button></form> }
-            @if (Model.CanWrite && Model.Tab == "AssetDetail" && Model.Rows.OfType<InventoryAsset>().FirstOrDefault() is { } current) { <form asp-action="Status" method="post" class="inventory-command">@Html.AntiForgeryToken()<input type="hidden" name="RequestId" value="@Guid.NewGuid().ToString("D")"/><input type="hidden" name="Lines[0].ItemId" value="@current.ItemId"/><input type="hidden" name="Lines[0].AssetId" value="@current.Id"/><input type="hidden" name="Lines[0].LotId" value="@current.LotId"/><input type="hidden" name="Lines[0].FromLocationId" value="@current.CurrentLocationId"/><input type="hidden" name="Lines[0].ExpectedAssetRevision" value="@current.Revision"/><input type="hidden" name="Lines[0].Type" value="9"/>@Field("Lines[0].Status", "Status", current.Status, options: Codes("Status", 0, 2, 3, 4, 5, 6))@Field("Lines[0].Note", "Note")<button class="btn btn-primary" type="submit">@localizer["Save"]</button></form> }
-            @if (Model.CanWrite && Model.Tab == "Kits") { <form asp-action="SaveKit" method="post" class="inventory-command inventory-kit">@Html.AntiForgeryToken()@Field("Name", "Name")<div class="inventory-kit-lines"><div class="inventory-kit-line">@Field("Lines[0].ItemId", "Items", null, options: itemOptions)@Field("Lines[0].Quantity", "Amount", 1, "number")<button class="btn btn-default inventory-remove-line" type="button">@localizer["Archive"]</button></div></div><button class="btn btn-default inventory-add-line" type="button">@localizer["AddLine"]</button><button class="btn btn-primary" type="submit">@localizer["Save"]</button></form> }
-            @if (Model.Tab == "History") {
-                if (Model.CanWitness) { <form asp-action="Witness" method="post" class="inventory-command">@Html.AntiForgeryToken()@Field("requestId", "WitnessRequest")@Field("attestation", "Attestation")<button class="btn btn-primary" type="submit">@localizer["Witness"]</button></form> }
-                if (Model.CanWrite) { <form asp-action="Rebuild" method="post" class="inventory-command">@Html.AntiForgeryToken()<button class="btn btn-default" type="submit">@localizer["Rebuild"]</button></form> }
-            }
-        }
-    }
-</div></div></div>
+        </div>
+    </div>
+</div>
+
+@section Styles {
+    <link rel="stylesheet" href="~/css/workspace.css" asp-append-version="true" />
+}
+
 @section Scripts {
-<script id="inventory-settings" type="application/json">@Html.Raw(JsonConvert.SerializeObject(new { protectedData = ViewBag.ProtectionEnforced == true, grant = (string)ViewBag.ProtectedGrant, expiry = (DateTime?)ViewBag.GrantExpiresOn, index = Url.Action("Index"), failed = localizer["UnableToComplete"].Value, witness = localizer["WitnessPending"].Value }, new JsonSerializerSettings { StringEscapeHandling = StringEscapeHandling.EscapeHtml }))</script>
-<script src="~/js/app/internal/inventory/inventory-modern.js" asp-append-version="true"></script>
-@if (ViewBag.ProtectionEnforced == true) { @await Html.PartialAsync("_AdpRevealScripts", new AdpRevealView { BannerTitle = localizer["ProtectedDataRequired"].Value, GrantExpiresOnUtc = (DateTime?)ViewBag.GrantExpiresOn, BindForms = new List<string> { "form.inventory-navigation", "form.inventory-command" } }) }
+    <script id="inventory-settings" type="application/json">@Html.Raw(JsonConvert.SerializeObject(new { protectedData = ViewBag.ProtectionEnforced == true, grant = (string)ViewBag.ProtectedGrant, expiry = (DateTime?)ViewBag.GrantExpiresOn, index = Url.Action("Index"), failed = localizer["UnableToComplete"].Value, witness = localizer["WitnessPending"].Value }, new JsonSerializerSettings { StringEscapeHandling = StringEscapeHandling.EscapeHtml }))</script>
+    <script id="workspace-settings" type="application/json">@Html.Raw(JsonConvert.SerializeObject(new { required = localizer["RequiredFieldsMissing"].Value, nothingEntered = localizer["NoRows"].Value, yes = localizer["Yes"].Value, no = localizer["No"].Value }, new JsonSerializerSettings { StringEscapeHandling = StringEscapeHandling.EscapeHtml }))</script>
+    <script src="~/js/app/internal/inventory/inventory-modern.js" asp-append-version="true"></script>
+    <script src="~/js/app/common/workspace/resgrid.common.workspace.js" asp-append-version="true"></script>
+    @if (ViewBag.ProtectionEnforced == true)
+    {
+        @await Html.PartialAsync("_AdpRevealScripts", new AdpRevealView { BannerTitle = localizer["ProtectedDataRequired"].Value, GrantExpiresOnUtc = (DateTime?)ViewBag.GrantExpiresOn, BindForms = new List<string> { "form.inventory-navigation", "form.inventory-command" } })
+    }
 }

--- a/Web/Resgrid.Web/Areas/User/Views/Inventory/_Shell.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Inventory/_Shell.cshtml
@@ -1,0 +1,69 @@
+@using Resgrid.Web.Areas.User.Models.Inventory
+@model InventoryWorkspaceView
+@inject IStringLocalizer<Resgrid.Localization.Areas.User.Inventory.Inventory> localizer
+@*
+    Page heading shared by the three inventory screens, laid out the same way as the rest of
+    the application: title and breadcrumb on the left, module buttons in a top-page-buttons
+    group on the right. ViewData["Module"] selects which one is current ("Inventory",
+    "Purchasing" or "Operations") and ViewData["Intro"] is an optional one line description.
+
+    The module switch has to be a POST for the same reason the tab strip does: under
+    Advanced Data Protection the request carries the reveal grant, and only the POST
+    forms that inventory-modern.js binds get one attached.
+*@
+@{
+    var module = (string)ViewData["Module"] ?? "Inventory";
+    var titles = new Dictionary<string, string>
+    {
+        ["Inventory"] = localizer["Inventory"].Value,
+        ["Purchasing"] = localizer["M4Purchasing"].Value,
+        ["Operations"] = localizer["M5Operations"].Value
+    };
+    var intro = (string)ViewData["Intro"];
+}
+<div class="row wrapper border-bottom white-bg page-heading">
+    <div class="col-sm-5">
+        <h2>@titles[module]</h2>
+        <ol class="breadcrumb">
+            <li><a asp-controller="Home" asp-action="Dashboard" asp-route-area="User">@commonLocalizer["HomeModule"]</a></li>
+            @if (module == "Inventory")
+            {
+                <li class="active"><strong>@localizer["Inventory"]</strong></li>
+            }
+            else
+            {
+                <li><a asp-controller="Inventory" asp-action="Index" asp-route-area="User">@localizer["Inventory"]</a></li>
+                <li class="active"><strong>@titles[module]</strong></li>
+            }
+        </ol>
+        @if (!string.IsNullOrEmpty(intro))
+        {
+            <small class="text-muted">@intro</small>
+        }
+    </div>
+    <div class="col-sm-7">
+        <div class="top-page-buttons rgw-modules">
+            @if (module != "Inventory")
+            {
+                <form asp-action="Reopen" method="post" class="inventory-navigation">
+                    @Html.AntiForgeryToken()
+                    <button class="btn btn-default" type="submit"><i class="fa fa-cubes"></i> @localizer["Inventory"]</button>
+                </form>
+            }
+            @if (module != "Purchasing")
+            {
+                <form asp-action="ReopenPurchasing" method="post" class="inventory-navigation">
+                    @Html.AntiForgeryToken()
+                    <button class="btn btn-default" type="submit"><i class="fa fa-shopping-cart"></i> @localizer["M4Purchasing"]</button>
+                </form>
+            }
+            @if (module != "Operations")
+            {
+                <form asp-action="ReopenOperations" method="post" class="inventory-navigation">
+                    @Html.AntiForgeryToken()
+                    <button class="btn btn-default" type="submit"><i class="fa fa-clipboard"></i> @localizer["M5Operations"]</button>
+                </form>
+            }
+        </div>
+    </div>
+</div>

--- a/Web/Resgrid.Web/Areas/User/Views/RecordDocuments/Diff.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/RecordDocuments/Diff.cshtml
@@ -1,11 +1,57 @@
 @model List<Resgrid.Model.RecordFieldDiff>
-@{ ViewBag.Title = "Compare report revisions"; }
+@inject IStringLocalizer<Resgrid.Localization.Areas.User.Records.Records> localizer
+@{
+    ViewBag.Title = "Resgrid | " + localizer["DiffHeader"];
+    ViewData["Title"] = localizer["DiffHeader"].Value;
+    ViewData["Subtitle"] = localizer["DiffRevisionRange", ViewData["From"], ViewData["To"]].Value;
+}
+
+@await Html.PartialAsync("_RmsShell")
+
 <div class="wrapper wrapper-content">
-    <h2>Revision @ViewData["From"] to revision @ViewData["To"]</h2>
-    <p><a asp-action="PrintDiff" asp-route-id="@ViewData["RecordId"]" asp-route-kind="@ViewData["Kind"]" asp-route-from="@ViewData["FromId"]" asp-route-to="@ViewData["ToId"]">Print comparison as PDF</a></p>
-    @if ((bool?)ViewData["Withheld"] == true) { <p class="alert alert-info">Restricted values are withheld under your current permissions.</p> }
-    @if (Model.Count == 0) { <p>No visible content changed.</p> }
-    <table class="table table-bordered"><thead><tr><th>Field</th><th>Before</th><th>After</th></tr></thead><tbody>
-    @foreach (var change in Model) { <tr><th>@(change.FieldLabel ?? change.FieldKey)</th><td style="white-space:pre-wrap">@change.OldValue</td><td style="white-space:pre-wrap">@change.NewValue</td></tr> }
-    </tbody></table>
+    <div class="ibox float-e-margins">
+        <div class="ibox-title"><h5>@localizer["DiffRevisionRange", ViewData["From"], ViewData["To"]]</h5></div>
+        <div class="ibox-content">
+
+            <div class="rgw-toolbar">
+                <div class="rgw-toolbar-spacer"></div>
+                <a class="btn btn-default btn-sm" asp-action="PrintDiff" asp-route-id="@ViewData["RecordId"]" asp-route-kind="@ViewData["Kind"]" asp-route-from="@ViewData["FromId"]" asp-route-to="@ViewData["ToId"]"><i class="fa fa-print"></i> @localizer["DiffPrint"]</a>
+            </div>
+
+            @if ((bool?)ViewData["Withheld"] == true)
+            {
+                <div class="alert alert-info"><i class="fa fa-lock"></i> @localizer["Withheld"]</div>
+            }
+
+            @if (Model.Count == 0)
+            {
+                <div class="text-center m-t-lg m-b-lg">
+                    <i class="fa fa-files-o fa-3x text-muted"></i>
+                    <h4 class="m-t-sm">@localizer["NoChanges"]</h4>
+                </div>
+            }
+            else
+            {
+                <div class="table-responsive">
+                    <table class="table table-bordered rgw-table">
+                        <thead><tr><th>@localizer["Field"]</th><th>@localizer["Before"]</th><th>@localizer["After"]</th></tr></thead>
+                        <tbody>
+                            @foreach (var change in Model)
+                            {
+                                <tr>
+                                    <th>@(change.FieldLabel ?? change.FieldKey)</th>
+                                    <td style="white-space:pre-wrap">@change.OldValue</td>
+                                    <td style="white-space:pre-wrap">@change.NewValue</td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                </div>
+            }
+        </div>
+    </div>
 </div>
+
+@section Styles {
+    <link rel="stylesheet" href="~/css/workspace.css" asp-append-version="true" />
+}

--- a/Web/Resgrid.Web/Areas/User/Views/RecordEvidence/Index.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/RecordEvidence/Index.cshtml
@@ -1,40 +1,107 @@
 @using Resgrid.Model
 @model Resgrid.Web.Areas.User.Models.Records.RecordEvidenceView
+@inject IStringLocalizer<Resgrid.Localization.Areas.User.Records.Records> localizer
 @{
-	ViewBag.Title = "Resgrid | Supporting evidence";
-	var context = Model.Context;
-	var recordController = context.RecordKind == RmsRecordKind.IncidentReport ? "IncidentReports" : "Records";
+    var context = Model.Context;
+    var recordController = context.RecordKind == RmsRecordKind.IncidentReport ? "IncidentReports" : "Records";
+    ViewBag.Title = "Resgrid | " + localizer["Evidence"];
+    ViewData["Title"] = localizer["Evidence"].Value + " — " + context.RecordNumber;
+    ViewData["Subtitle"] = localizer["EvidenceIntro"].Value;
+    ViewData["ParentText"] = context.RecordNumber;
+    ViewData["ParentController"] = recordController;
+    ViewData["ParentAction"] = "Details";
+    ViewData["ParentId"] = context.RecordId;
 }
+
+@await Html.PartialAsync("_RmsShell")
+
 <div class="wrapper wrapper-content">
-	<h2>Supporting evidence — @context.RecordNumber</h2>
-	<p><a asp-controller="@recordController" asp-action="Details" asp-route-id="@context.RecordId">Return to report</a></p>
-	@if (!string.IsNullOrWhiteSpace(Model.Message)) { <div class="alert alert-info" role="status">@Model.Message</div> }
-	<p>Captured manifests preserve the selected source facts and their checksum. Draft captures become part of the signed revision. Corrections preserve earlier evidence in the history.</p>
-	@if (context.CanCapture)
-	{
-		<p><a class="btn btn-primary" asp-action="Select" asp-route-recordId="@context.RecordId" asp-route-recordKind="@context.RecordKind">Select and capture evidence</a>
-		<a class="btn btn-default" asp-controller="RecordsInventory" asp-action="Edit" asp-route-recordId="@context.RecordId" asp-route-kind="@context.RecordKind">Record inventory usage</a></p>
-	}
-	@if (Model.Artifacts.Count == 0) { <p>No evidence on this page.</p> }
-	<nav aria-label="Evidence pages">
-		@if (Model.Page > 0) { <a asp-action="Index" asp-route-recordId="@context.RecordId" asp-route-recordKind="@context.RecordKind" asp-route-page="@(Model.Page - 1)">Previous page</a> }
-		@if (Model.HasMore) { <a asp-action="Index" asp-route-recordId="@context.RecordId" asp-route-recordKind="@context.RecordKind" asp-route-page="@(Model.Page + 1)">Next page</a> }
-	</nav>
-	@foreach (var artifact in Model.Artifacts)
-	{
-		<div class="ibox"><div class="ibox-content">
-			@if (artifact.Withheld)
-			{
-				<p><i class="fa fa-lock" aria-hidden="true"></i> Restricted evidence withheld.</p>
-			}
-			else
-			{
-				<h3>@artifact.Title</h3>
-				<p>@artifact.Reason</p>
-				<p>@artifact.Items source item(s) · captured @artifact.CapturedOn.ToString("yyyy-MM-dd HH:mm:ss") UTC · @(artifact.Superseded ? "Superseded" : "Current") · @(artifact.RevisionId == null ? "Draft" : "Signed revision: " + artifact.RevisionId)</p>
-				<p>Source version: <code style="overflow-wrap:anywhere">@artifact.SourceVersion</code><br />SHA-256: <code style="overflow-wrap:anywhere">@artifact.Checksum</code></p>
-				@if (context.CanExport) { <a class="btn btn-default" asp-action="Manifest" asp-route-recordId="@context.RecordId" asp-route-recordKind="@context.RecordKind" asp-route-artifactId="@artifact.Id">Download verified manifest</a> }
-			}
-		</div></div>
-	}
+    <div class="ibox float-e-margins">
+        <div class="ibox-title"><h5>@localizer["Evidence"] &middot; @context.RecordNumber</h5></div>
+        <div class="ibox-content">
+
+            @if (!string.IsNullOrWhiteSpace(Model.Message))
+            {
+                <div class="alert alert-info" role="status">@Model.Message</div>
+            }
+
+            <div class="alert alert-info"><i class="fa fa-info-circle"></i> @localizer["EvidenceManifestIntro"]</div>
+
+            <div class="rgw-toolbar">
+                <a class="btn btn-default btn-sm" asp-controller="@recordController" asp-action="Details" asp-route-id="@context.RecordId"><i class="fa fa-arrow-left"></i> @localizer["ReturnToReport"]</a>
+                <div class="rgw-toolbar-spacer"></div>
+                @if (context.CanCapture)
+                {
+                    <a class="btn btn-primary" asp-action="Select" asp-route-recordId="@context.RecordId" asp-route-recordKind="@context.RecordKind"><i class="fa fa-plus"></i> @localizer["AddEvidence"]</a>
+                    <a class="btn btn-default" asp-controller="RecordsInventory" asp-action="Edit" asp-route-recordId="@context.RecordId" asp-route-kind="@context.RecordKind"><i class="fa fa-cubes"></i> @localizer["EvidenceInventoryUsage"]</a>
+                }
+            </div>
+
+            @if (Model.Artifacts.Count == 0)
+            {
+                <div class="text-center m-t-lg m-b-lg">
+                    <i class="fa fa-folder-open-o fa-3x text-muted"></i>
+                    <h4 class="m-t-sm">@localizer["NoEvidenceCaptured"]</h4>
+                </div>
+            }
+            else
+            {
+                <div class="row">
+                    @foreach (var artifact in Model.Artifacts)
+                    {
+                        <div class="col-md-6">
+                            <div class="ibox">
+                                <div class="ibox-title">
+                                    <h5>@(artifact.Withheld ? localizer["EvidenceWithheld"].Value : artifact.Title)</h5>
+                                </div>
+                                <div class="ibox-content">
+                                    @if (artifact.Withheld)
+                                    {
+                                        <p class="text-muted"><i class="fa fa-lock" aria-hidden="true"></i> @localizer["EvidenceWithheld"]</p>
+                                    }
+                                    else
+                                    {
+                                        <p>
+                                            <span class="label @(artifact.Superseded ? "" : "label-success")">@localizer[artifact.Superseded ? "Superseded" : "EvidenceCurrent"]</span>
+                                            <span class="label @(artifact.RevisionId == null ? "label-warning" : "label-primary")">@(artifact.RevisionId == null ? localizer["EvidenceDraft"].Value : localizer["EvidenceSignedRevision"].Value + " " + artifact.RevisionId)</span>
+                                        </p>
+                                        <p style="white-space:pre-wrap">@artifact.Reason</p>
+                                        <dl class="dl-horizontal">
+                                            <dt>@localizer["EvidenceItems"]</dt><dd>@artifact.Items</dd>
+                                            <dt>@localizer["CapturedOn"]</dt><dd>@artifact.CapturedOn.ToString("yyyy-MM-dd HH:mm:ss") UTC</dd>
+                                            <dt>@localizer["EvidenceSourceVersion"]</dt><dd><code style="overflow-wrap:anywhere">@artifact.SourceVersion</code></dd>
+                                            <dt>@localizer["Checksum"]</dt><dd><code style="overflow-wrap:anywhere">@artifact.Checksum</code></dd>
+                                        </dl>
+                                        @if (context.CanExport)
+                                        {
+                                            <a class="btn btn-default btn-sm" asp-action="Manifest" asp-route-recordId="@context.RecordId" asp-route-recordKind="@context.RecordKind" asp-route-artifactId="@artifact.Id"><i class="fa fa-download"></i> @localizer["EvidenceDownloadManifest"]</a>
+                                        }
+                                    }
+                                </div>
+                            </div>
+                        </div>
+                    }
+                </div>
+            }
+
+            @if (Model.Page > 0 || Model.HasMore)
+            {
+                <div class="rgw-pager">
+                    @if (Model.Page > 0)
+                    {
+                        <a class="btn btn-default btn-sm" asp-action="Index" asp-route-recordId="@context.RecordId" asp-route-recordKind="@context.RecordKind" asp-route-page="@(Model.Page - 1)"><i class="fa fa-chevron-left"></i> @localizer["PreviousPage"]</a>
+                    }
+                    @if (Model.HasMore)
+                    {
+                        <a class="btn btn-default btn-sm" asp-action="Index" asp-route-recordId="@context.RecordId" asp-route-recordKind="@context.RecordKind" asp-route-page="@(Model.Page + 1)">@localizer["NextPage"] <i class="fa fa-chevron-right"></i></a>
+                    }
+                    <span class="text-muted">@(Model.Page + 1)</span>
+                </div>
+            }
+        </div>
+    </div>
 </div>
+
+@section Styles {
+    <link rel="stylesheet" href="~/css/workspace.css" asp-append-version="true" />
+}

--- a/Web/Resgrid.Web/Areas/User/Views/RecordEvidence/Select.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/RecordEvidence/Select.cshtml
@@ -1,84 +1,212 @@
 @using Resgrid.Model
 @model Resgrid.Web.Areas.User.Models.Records.RecordEvidenceSelectionView
 @inject IStringLocalizer<Resgrid.Localization.Areas.User.Records.Records> localizer
+@*
+    Choosing what to capture. The source picker is a filter bar, the per-source guidance is a
+    help alert, and the choices are a field grid, so the page reads the same way as the other
+    workspace screens. The field names the capture posts are unchanged.
+*@
 @{
-	ViewBag.Title = "Resgrid | Select supporting evidence";
-	var selection = Model.Selection;
-	var context = selection.Context;
-	var source = selection.Sources.FirstOrDefault(s => s.Kind == selection.SourceKind);
+    var selection = Model.Selection;
+    var context = selection.Context;
+    var source = selection.Sources.FirstOrDefault(s => s.Kind == selection.SourceKind);
+    ViewBag.Title = "Resgrid | " + localizer["AddEvidence"];
+    ViewData["Title"] = localizer["AddEvidence"].Value + " — " + context.RecordNumber;
+    ViewData["Subtitle"] = localizer["EvidenceIntro"].Value;
+    ViewData["ParentText"] = localizer["Evidence"].Value;
+    ViewData["ParentController"] = "RecordEvidence";
+    ViewData["ParentAction"] = "Index";
+
+    string SourceGuidance() => selection.SourceKind switch
+    {
+        RmsEvidenceKind.TrackingFix => localizer["EvidenceTrackingHelp"].Value,
+        RmsEvidenceKind.CertificationSnapshot => localizer["EvidenceCertificationHelp"].Value,
+        RmsEvidenceKind.RunCardActivation => localizer["EvidenceRunCardHelp"].Value,
+        RmsEvidenceKind.InventoryUsage => localizer["EvidenceInventoryHelp"].Value,
+        RmsEvidenceKind.ModuleProjection => localizer["ProjectionIntro"].Value,
+        RmsEvidenceKind.ChatPromotion => localizer["EvidenceChatHelp"].Value,
+        _ => null
+    };
+
+    string ChoiceLegend() => selection.SourceKind switch
+    {
+        RmsEvidenceKind.TrackingFix => localizer["Units"].Value,
+        RmsEvidenceKind.CertificationSnapshot => localizer["EvidencePersonnel"].Value,
+        RmsEvidenceKind.ModuleProjection => localizer["ProjectionKind"].Value,
+        _ => localizer["EvidenceMessages"].Value
+    };
+
+    var hasChoices = selection.SourceKind is RmsEvidenceKind.TrackingFix or RmsEvidenceKind.CertificationSnapshot
+        or RmsEvidenceKind.ChatPromotion or RmsEvidenceKind.ModuleProjection;
 }
+
+@await Html.PartialAsync("_RmsShell")
+
 <div class="wrapper wrapper-content">
-	<h2>Select supporting evidence — @context.RecordNumber</h2>
-	<p><a asp-action="Index" asp-route-recordId="@context.RecordId" asp-route-recordKind="@context.RecordKind">Evidence history</a></p>
-	<form method="get" asp-action="Select" class="form-inline">
-		<input type="hidden" name="recordId" value="@context.RecordId" />
-		<input type="hidden" name="recordKind" value="@context.RecordKind" />
-		<label for="sourceKind">Source</label>
-		<select id="sourceKind" name="sourceKind" class="form-control">
-			@foreach (var item in selection.Sources)
-			{
-				var restricted = item.Kind == RmsEvidenceKind.ChatPromotion || item.Kind == RmsEvidenceKind.CertificationSnapshot || item.Kind == RmsEvidenceKind.InventoryUsage;
-				<option value="@item.Kind" selected="@(item.Kind == selection.SourceKind)" disabled="@(restricted && !context.CanViewRestricted)">@localizer["Evidence" + item.Kind]@(!item.Available ? " (unavailable)" : restricted && !context.CanViewRestricted ? " (restricted access required)" : "")</option>
-			}
-		</select>
-		<button type="submit" class="btn btn-default">Load source</button>
-	</form>
-	<hr />
-	@if (source?.Available != true)
-	{
-		<div class="alert alert-warning">@source?.Reason No evidence will be recorded for an unavailable source.</div>
-	}
-	else
-	{
-		@if (selection.SourceKind == RmsEvidenceKind.ChatPromotion)
-		{
-			<form method="get" asp-action="Select" class="form-inline">
-				<input type="hidden" name="recordId" value="@context.RecordId" /><input type="hidden" name="recordKind" value="@context.RecordKind" /><input type="hidden" name="sourceKind" value="@selection.SourceKind" />
-				<label for="channelId">Incident channel</label><select id="channelId" name="channelId" class="form-control" required>
-					<option value="">Choose a channel</option>
-					@foreach (var channel in selection.Channels) { <option value="@channel.Id" selected="@(channel.Id == selection.ChannelId)">@channel.Label</option> }
-				</select><button type="submit" class="btn btn-default">Load messages</button>
-			</form>
-			<p>Select the messages to preserve. Thread replies are included. Each page is a separate capture; capture this page before moving to the next. Message bodies are displayed as text.</p>
-		}
-		<form method="post" asp-action="Capture">
-			@Html.AntiForgeryToken()
-			<input type="hidden" asp-for="Input.RecordId" /><input type="hidden" asp-for="Input.RecordKind" /><input type="hidden" asp-for="Input.SourceKind" /><input type="hidden" asp-for="Input.RowVersion" />
-			@if (selection.SourceKind == RmsEvidenceKind.TrackingFix)
-			{
-				<p>Choose at most 20 units and a window of at most 24 hours. Up to 24 fixes per unit are sampled across that window. Capture additional windows separately.</p>
-				<div class="form-group"><label asp-for="Input.StartUtc">Coverage start (UTC)</label><input asp-for="Input.StartUtc" asp-format="{0:yyyy-MM-ddTHH:mm:ss}" type="datetime-local" step="1" class="form-control" required /></div>
-				<div class="form-group"><label asp-for="Input.EndUtc">Coverage end (UTC)</label><input asp-for="Input.EndUtc" asp-format="{0:yyyy-MM-ddTHH:mm:ss}" type="datetime-local" step="1" class="form-control" required /></div>
-			}
-			@if (selection.SourceKind == RmsEvidenceKind.CertificationSnapshot)
-			{
-				<p>Choose personnel whose qualification status belongs in this report. Certificate numbers and document files remain in Certifications.</p>
-				<div class="form-group"><label asp-for="Input.EndUtc">Incident time for validity (UTC)</label><input asp-for="Input.EndUtc" asp-format="{0:yyyy-MM-ddTHH:mm:ss}" type="datetime-local" step="1" class="form-control" required /></div>
-			}
-			@if (selection.SourceKind == RmsEvidenceKind.RunCardActivation) { <p>Capture the dispatch decisions recorded by Run Cards for this report’s Call. A missing recorded decision cannot be reconstructed by RMS.</p> }
-			@if (selection.SourceKind == RmsEvidenceKind.InventoryUsage) { <p>Refresh the evidence for all recorded inventory consumption. This action does not consume stock again.</p> }
-			@if (selection.SourceKind == RmsEvidenceKind.ModuleProjection) { <p>@localizer["ProjectionIntro"]</p> }
-			@if (selection.SourceKind == RmsEvidenceKind.TrackingFix || selection.SourceKind == RmsEvidenceKind.CertificationSnapshot || selection.SourceKind == RmsEvidenceKind.ChatPromotion || selection.SourceKind == RmsEvidenceKind.ModuleProjection)
-			{
-				<fieldset><legend>@(selection.SourceKind == RmsEvidenceKind.TrackingFix ? "Units" : selection.SourceKind == RmsEvidenceKind.CertificationSnapshot ? "Personnel" : selection.SourceKind == RmsEvidenceKind.ModuleProjection ? localizer["ProjectionKind"].Value : "Messages")</legend>
-				@if (selection.Choices.Count == 0) { <p>No accessible items on this page.</p> }
-				@foreach (var choice in selection.Choices)
-				{
-					var field = selection.SourceKind == RmsEvidenceKind.TrackingFix ? "Input.UnitIds" : selection.SourceKind == RmsEvidenceKind.CertificationSnapshot ? "Input.UserIds" : "Input.SourceIds";
-					<div class="checkbox"><label><input type="@(selection.SourceKind == RmsEvidenceKind.ModuleProjection ? "radio" : "checkbox")" name="@field" value="@choice.Id" />@(selection.SourceKind == RmsEvidenceKind.ModuleProjection ? localizer["Projection" + choice.Id].Value : choice.Label)
-					@if (choice.Sequence.HasValue) { <span> · #@choice.Sequence · @choice.OccurredOn?.ToString("yyyy-MM-dd HH:mm:ss") UTC</span> }
-					@if (choice.EditedOn.HasValue) { <span> · edited @choice.EditedOn.Value.ToString("yyyy-MM-dd HH:mm:ss") UTC</span> }
-					@if (choice.Body != null) { <span style="display:block;white-space:pre-wrap;overflow-wrap:anywhere">@choice.Body</span> }
-					</label></div>
-				}
-				</fieldset>
-			}
-			<div class="form-group"><label asp-for="Input.CaptureReason">Reason for including this evidence</label><textarea asp-for="Input.CaptureReason" class="form-control" rows="3" maxlength="500" required></textarea></div>
-			<button type="submit" class="btn btn-primary">Capture selected evidence</button>
-		</form>
-		@if (selection.NextSequence.HasValue)
-		{
-			<p><a asp-action="Select" asp-route-recordId="@context.RecordId" asp-route-recordKind="@context.RecordKind" asp-route-sourceKind="@selection.SourceKind" asp-route-channelId="@selection.ChannelId" asp-route-afterSequence="@selection.NextSequence">Next message page (uncaptured selections will be cleared)</a></p>
-		}
-	}
+    <div class="ibox float-e-margins">
+        <div class="ibox-title"><h5>@localizer["AddEvidence"] &middot; @context.RecordNumber</h5></div>
+        <div class="ibox-content">
+
+            <div class="rgw-toolbar">
+                <a class="btn btn-default btn-sm" asp-action="Index" asp-route-recordId="@context.RecordId" asp-route-recordKind="@context.RecordKind"><i class="fa fa-arrow-left"></i> @localizer["Evidence"]</a>
+            </div>
+
+            <div class="rgw-filter">
+                <form method="get" asp-action="Select">
+                    <input type="hidden" name="recordId" value="@context.RecordId" />
+                    <input type="hidden" name="recordKind" value="@context.RecordKind" />
+                    <div class="rgw-grid">
+                        <div class="form-group">
+                            <label for="sourceKind">@localizer["EvidenceSource"]</label>
+                            <select id="sourceKind" name="sourceKind" class="form-control">
+                                @foreach (var item in selection.Sources)
+                                {
+                                    var restricted = item.Kind == RmsEvidenceKind.ChatPromotion || item.Kind == RmsEvidenceKind.CertificationSnapshot || item.Kind == RmsEvidenceKind.InventoryUsage;
+                                    var suffix = !item.Available
+                                        ? " (" + localizer["EvidenceUnavailable"].Value + ")"
+                                        : restricted && !context.CanViewRestricted ? " (" + localizer["EvidenceRestricted"].Value + ")" : "";
+                                    <option value="@item.Kind" selected="@(item.Kind == selection.SourceKind)" disabled="@(restricted && !context.CanViewRestricted)">@localizer["Evidence" + item.Kind]@suffix</option>
+                                }
+                            </select>
+                        </div>
+                    </div>
+                    <div class="rgw-filter-actions">
+                        <button type="submit" class="btn btn-primary"><i class="fa fa-refresh"></i> @localizer["EvidenceLoadSource"]</button>
+                    </div>
+                </form>
+            </div>
+
+            @if (source?.Available != true)
+            {
+                <div class="alert alert-warning"><i class="fa fa-exclamation-triangle"></i> @source?.Reason @localizer["EvidenceUnavailableNotice"]</div>
+            }
+            else
+            {
+                @if (selection.SourceKind == RmsEvidenceKind.ChatPromotion)
+                {
+                    <div class="rgw-filter">
+                        <form method="get" asp-action="Select">
+                            <input type="hidden" name="recordId" value="@context.RecordId" />
+                            <input type="hidden" name="recordKind" value="@context.RecordKind" />
+                            <input type="hidden" name="sourceKind" value="@selection.SourceKind" />
+                            <div class="rgw-grid">
+                                <div class="form-group">
+                                    <label for="channelId">@localizer["EvidenceChannel"]</label>
+                                    <select id="channelId" name="channelId" class="form-control" required>
+                                        <option value="">@localizer["EvidenceChooseChannel"]</option>
+                                        @foreach (var channel in selection.Channels)
+                                        {
+                                            <option value="@channel.Id" selected="@(channel.Id == selection.ChannelId)">@channel.Label</option>
+                                        }
+                                    </select>
+                                </div>
+                            </div>
+                            <div class="rgw-filter-actions">
+                                <button type="submit" class="btn btn-default"><i class="fa fa-refresh"></i> @localizer["EvidenceLoadMessages"]</button>
+                            </div>
+                        </form>
+                    </div>
+                }
+
+                var guidance = SourceGuidance();
+                if (!string.IsNullOrEmpty(guidance))
+                {
+                    <div class="alert alert-info"><i class="fa fa-info-circle"></i> @guidance</div>
+                }
+
+                <form method="post" asp-action="Capture">
+                    @Html.AntiForgeryToken()
+                    <input type="hidden" asp-for="Input.RecordId" />
+                    <input type="hidden" asp-for="Input.RecordKind" />
+                    <input type="hidden" asp-for="Input.SourceKind" />
+                    <input type="hidden" asp-for="Input.RowVersion" />
+
+                    @if (selection.SourceKind == RmsEvidenceKind.TrackingFix)
+                    {
+                        <div class="rgw-grid">
+                            <div class="form-group">
+                                <label asp-for="Input.StartUtc">@localizer["EvidenceCoverageStart"]</label>
+                                <input asp-for="Input.StartUtc" asp-format="{0:yyyy-MM-ddTHH:mm:ss}" type="datetime-local" step="1" class="form-control" required />
+                            </div>
+                            <div class="form-group">
+                                <label asp-for="Input.EndUtc">@localizer["EvidenceCoverageEnd"]</label>
+                                <input asp-for="Input.EndUtc" asp-format="{0:yyyy-MM-ddTHH:mm:ss}" type="datetime-local" step="1" class="form-control" required />
+                            </div>
+                        </div>
+                    }
+                    @if (selection.SourceKind == RmsEvidenceKind.CertificationSnapshot)
+                    {
+                        <div class="rgw-grid">
+                            <div class="form-group">
+                                <label asp-for="Input.EndUtc">@localizer["EvidenceValidityTime"]</label>
+                                <input asp-for="Input.EndUtc" asp-format="{0:yyyy-MM-ddTHH:mm:ss}" type="datetime-local" step="1" class="form-control" required />
+                            </div>
+                        </div>
+                    }
+
+                    @if (hasChoices)
+                    {
+                        <div class="panel panel-default">
+                            <div class="panel-heading">@ChoiceLegend()</div>
+                            <div class="panel-body">
+                                @if (selection.Choices.Count == 0)
+                                {
+                                    <p class="text-muted">@localizer["EvidenceNoChoices"]</p>
+                                }
+                                @foreach (var choice in selection.Choices)
+                                {
+                                    var field = selection.SourceKind == RmsEvidenceKind.TrackingFix ? "Input.UnitIds"
+                                        : selection.SourceKind == RmsEvidenceKind.CertificationSnapshot ? "Input.UserIds" : "Input.SourceIds";
+                                    <div class="checkbox">
+                                        <label>
+                                            <input type="@(selection.SourceKind == RmsEvidenceKind.ModuleProjection ? "radio" : "checkbox")" name="@field" value="@choice.Id" />
+                                            @(selection.SourceKind == RmsEvidenceKind.ModuleProjection ? localizer["Projection" + choice.Id].Value : choice.Label)
+                                            @if (choice.Sequence.HasValue)
+                                            {
+                                                <span class="text-muted"> &middot; #@choice.Sequence &middot; @choice.OccurredOn?.ToString("yyyy-MM-dd HH:mm:ss") UTC</span>
+                                            }
+                                            @if (choice.EditedOn.HasValue)
+                                            {
+                                                <span class="text-muted"> &middot; @localizer["EvidenceEdited"] @choice.EditedOn.Value.ToString("yyyy-MM-dd HH:mm:ss") UTC</span>
+                                            }
+                                            @if (choice.Body != null)
+                                            {
+                                                <span style="display:block;white-space:pre-wrap;overflow-wrap:anywhere">@choice.Body</span>
+                                            }
+                                        </label>
+                                    </div>
+                                }
+                            </div>
+                        </div>
+                    }
+
+                    <div class="rgw-grid">
+                        <div class="form-group rgw-wide">
+                            <label asp-for="Input.CaptureReason">@localizer["CaptureReason"]</label>
+                            <textarea asp-for="Input.CaptureReason" class="form-control" rows="3" maxlength="500" required></textarea>
+                            <span class="help-block">@localizer["EvidenceReasonRequired"]</span>
+                        </div>
+                    </div>
+
+                    <div class="rgw-wizard-actions">
+                        <a class="btn btn-white" asp-action="Index" asp-route-recordId="@context.RecordId" asp-route-recordKind="@context.RecordKind">@localizer["Cancel"]</a>
+                        <div class="rgw-wizard-spacer"></div>
+                        <button type="submit" class="btn btn-primary">@localizer["Capture"]</button>
+                    </div>
+                </form>
+
+                @if (selection.NextSequence.HasValue)
+                {
+                    <div class="rgw-pager">
+                        <a class="btn btn-default btn-sm" asp-action="Select" asp-route-recordId="@context.RecordId" asp-route-recordKind="@context.RecordKind" asp-route-sourceKind="@selection.SourceKind" asp-route-channelId="@selection.ChannelId" asp-route-afterSequence="@selection.NextSequence">@localizer["NextPage"] <i class="fa fa-chevron-right"></i></a>
+                        <span class="text-muted">@localizer["EvidencePageWarning"]</span>
+                    </div>
+                }
+            }
+        </div>
+    </div>
 </div>
+
+@section Styles {
+    <link rel="stylesheet" href="~/css/workspace.css" asp-append-version="true" />
+}

--- a/Web/Resgrid.Web/Areas/User/Views/RecordLegalHolds/Index.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/RecordLegalHolds/Index.cshtml
@@ -1,35 +1,214 @@
 @using Resgrid.Model
 @model List<RmsRecordLegalHold>
-@{ ViewBag.Title = "Records preservation holds"; }
-<h1>Records preservation holds</h1>
-<p>Use a preservation hold for litigation, investigation or a records request. A record hold also protects its analysis and evidence. Releasing a disclosure does not release its preservation hold.</p>
-@if (TempData["HoldMessage"] != null) { <p class="alert alert-success">@TempData["HoldMessage"]</p> }
-@if (TempData["HoldError"] != null) { <p class="alert alert-danger">@TempData["HoldError"]</p> }
-<h2>Place a hold</h2>
-<form method="post" asp-action="Place" asp-area="User" asp-controller="RecordLegalHolds">
-@Html.AntiForgeryToken()
-<label>Specific record ID (leave blank for a definition/date scope)<input class="form-control" name="RecordId" value="@ViewBag.RecordId" maxlength="36" /></label>
-<label>Definition<select class="form-control" name="DefinitionKey"><option value="">All definitions</option>@foreach (var key in RmsDefinitionKeys.LockedTypes.Keys) { <option value="@key">@key</option> }<option value="@RmsDefinitionKeys.NerisIncidentReport">NERIS incident and analysis</option></select></label>
-<p>For a definition/date scope, leave both dates blank to preserve every date. These times are UTC.</p>
-<label>Period start (UTC)<input class="form-control" type="datetime-local" name="PeriodStart" /></label>
-<label>Period end (UTC)<input class="form-control" type="datetime-local" name="PeriodEnd" /></label>
-<label>Reason<select class="form-control" name="Reason"><option>Litigation</option><option>Investigation</option><option>Public records request</option><option>Other</option></select></label>
-<label>Authority or case/request reference<input class="form-control" name="ReferenceNumber" required maxlength="100" /></label>
-<label>Preservation instructions and basis<textarea class="form-control" name="Notes" required maxlength="4000"></textarea></label>
-<p><button class="btn btn-primary">Place preservation hold</button></p>
-</form>
-<h2>Hold history</h2>
-@foreach (var hold in Model)
-{
- <section class="panel panel-default"><div class="panel-heading"><h3>@hold.ReferenceNumber · @(hold.IsActive ? "Active" : "Released")</h3></div><div class="panel-body">
- <p>@hold.Reason · Record: @(hold.RecordId ?? "All matching") · Definition: @(hold.DefinitionKey ?? "All")</p>
- <p>Period: @(hold.PeriodStart?.ToString("u") ?? "Any start") to @(hold.PeriodEnd?.ToString("u") ?? "Any end")</p>
- <p style="white-space:pre-wrap">@hold.Notes</p><p>Placed @hold.PlacedOn.ToString("u") by @hold.PlacedByUserId</p>
- @if (hold.IsActive) {
-  <form method="post" asp-action="Release" asp-controller="RecordLegalHolds" asp-area="User">@Html.AntiForgeryToken()
-  <input type="hidden" name="id" value="@hold.RmsRecordLegalHoldId" /><input type="hidden" name="expectedVersion" value="@hold.RowVersion" />
-  <label>Authority and reason for releasing preservation<textarea class="form-control" name="reason" required maxlength="4000"></textarea></label>
-  <button class="btn btn-warning">Release this hold</button></form>
- } else { <p>Released @hold.ReleasedOn?.ToString("u") by @hold.ReleasedByUserId</p><p style="white-space:pre-wrap">@hold.ReleaseNotes</p> }
- </div></section>
+@inject IStringLocalizer<Resgrid.Localization.Areas.User.Records.Records> localizer
+@*
+    Preservation holds. Placing a hold and releasing one both need an authority reference and
+    a written basis, so each opens in a dialog rather than sitting inline under the list.
+*@
+@{
+    ViewBag.Title = "Resgrid | " + localizer["LegalHoldsHeader"];
+    ViewData["Title"] = localizer["LegalHoldsHeader"].Value;
+    ViewData["Subtitle"] = localizer["LegalHoldsIntro"].Value;
+}
+
+@await Html.PartialAsync("_RmsShell")
+
+<div class="wrapper wrapper-content">
+    <div class="ibox float-e-margins">
+        <div class="ibox-title"><h5>@localizer["LegalHoldsHeader"]</h5></div>
+        <div class="ibox-content">
+
+            @if (TempData["HoldMessage"] != null)
+            {
+                <div class="alert alert-success" role="status">@TempData["HoldMessage"]</div>
+            }
+            @if (TempData["HoldError"] != null)
+            {
+                <div class="alert alert-danger" role="alert">@TempData["HoldError"]</div>
+            }
+
+            <div class="alert alert-info"><i class="fa fa-info-circle"></i> @localizer["LegalHoldsIntro"]</div>
+
+            <div class="rgw-toolbar">
+                <div class="rgw-toolbar-spacer"></div>
+                <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#hold-place"><i class="fa fa-lock"></i> @localizer["PlaceHold"]</button>
+            </div>
+
+            @if (Model.Count == 0)
+            {
+                <div class="text-center m-t-lg m-b-lg">
+                    <i class="fa fa-lock fa-3x text-muted"></i>
+                    <h4 class="m-t-sm">@localizer["NoHolds"]</h4>
+                    <p class="text-muted">@localizer["NoRowsHelp"]</p>
+                </div>
+            }
+            else
+            {
+                <div class="table-responsive">
+                    <table class="table table-striped rgw-table">
+                        <thead>
+                            <tr>
+                                <th>@localizer["HoldReference"]</th>
+                                <th>@localizer["HoldScope"]</th>
+                                <th>@localizer["HoldPeriod"]</th>
+                                <th>@localizer["State"]</th>
+                                <th class="rgw-row-actions">@localizer["Actions"]</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var hold in Model)
+                            {
+                                <tr>
+                                    <td>
+                                        @hold.ReferenceNumber
+                                        <small class="text-muted rgw-sub">@hold.Reason</small>
+                                    </td>
+                                    <td>
+                                        @(hold.RecordId ?? localizer["HoldAllMatching"].Value)
+                                        <small class="text-muted rgw-sub">@(hold.DefinitionKey ?? localizer["AllDefinitions"].Value)</small>
+                                    </td>
+                                    <td>
+                                        @(hold.PeriodStart?.ToString("u") ?? localizer["HoldAnyStart"].Value)
+                                        &mdash;
+                                        @(hold.PeriodEnd?.ToString("u") ?? localizer["HoldAnyEnd"].Value)
+                                    </td>
+                                    <td>
+                                        <span class="label @(hold.IsActive ? "label-danger" : "label-success")">@localizer[hold.IsActive ? "HoldActive" : "Released"]</span>
+                                        @if (hold.IsActive)
+                                        {
+                                            <small class="text-muted rgw-sub">@localizer["HoldPlacedBy"]: @hold.PlacedByUserId &middot; @hold.PlacedOn.ToString("u")</small>
+                                        }
+                                        else
+                                        {
+                                            <small class="text-muted rgw-sub">@localizer["HoldReleasedBy"]: @hold.ReleasedByUserId &middot; @hold.ReleasedOn?.ToString("u")</small>
+                                        }
+                                    </td>
+                                    <td class="rgw-row-actions">
+                                        @if (hold.IsActive)
+                                        {
+                                            <button type="button" class="btn btn-xs btn-warning" data-toggle="modal" data-target="#hold-release-@hold.RmsRecordLegalHoldId">@localizer["ReleaseHold"]</button>
+                                        }
+                                    </td>
+                                </tr>
+                                @if (!string.IsNullOrWhiteSpace(hold.Notes) || !string.IsNullOrWhiteSpace(hold.ReleaseNotes))
+                                {
+                                    <tr>
+                                        <td colspan="5">
+                                            <div style="white-space:pre-wrap">@hold.Notes</div>
+                                            @if (!string.IsNullOrWhiteSpace(hold.ReleaseNotes))
+                                            {
+                                                <div class="text-muted" style="white-space:pre-wrap">@hold.ReleaseNotes</div>
+                                            }
+                                        </td>
+                                    </tr>
+                                }
+                            }
+                        </tbody>
+                    </table>
+                </div>
+            }
+
+            @* ── Dialogs ─────────────────────────────────────────────────────── *@
+            <div class="modal fade rgw-modal" id="hold-place" tabindex="-1" role="dialog" aria-labelledby="hold-place-title">
+                <div class="modal-dialog modal-lg" role="document">
+                    <div class="modal-content">
+                        <div class="modal-header">
+                            <button type="button" class="close" data-dismiss="modal" aria-label="@localizer["Cancel"]"><span aria-hidden="true">&times;</span></button>
+                            <h4 class="modal-title" id="hold-place-title">@localizer["PlaceHold"]</h4>
+                        </div>
+                        <div class="modal-body">
+                            <form method="post" asp-action="Place" asp-area="User" asp-controller="RecordLegalHolds">
+                                @Html.AntiForgeryToken()
+                                <div class="rgw-grid">
+                                    <div class="form-group">
+                                        <label for="hold-record">@localizer["HoldRecordId"]</label>
+                                        <input class="form-control" id="hold-record" name="RecordId" value="@ViewBag.RecordId" maxlength="36" />
+                                        <span class="help-block">@localizer["HoldRecordIdHelp"]</span>
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="hold-definition">@localizer["HoldDefinition"]</label>
+                                        <select class="form-control" id="hold-definition" name="DefinitionKey">
+                                            <option value="">@localizer["AllDefinitions"]</option>
+                                            @foreach (var key in RmsDefinitionKeys.LockedTypes.Keys)
+                                            {
+                                                <option value="@key">@key</option>
+                                            }
+                                            <option value="@RmsDefinitionKeys.NerisIncidentReport">@localizer["HoldNerisScope"]</option>
+                                        </select>
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="hold-start">@localizer["HoldPeriodStart"]</label>
+                                        <input class="form-control" id="hold-start" type="datetime-local" name="PeriodStart" />
+                                        <span class="help-block">@localizer["HoldScopeHelp"]</span>
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="hold-end">@localizer["HoldPeriodEnd"]</label>
+                                        <input class="form-control" id="hold-end" type="datetime-local" name="PeriodEnd" />
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="hold-reason">@localizer["HoldReason"]</label>
+                                        <select class="form-control" id="hold-reason" name="Reason">
+                                            <option value="Litigation">@localizer["HoldReasonLitigation"]</option>
+                                            <option value="Investigation">@localizer["HoldReasonInvestigation"]</option>
+                                            <option value="Public records request">@localizer["HoldReasonRecordsRequest"]</option>
+                                            <option value="Other">@localizer["HoldReasonOther"]</option>
+                                        </select>
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="hold-reference">@localizer["HoldReference"]</label>
+                                        <input class="form-control" id="hold-reference" name="ReferenceNumber" required maxlength="100" />
+                                    </div>
+                                    <div class="form-group rgw-wide">
+                                        <label for="hold-notes">@localizer["HoldNotes"]</label>
+                                        <textarea class="form-control" id="hold-notes" name="Notes" rows="3" required maxlength="4000"></textarea>
+                                    </div>
+                                </div>
+                                <div class="rgw-wizard-actions">
+                                    <div class="rgw-wizard-spacer"></div>
+                                    <button type="button" class="btn btn-white" data-dismiss="modal">@localizer["Cancel"]</button>
+                                    <button class="btn btn-primary" type="submit">@localizer["PlaceHold"]</button>
+                                </div>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            @foreach (var hold in Model.Where(x => x.IsActive))
+            {
+                <div class="modal fade rgw-modal" id="hold-release-@hold.RmsRecordLegalHoldId" tabindex="-1" role="dialog" aria-labelledby="hold-release-@(hold.RmsRecordLegalHoldId)-title">
+                    <div class="modal-dialog" role="document">
+                        <div class="modal-content">
+                            <div class="modal-header">
+                                <button type="button" class="close" data-dismiss="modal" aria-label="@localizer["Cancel"]"><span aria-hidden="true">&times;</span></button>
+                                <h4 class="modal-title" id="hold-release-@(hold.RmsRecordLegalHoldId)-title">@localizer["ReleaseHold"] &middot; @hold.ReferenceNumber</h4>
+                            </div>
+                            <div class="modal-body">
+                                <form method="post" asp-action="Release" asp-controller="RecordLegalHolds" asp-area="User">
+                                    @Html.AntiForgeryToken()
+                                    <input type="hidden" name="id" value="@hold.RmsRecordLegalHoldId" />
+                                    <input type="hidden" name="expectedVersion" value="@hold.RowVersion" />
+                                    <div class="rgw-grid">
+                                        <div class="form-group rgw-wide">
+                                            <label for="release-reason-@hold.RmsRecordLegalHoldId">@localizer["ReleaseHoldReason"]</label>
+                                            <textarea class="form-control" id="release-reason-@hold.RmsRecordLegalHoldId" name="reason" rows="3" required maxlength="4000"></textarea>
+                                        </div>
+                                    </div>
+                                    <div class="rgw-wizard-actions">
+                                        <div class="rgw-wizard-spacer"></div>
+                                        <button type="button" class="btn btn-white" data-dismiss="modal">@localizer["Cancel"]</button>
+                                        <button class="btn btn-warning" type="submit">@localizer["ReleaseHold"]</button>
+                                    </div>
+                                </form>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            }
+        </div>
+    </div>
+</div>
+
+@section Styles {
+    <link rel="stylesheet" href="~/css/workspace.css" asp-append-version="true" />
 }

--- a/Web/Resgrid.Web/Areas/User/Views/RecordSubmissions/Details.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/RecordSubmissions/Details.cshtml
@@ -1,61 +1,227 @@
 @using Resgrid.Model
 @model Resgrid.Web.Areas.User.Models.Records.RecordSubmissionView
+@inject IStringLocalizer<Resgrid.Localization.Areas.User.Records.Records> localizer
+@*
+    Submission history and recovery. The two recovery commands are consequential and both ask
+    for a written basis, so each opens in a dialog; the delivery history stays inline because
+    it is what the reader came to read.
+*@
+@functions {
+    string StatePill(RmsSubmissionState state) => state switch
+    {
+        RmsSubmissionState.Rejected or RmsSubmissionState.Failed => "label-danger",
+        _ => "label-info"
+    };
+}
 @{
-    ViewBag.Title = "Submission history and recovery";
     var submission = Model.Submission;
-    var canBind = submission.DestinationIdentity == null && submission.SentOn == null && submission.Attempts == 0 && submission.ExternalId == null && !submission.RequiresReconciliation && !submission.CreatePendingReceipt;
+    var canBind = submission.DestinationIdentity == null && submission.SentOn == null && submission.Attempts == 0
+        && submission.ExternalId == null && !submission.RequiresReconciliation && !submission.CreatePendingReceipt;
     var ambiguous = submission.RequiresReconciliation || submission.CreatePendingReceipt;
     var recoverable = ambiguous || submission.State == (int)RmsSubmissionState.Rejected || submission.State == (int)RmsSubmissionState.Failed;
     var reportController = submission.Destination == RmsSubmissionDestinations.NerisIncidentAnalysis ? "IncidentAnalysis" : "IncidentReports";
+    var canVerifyAbsence = Model.IsAdministrator && submission.ExternalId == null && recoverable;
+
+    ViewBag.Title = "Resgrid | " + localizer["SubmissionRecoveryHeader"];
+    ViewData["Title"] = localizer["SubmissionRecoveryHeader"].Value;
+    ViewData["Subtitle"] = localizer["SubmissionRecoveryIntro"].Value;
+    ViewData["ParentText"] = localizer["Submissions"].Value;
+    ViewData["ParentController"] = reportController;
+    ViewData["ParentAction"] = "Details";
+    ViewData["ParentId"] = submission.RecordId;
 }
+
+@await Html.PartialAsync("_RmsShell")
+
 <div class="wrapper wrapper-content">
-    <h2>Submission history and recovery</h2>
-    <p><a asp-controller="@reportController" asp-action="Details" asp-route-id="@submission.RecordId">Return to report</a></p>
-    @if (Model.Message != null) { <p class="alert alert-success" role="status">@Model.Message</p> }
-    @if (Model.Error != null) { <p class="alert alert-danger" role="alert">@Model.Error</p> }
-    <dl>
-        <dt>State</dt><dd>@((RmsSubmissionState)submission.State)</dd>
-        <dt>Destination</dt><dd>@submission.Destination · @submission.DestinationVersion</dd>
-        <dt>Filing identifier</dt><dd>@(submission.ExternalId ?? "No identifier recorded")</dd>
-        <dt>Attempts</dt><dd>@submission.Attempts / @submission.MaxAttempts</dd>
-        <dt>Latest issue</dt><dd>@submission.ErrorSummary</dd>
-    </dl>
-    <h3>Delivery and response history</h3>
-    <p>Times are UTC. Earlier responses remain available after rejection, retry and correction.</p>
-    @if (Model.Exchanges.Count == 0) { <p>No exchange history was recorded for this legacy submission. Its last stored response appears below.</p> }
-    @foreach (var exchange in Model.Exchanges.OrderBy(e => e.OccurredOn).ThenBy(e => e.RmsSubmissionExchangeId))
-    {
-        <details style="margin-bottom:12px">
-            <summary>@exchange.OccurredOn.ToString("u") — @exchange.Operation / @exchange.Stage · attempt @exchange.AttemptNumber</summary>
-            <p>Exchange @exchange.ExchangeId</p>
-            @if (exchange.OutcomeJson != null) { <pre style="white-space:pre-wrap;overflow-wrap:anywhere">@exchange.OutcomeJson</pre><p>Response checksum: @exchange.OutcomeChecksum</p> }
-        </details>
-    }
-    <details><summary>Exact queued payload</summary><pre style="white-space:pre-wrap;overflow-wrap:anywhere">@submission.PayloadJson</pre><p>Payload checksum: @submission.PayloadChecksum</p></details>
-    @if (submission.ResponseJson != null) { <details><summary>Last stored destination response</summary><pre style="white-space:pre-wrap;overflow-wrap:anywhere">@submission.ResponseJson</pre><p>Response checksum: @submission.ResponseChecksum</p></details> }
-    @if (canBind || ambiguous)
-    {
-        <h3>@(canBind ? "Bind an unsent submission" : "Verify an existing destination filing")</h3>
-        <p>@(canBind ? "Review the department's current NERIS entity and destination. Binding this unsent submission queues it for delivery." : "Locate the filing in the original destination. Its identifier is checked against the queued report before polling resumes.")</p>
-        <form method="post" asp-action="Reconcile">
-            @Html.AntiForgeryToken()
-            <input type="hidden" name="submissionId" value="@submission.RmsSubmissionId" /><input type="hidden" name="RowVersion" value="@submission.RowVersion" />
-            @if (!canBind) { <label for="external-id">Destination filing identifier</label><input id="external-id" name="ExternalId" class="form-control" value="@submission.ExternalId" maxlength="100" required /> }
-            <label for="receipt-reason">Reason</label><textarea id="receipt-reason" name="Reason" class="form-control" maxlength="2000" required></textarea>
-            <button type="submit" class="btn btn-primary">@(canBind ? "Bind and queue" : "Verify receipt")</button>
-        </form>
-    }
-    @if (Model.IsAdministrator && submission.ExternalId == null && recoverable)
-    {
-        <h3>Record externally verified absence of a filing</h3>
-        <p>Use only after the original destination or its support team confirms that this attempted filing was not created. An empty search result alone is insufficient. This records your verification and clears the recovery block; it sends nothing and does not schedule a retry.</p>
-        <form method="post" asp-action="Reconcile">
-            @Html.AntiForgeryToken()
-            <input type="hidden" name="submissionId" value="@submission.RmsSubmissionId" /><input type="hidden" name="RowVersion" value="@submission.RowVersion" />
-            <label for="verification-reference">Destination verification or support reference</label><input id="verification-reference" name="VerificationReference" class="form-control" maxlength="500" required />
-            <label for="absence-reason">What was verified, and by whom</label><textarea id="absence-reason" name="Reason" class="form-control" maxlength="2000" required></textarea>
-            <p><label><input type="checkbox" name="ConfirmedNotCreated" value="true" required /> I verified that the original destination did not create this filing.</label></p>
-            <button type="submit" class="btn btn-warning">Record verification without sending</button>
-        </form>
-    }
+    <div class="ibox float-e-margins">
+        <div class="ibox-title"><h5>@localizer["SubmissionRecoveryHeader"]</h5></div>
+        <div class="ibox-content">
+
+            @if (Model.Message != null)
+            {
+                <div class="alert alert-success" role="status">@Model.Message</div>
+            }
+            @if (Model.Error != null)
+            {
+                <div class="alert alert-danger" role="alert">@Model.Error</div>
+            }
+
+            <div class="rgw-toolbar">
+                <a class="btn btn-default btn-sm" asp-controller="@reportController" asp-action="Details" asp-route-id="@submission.RecordId"><i class="fa fa-arrow-left"></i> @localizer["ReturnToReport"]</a>
+                <div class="rgw-toolbar-spacer"></div>
+                @if (canBind || ambiguous)
+                {
+                    <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#submission-reconcile">
+                        <i class="fa fa-link"></i> @localizer[canBind ? "SubmissionBindHeader" : "SubmissionVerifyHeader"]
+                    </button>
+                }
+                @if (canVerifyAbsence)
+                {
+                    <button type="button" class="btn btn-warning" data-toggle="modal" data-target="#submission-absence">
+                        <i class="fa fa-ban"></i> @localizer["SubmissionAbsenceHeader"]
+                    </button>
+                }
+            </div>
+
+            <p class="text-muted">
+                <span class="label @StatePill((RmsSubmissionState)submission.State)">@localizer["SubmissionState" + (RmsSubmissionState)submission.State]</span>
+                @submission.Destination &middot; @submission.DestinationVersion
+            </p>
+
+            <dl class="dl-horizontal">
+                <dt>@localizer["ExternalId"]</dt><dd>@(submission.ExternalId ?? localizer["SubmissionNoIdentifier"].Value)</dd>
+                <dt>@localizer["Attempts"]</dt><dd>@submission.Attempts / @submission.MaxAttempts</dd>
+                <dt>@localizer["SubmissionLatestIssue"]</dt><dd>@submission.ErrorSummary</dd>
+            </dl>
+
+            <div class="hr-line-dashed"></div>
+
+            <h3>@localizer["SubmissionExchangeHeader"]</h3>
+            <div class="alert alert-info"><i class="fa fa-info-circle"></i> @localizer["SubmissionExchangeIntro"]</div>
+
+            @if (Model.Exchanges.Count == 0)
+            {
+                <div class="text-center m-t-lg m-b-lg">
+                    <i class="fa fa-exchange fa-3x text-muted"></i>
+                    <h4 class="m-t-sm">@localizer["SubmissionNoExchanges"]</h4>
+                </div>
+            }
+            else
+            {
+                <div class="table-responsive">
+                    <table class="table table-striped rgw-table">
+                        <thead><tr><th>@localizer["OccurredOn"]</th><th>@localizer["SubmissionOperation"]</th><th class="text-right">@localizer["Attempts"]</th><th>@localizer["SubmissionResponse"]</th></tr></thead>
+                        <tbody>
+                            @foreach (var exchange in Model.Exchanges.OrderBy(e => e.OccurredOn).ThenBy(e => e.RmsSubmissionExchangeId))
+                            {
+                                <tr>
+                                    <td>@exchange.OccurredOn.ToString("u")</td>
+                                    <td>
+                                        @exchange.Operation / @exchange.Stage
+                                        <small class="text-muted rgw-sub">@exchange.ExchangeId</small>
+                                    </td>
+                                    <td class="text-right">@exchange.AttemptNumber</td>
+                                    <td>
+                                        @if (exchange.OutcomeJson != null)
+                                        {
+                                            <details>
+                                                <summary>@localizer["SubmissionResponse"]</summary>
+                                                <pre style="white-space:pre-wrap;overflow-wrap:anywhere">@exchange.OutcomeJson</pre>
+                                                <small class="text-muted">@localizer["Checksum"]: @exchange.OutcomeChecksum</small>
+                                            </details>
+                                        }
+                                    </td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                </div>
+            }
+
+            <div class="panel panel-default">
+                <div class="panel-heading">@localizer["Payload"]</div>
+                <div class="panel-body">
+                    <pre style="white-space:pre-wrap;overflow-wrap:anywhere">@submission.PayloadJson</pre>
+                    <small class="text-muted">@localizer["Checksum"]: @submission.PayloadChecksum</small>
+                </div>
+            </div>
+
+            @if (submission.ResponseJson != null)
+            {
+                <div class="panel panel-default">
+                    <div class="panel-heading">@localizer["SubmissionLastResponseHeader"]</div>
+                    <div class="panel-body">
+                        <pre style="white-space:pre-wrap;overflow-wrap:anywhere">@submission.ResponseJson</pre>
+                        <small class="text-muted">@localizer["Checksum"]: @submission.ResponseChecksum</small>
+                    </div>
+                </div>
+            }
+
+            @* ── Dialogs ─────────────────────────────────────────────────────── *@
+            @if (canBind || ambiguous)
+            {
+                <div class="modal fade rgw-modal" id="submission-reconcile" tabindex="-1" role="dialog" aria-labelledby="submission-reconcile-title">
+                    <div class="modal-dialog" role="document">
+                        <div class="modal-content">
+                            <div class="modal-header">
+                                <button type="button" class="close" data-dismiss="modal" aria-label="@localizer["Cancel"]"><span aria-hidden="true">&times;</span></button>
+                                <h4 class="modal-title" id="submission-reconcile-title">@localizer[canBind ? "SubmissionBindHeader" : "SubmissionVerifyHeader"]</h4>
+                            </div>
+                            <div class="modal-body">
+                                <p class="text-muted">@localizer[canBind ? "SubmissionBindIntro" : "SubmissionVerifyIntro"]</p>
+                                <form method="post" asp-action="Reconcile">
+                                    @Html.AntiForgeryToken()
+                                    <input type="hidden" name="submissionId" value="@submission.RmsSubmissionId" />
+                                    <input type="hidden" name="RowVersion" value="@submission.RowVersion" />
+                                    <div class="rgw-grid">
+                                        @if (!canBind)
+                                        {
+                                            <div class="form-group rgw-wide">
+                                                <label for="external-id">@localizer["ExternalId"]</label>
+                                                <input id="external-id" name="ExternalId" class="form-control" value="@submission.ExternalId" maxlength="100" required />
+                                            </div>
+                                        }
+                                        <div class="form-group rgw-wide">
+                                            <label for="receipt-reason">@localizer["Reason"]</label>
+                                            <textarea id="receipt-reason" name="Reason" class="form-control" rows="3" maxlength="2000" required></textarea>
+                                        </div>
+                                    </div>
+                                    <div class="rgw-wizard-actions">
+                                        <div class="rgw-wizard-spacer"></div>
+                                        <button type="button" class="btn btn-white" data-dismiss="modal">@localizer["Cancel"]</button>
+                                        <button type="submit" class="btn btn-primary">@localizer[canBind ? "SubmissionBindAction" : "SubmissionVerifyAction"]</button>
+                                    </div>
+                                </form>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            }
+
+            @if (canVerifyAbsence)
+            {
+                <div class="modal fade rgw-modal" id="submission-absence" tabindex="-1" role="dialog" aria-labelledby="submission-absence-title">
+                    <div class="modal-dialog modal-lg" role="document">
+                        <div class="modal-content">
+                            <div class="modal-header">
+                                <button type="button" class="close" data-dismiss="modal" aria-label="@localizer["Cancel"]"><span aria-hidden="true">&times;</span></button>
+                                <h4 class="modal-title" id="submission-absence-title">@localizer["SubmissionAbsenceHeader"]</h4>
+                            </div>
+                            <div class="modal-body">
+                                <div class="alert alert-warning"><i class="fa fa-exclamation-triangle"></i> @localizer["SubmissionAbsenceIntro"]</div>
+                                <form method="post" asp-action="Reconcile">
+                                    @Html.AntiForgeryToken()
+                                    <input type="hidden" name="submissionId" value="@submission.RmsSubmissionId" />
+                                    <input type="hidden" name="RowVersion" value="@submission.RowVersion" />
+                                    <div class="rgw-grid">
+                                        <div class="form-group rgw-wide">
+                                            <label for="verification-reference">@localizer["SubmissionVerificationReference"]</label>
+                                            <input id="verification-reference" name="VerificationReference" class="form-control" maxlength="500" required />
+                                        </div>
+                                        <div class="form-group rgw-wide">
+                                            <label for="absence-reason">@localizer["SubmissionAbsenceReason"]</label>
+                                            <textarea id="absence-reason" name="Reason" class="form-control" rows="3" maxlength="2000" required></textarea>
+                                        </div>
+                                        <div class="form-group rgw-wide">
+                                            <div class="checkbox"><label><input type="checkbox" name="ConfirmedNotCreated" value="true" required /> @localizer["SubmissionAbsenceConfirm"]</label></div>
+                                        </div>
+                                    </div>
+                                    <div class="rgw-wizard-actions">
+                                        <div class="rgw-wizard-spacer"></div>
+                                        <button type="button" class="btn btn-white" data-dismiss="modal">@localizer["Cancel"]</button>
+                                        <button type="submit" class="btn btn-warning">@localizer["SubmissionAbsenceAction"]</button>
+                                    </div>
+                                </form>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            }
+        </div>
+    </div>
 </div>
+
+@section Styles {
+    <link rel="stylesheet" href="~/css/workspace.css" asp-append-version="true" />
+}

--- a/Web/Resgrid.Web/Areas/User/Views/Records/Dashboard.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Records/Dashboard.cshtml
@@ -27,7 +27,15 @@
 	}
 	@if (!Model.ModuleState.RecordsUsable)
 	{
-		<div class="alert alert-warning">@localizer["RecordsNotActivated"]</div>
+		<div class="alert alert-warning">
+			@localizer["NotActivatedNotice"]
+			@if (Model.IsDepartmentAdmin && Model.ModuleState.FlagEnabled)
+			{
+				<div class="m-t-sm">
+					<a class="btn btn-warning" asp-controller="Records" asp-action="Activate" asp-route-area="User"><i class="fa fa-power-off"></i> @localizer["ActivateHeader"]</a>
+				</div>
+			}
+		</div>
 	}
 
 	@if (d != null)

--- a/Web/Resgrid.Web/Areas/User/Views/Records/Details.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Records/Details.cshtml
@@ -245,7 +245,7 @@
 						<form method="post" enctype="multipart/form-data" asp-controller="Records" asp-action="AddAttachment" asp-route-area="User" asp-route-id="@record.RmsOperationalRecordId">
 							@Html.AntiForgeryToken()
 							<input type="file" name="files" multiple />
-							<label for="record-file-classification">File classification</label><select id="record-file-classification" name="classification" class="form-control"><option value="1">Restricted</option><option value="0">Unrestricted operational content</option></select>
+							<label for="record-file-classification">@localizer["FileClassification"]</label><select id="record-file-classification" name="classification" class="form-control"><option value="1">@localizer["ClassificationRestricted"]</option><option value="0">@localizer["ClassificationUnrestricted"]</option></select>
 							<button type="submit" class="btn btn-xs btn-default m-t-xs">@localizer["AddAttachment"]</button>
 						</form>
 					}

--- a/Web/Resgrid.Web/Areas/User/Views/Records/Edit.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Records/Edit.cshtml
@@ -118,7 +118,7 @@
 								<div class="col-sm-6"><select class="form-control" asp-for="CallId" asp-items="Model.Calls"><option value="">@localizer["NoCall"]</option></select></div>
 								@if (t == RmsOperationalRecordType.Run && !Model.CallId.HasValue && ClaimsAuthorizationHelper.CanCreateCall())
 								{
-									<div class="col-sm-4">@if (Model.IsNew) { <span>Save the draft to create and link a historical Call.</span> } else { <a asp-action="NewRunCall" asp-controller="Records" asp-route-area="User" asp-route-id="@Model.RecordId" class="btn btn-default">Create Call for Run</a> }</div>
+									<div class="col-sm-4">@if (Model.IsNew) { <span>@localizer["NewRunCallSaveFirst"]</span> } else { <a asp-action="NewRunCall" asp-controller="Records" asp-route-area="User" asp-route-id="@Model.RecordId" class="btn btn-default">@localizer["NewRunCallHeader"]</a> }</div>
 								}
 							</div>
 							<div class="form-group">
@@ -232,16 +232,16 @@
 							@for (var i = 0; i < Model.ParticipantRows.Count; i++)
 							{
 								var participant = Model.ParticipantRows[i]; var name = Model.Personnel.FirstOrDefault(p => p.Value == participant.UserId)?.Text ?? participant.UserId;
-								<tr><td><label><input type="checkbox" asp-for="ParticipantRows[i].Selected" /> Include</label><select class="form-control input-sm" asp-for="ParticipantRows[i].UserId" asp-items="Model.Personnel" aria-label="Participant"><option value="">Choose a participant</option>
+								<tr><td><label><input type="checkbox" asp-for="ParticipantRows[i].Selected" /> Include</label><select class="form-control input-sm" asp-for="ParticipantRows[i].UserId" asp-items="Model.Personnel" aria-label="@localizer["ParticipantLabel"]"><option value="">@localizer["ParticipantChoose"]</option>
 								@if (!string.IsNullOrWhiteSpace(participant.UserId) && Model.Personnel.All(p => p.Value != participant.UserId)) { <option value="@participant.UserId">@name</option> }
 								</select></td>
-								<td><select class="form-control input-sm" asp-for="ParticipantRows[i].UnitId" asp-items="Model.AvailableUnits"><option value="">No assigned unit</option>
-								@if (participant.UnitId.HasValue && Model.AvailableUnits.All(u => u.Value != participant.UnitId.Value.ToString())) { <option value="@participant.UnitId">Previously assigned unit @participant.UnitId</option> }
-								</select></td><td><input class="form-control input-sm" asp-for="ParticipantRows[i].Role" maxlength="100" aria-label="Role for @name" /></td></tr>
+								<td><select class="form-control input-sm" asp-for="ParticipantRows[i].UnitId" asp-items="Model.AvailableUnits"><option value="">@localizer["ParticipantNoUnit"]</option>
+								@if (participant.UnitId.HasValue && Model.AvailableUnits.All(u => u.Value != participant.UnitId.Value.ToString())) { <option value="@participant.UnitId">@localizer["ParticipantPreviousUnit"] @participant.UnitId</option> }
+								</select></td><td><input class="form-control input-sm" asp-for="ParticipantRows[i].Role" maxlength="100" aria-label="@localizer["ParticipantRoleFor", name]" /></td></tr>
 							}
 							</tbody></table>
-							<button class="btn btn-default" type="button" id="add-record-participant">Add participant</button>
-							<template id="record-participant-template"><tr><td><label><input type="checkbox" name="ParticipantRows[__index__].Selected" value="true" checked /> Include</label><input type="hidden" name="ParticipantRows[__index__].Selected" value="false" /><select class="form-control input-sm" name="ParticipantRows[__index__].UserId" aria-label="Participant"><option value="">Choose a participant</option>@foreach (var p in Model.Personnel) { <option value="@p.Value">@p.Text</option> }</select></td><td><select class="form-control input-sm" name="ParticipantRows[__index__].UnitId" aria-label="Assigned unit"><option value="">No assigned unit</option>@foreach (var unit in Model.AvailableUnits) { <option value="@unit.Value">@unit.Text</option> }</select></td><td><input class="form-control input-sm" name="ParticipantRows[__index__].Role" maxlength="100" aria-label="Participant role" /></td></tr></template>
+							<button class="btn btn-default" type="button" id="add-record-participant">@localizer["ParticipantAdd"]</button>
+							<template id="record-participant-template"><tr><td><label><input type="checkbox" name="ParticipantRows[__index__].Selected" value="true" checked /> @localizer["ParticipantInclude"]</label><input type="hidden" name="ParticipantRows[__index__].Selected" value="false" /><select class="form-control input-sm" name="ParticipantRows[__index__].UserId" aria-label="@localizer["ParticipantLabel"]"><option value="">@localizer["ParticipantChoose"]</option>@foreach (var p in Model.Personnel) { <option value="@p.Value">@p.Text</option> }</select></td><td><select class="form-control input-sm" name="ParticipantRows[__index__].UnitId" aria-label="@localizer["ParticipantUnitLabel"]"><option value="">@localizer["ParticipantNoUnit"]</option>@foreach (var unit in Model.AvailableUnits) { <option value="@unit.Value">@unit.Text</option> }</select></td><td><input class="form-control input-sm" name="ParticipantRows[__index__].Role" maxlength="100" aria-label="@localizer["ParticipantRoleLabel"]" /></td></tr></template>
 							<script src="~/js/record-participants.js" asp-append-version="true" defer></script>
 						</div>
 					</div>
@@ -288,7 +288,7 @@
 					<div class="ibox-title"><h5>@localizer["Attachments"]</h5></div>
 					<div class="ibox-content">
 						<input type="file" name="files" multiple />
-						<label asp-for="AttachmentClassification">File classification (including names and descriptions)</label><select asp-for="AttachmentClassification" class="form-control"><option value="1">Restricted</option><option value="0">Unrestricted operational content</option></select>
+						<label asp-for="AttachmentClassification">@localizer["FileClassification"]</label><select asp-for="AttachmentClassification" class="form-control"><option value="1">@localizer["ClassificationRestricted"]</option><option value="0">@localizer["ClassificationUnrestricted"]</option></select><span class="help-block">@localizer["FileClassificationHelp"]</span>
 					</div>
 				</div>
 

--- a/Web/Resgrid.Web/Areas/User/Views/Records/Index.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Records/Index.cshtml
@@ -31,58 +31,92 @@
 		</ol>
 	</div>
 	<div class="col-sm-8">
-		<div class="btn-group top-page-buttons" style="float:right;padding-right:15px;">
-			@if (Model.ModuleState.RecordsUsable && ClaimsAuthorizationHelper.CanCreateRecord())
+		@{
+			// Everything past the three primary actions lives in two menus so the heading stays readable.
+			var usable = Model.ModuleState.RecordsUsable;
+			var canExport = usable && ClaimsAuthorizationHelper.CanExportRecords();
+			var canAccountability = usable && (Model.IsDepartmentAdmin || ClaimsAuthorizationHelper.CanReviewRecords() || ClaimsAuthorizationHelper.CanApproveRecords() || ClaimsAuthorizationHelper.CanManageRecordReports());
+			var canQuality = usable && Model.QualityReviewOn && ClaimsAuthorizationHelper.CanReviewRecords();
+			var canAnalytics = usable && Model.AnalyticsOn;
+			var canDisclosures = usable && ClaimsAuthorizationHelper.CanManageRecordDisclosures();
+			var canTemplates = usable && ClaimsAuthorizationHelper.CanManageRecordReports();
+			var canDefinitions = usable && ClaimsAuthorizationHelper.CanManageRecordDefinitions();
+			var canDeployments = usable && ClaimsAuthorizationHelper.CanCreateRecord();
+			var showManage = canDisclosures || canTemplates || canDefinitions || canDeployments || Model.IsDepartmentAdmin;
+		}
+		<div class="btn-toolbar top-page-buttons" style="float:right;padding-right:15px;">
+			@if (usable)
 			{
-				<a class="btn btn-success" asp-controller="Records" asp-action="New" asp-route-area="User"><i class="icon-plus"></i> @localizer["NewRecord"]</a>
+				<div class="btn-group">
+					@if (ClaimsAuthorizationHelper.CanCreateRecord())
+					{
+						<a class="btn btn-success" asp-controller="Records" asp-action="New" asp-route-area="User"><i class="icon-plus"></i> @localizer["NewRecord"]</a>
+					}
+					<a class="btn btn-primary" asp-controller="IncidentReports" asp-action="Index" asp-route-area="User"><i class="fa fa-fire"></i> @localizer["IncidentReports"]</a>
+					<a class="btn btn-default" asp-controller="Records" asp-action="Dashboard" asp-route-area="User"><i class="fa fa-dashboard"></i> @localizer["RecordsDashboard"]</a>
+				</div>
 			}
-			@if (Model.ModuleState.RecordsUsable)
+			@if (usable)
 			{
-				<a class="btn btn-primary" asp-controller="IncidentReports" asp-action="Index" asp-route-area="User"><i class="fa fa-fire"></i> @localizer["IncidentReports"]</a>
-				<a class="btn btn-default" asp-controller="Records" asp-action="Dashboard" asp-route-area="User"><i class="fa fa-dashboard"></i> @localizer["RecordsDashboard"]</a>
+				<div class="btn-group">
+					<button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-bar-chart"></i> @localizer["ReportsMenu"] <span class="caret"></span></button>
+					<ul class="dropdown-menu dropdown-menu-right">
+						@if (canExport)
+						{
+							<li role="presentation" class="dropdown-header">@localizer["ExportListHeader"]</li>
+							<li><a asp-controller="Records" asp-action="ExportList" asp-route-area="User" asp-route-year="@Model.Year" asp-route-definitionKey="@Model.DefinitionKey" asp-route-state="@Model.StateFilter" asp-route-q="@Model.Query" asp-route-format="csv"><i class="fa fa-download"></i> @localizer["ExportCsv"]</a></li>
+							<li><a asp-controller="Records" asp-action="ExportList" asp-route-area="User" asp-route-year="@Model.Year" asp-route-definitionKey="@Model.DefinitionKey" asp-route-state="@Model.StateFilter" asp-route-q="@Model.Query" asp-route-format="json"><i class="fa fa-download"></i> @localizer["ExportJson"]</a></li>
+							<li role="separator" class="divider"></li>
+						}
+						<li><a asp-controller="RecordSavedReports" asp-action="Index" asp-route-area="User"><i class="fa fa-table"></i> @localizer["SavedReports"]</a></li>
+						@if (canAnalytics)
+						{
+							<li><a asp-controller="RecordsAnalytics" asp-action="Index" asp-route-area="User"><i class="fa fa-bar-chart"></i> @localizer["AnalyticsHeader"]</a></li>
+						}
+						@if (canAccountability)
+						{
+							<li><a asp-controller="Records" asp-action="Accountability" asp-route-area="User"><i class="fa fa-users"></i> @localizer["Accountability"]</a></li>
+						}
+						@if (canQuality)
+						{
+							<li><a asp-controller="RecordsQuality" asp-action="Index" asp-route-area="User"><i class="fa fa-check-square-o"></i> @localizer["QualityReview"]</a></li>
+						}
+					</ul>
+				</div>
 			}
-			@if (Model.ModuleState.RecordsUsable && ClaimsAuthorizationHelper.CanManageRecordDisclosures())
+			@if (showManage)
 			{
-				<a class="btn btn-default" asp-controller="Disclosures" asp-action="Index" asp-route-area="User"><i class="fa fa-gavel"></i> @localizer["Disclosures"]</a>
-			}
-			@if (Model.ModuleState.RecordsUsable && ClaimsAuthorizationHelper.CanManageRecordReports())
-			{
-				<a class="btn btn-default" asp-controller="RecordsExportTemplates" asp-action="Index" asp-route-area="User"><i class="fa fa-paper-plane"></i> @localizer["ExportTemplates"]</a>
-			}
-			@if (Model.ModuleState.RecordsUsable && ClaimsAuthorizationHelper.CanManageRecordDefinitions())
-			{
-				<a class="btn btn-default" asp-controller="RecordDefinitions" asp-action="Index" asp-route-area="User"><i class="fa fa-cubes"></i> @localizer["Definitions"]</a>
-			}
-			@if (Model.ModuleState.RecordsUsable)
-			{
-				<a class="btn btn-default" asp-controller="RecordSavedReports" asp-action="Index" asp-route-area="User"><i class="fa fa-table"></i> @localizer["SavedReports"]</a>
-			}
-			@if (Model.ModuleState.RecordsUsable && ClaimsAuthorizationHelper.CanCreateRecord())
-			{
-				<a class="btn btn-default" asp-controller="RecordDeployments" asp-action="Index" asp-route-area="User"><i class="fa fa-globe"></i> @localizer["Deployments"]</a>
-			}
-			@if (Model.ModuleState.RecordsUsable && ClaimsAuthorizationHelper.CanExportRecords())
-			{
-				<a class="btn btn-default" asp-controller="Records" asp-action="ExportList" asp-route-area="User" asp-route-year="@Model.Year" asp-route-definitionKey="@Model.DefinitionKey" asp-route-state="@Model.StateFilter" asp-route-q="@Model.Query" asp-route-format="csv"><i class="fa fa-download"></i> @localizer["ExportCsv"]</a>
-				<a class="btn btn-default" asp-controller="Records" asp-action="ExportList" asp-route-area="User" asp-route-year="@Model.Year" asp-route-definitionKey="@Model.DefinitionKey" asp-route-state="@Model.StateFilter" asp-route-q="@Model.Query" asp-route-format="json"><i class="fa fa-download"></i> @localizer["ExportJson"]</a>
-			}
-			@if (Model.ModuleState.RecordsUsable && (Model.IsDepartmentAdmin || ClaimsAuthorizationHelper.CanReviewRecords() || ClaimsAuthorizationHelper.CanApproveRecords() || ClaimsAuthorizationHelper.CanManageRecordReports()))
-			{
-				<a class="btn btn-default" asp-controller="Records" asp-action="Accountability" asp-route-area="User"><i class="fa fa-users"></i> @localizer["Accountability"]</a>
-			}
-			@if (Model.ModuleState.RecordsUsable && Model.QualityReviewOn && ClaimsAuthorizationHelper.CanReviewRecords())
-			{
-				<a class="btn btn-default" asp-controller="RecordsQuality" asp-action="Index" asp-route-area="User"><i class="fa fa-check-square-o"></i> @localizer["QualityReview"]</a>
-			}
-			@if (Model.ModuleState.RecordsUsable && Model.AnalyticsOn)
-			{
-				<a class="btn btn-default" asp-controller="RecordsAnalytics" asp-action="Index" asp-route-area="User"><i class="fa fa-bar-chart"></i> @localizer["AnalyticsHeader"]</a>
-			}
-			@if (Model.IsDepartmentAdmin)
-			{
-				<a class="btn btn-default" asp-controller="RecordsHealth" asp-action="Index" asp-route-area="User"><i class="fa fa-heartbeat"></i> @localizer["RecordsHealth"]</a>
-				<a class="btn btn-default" asp-controller="Records" asp-action="FieldRollout" asp-route-area="User"><i class="fa fa-mobile"></i> @localizer["FieldRollout"]</a>
-				<a class="btn btn-inverse" asp-controller="Records" asp-action="Settings" asp-route-area="User"><i class="fa fa-cog"></i> @localizer["Settings"]</a>
+				<div class="btn-group">
+					<button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-cog"></i> @localizer["ManageMenu"] <span class="caret"></span></button>
+					<ul class="dropdown-menu dropdown-menu-right">
+						@if (canDisclosures)
+						{
+							<li><a asp-controller="Disclosures" asp-action="Index" asp-route-area="User"><i class="fa fa-gavel"></i> @localizer["Disclosures"]</a></li>
+						}
+						@if (canDeployments)
+						{
+							<li><a asp-controller="RecordDeployments" asp-action="Index" asp-route-area="User"><i class="fa fa-globe"></i> @localizer["Deployments"]</a></li>
+						}
+						@if (canDefinitions)
+						{
+							<li><a asp-controller="RecordDefinitions" asp-action="Index" asp-route-area="User"><i class="fa fa-cubes"></i> @localizer["Definitions"]</a></li>
+						}
+						@if (canTemplates)
+						{
+							<li><a asp-controller="RecordsExportTemplates" asp-action="Index" asp-route-area="User"><i class="fa fa-paper-plane"></i> @localizer["ExportTemplates"]</a></li>
+						}
+						@if (Model.IsDepartmentAdmin)
+						{
+							if (canDisclosures || canDeployments || canDefinitions || canTemplates)
+							{
+								<li role="separator" class="divider"></li>
+							}
+							<li><a asp-controller="RecordsHealth" asp-action="Index" asp-route-area="User"><i class="fa fa-heartbeat"></i> @localizer["RecordsHealth"]</a></li>
+							<li><a asp-controller="Records" asp-action="FieldRollout" asp-route-area="User"><i class="fa fa-mobile"></i> @localizer["FieldRollout"]</a></li>
+							<li><a asp-controller="Records" asp-action="Settings" asp-route-area="User"><i class="fa fa-cog"></i> @localizer["Settings"]</a></li>
+						}
+					</ul>
+				</div>
 			}
 		</div>
 	</div>
@@ -242,6 +276,10 @@
 		</div>
 	</div>
 </div>
+
+@section Styles {
+	<link rel="stylesheet" href="~/css/workspace.css" asp-append-version="true" />
+}
 
 @section Scripts {
 	<script>

--- a/Web/Resgrid.Web/Areas/User/Views/Records/NewRunCall.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Records/NewRunCall.cshtml
@@ -1,16 +1,60 @@
 @model Resgrid.Web.Areas.User.Models.Records.RecordNewCallView
-@{ ViewBag.Title = "Resgrid | Create Call for Run"; }
-<div class="wrapper wrapper-content"><div class="ibox"><div class="ibox-title"><h2>Create Call for Run</h2></div><div class="ibox-content">
-    <p>Record a past incident and link it to this Run. The Call is created as closed and does not dispatch responders.</p>
-    @if (!string.IsNullOrEmpty(Model.ErrorMessage)) { <div class="alert alert-danger">@Model.ErrorMessage</div> }
-    <form method="post" asp-action="NewRunCall" asp-controller="Records" asp-area="User">
-        @Html.AntiForgeryToken()
-        <input type="hidden" asp-for="RecordId" /><input type="hidden" asp-for="RowVersion" />
-        <div class="form-group"><label asp-for="Name">Call name</label><input asp-for="Name" class="form-control" maxlength="200" required /></div>
-        <div class="form-group"><label asp-for="OccurredOn">Occurred at (department local time)</label><input asp-for="OccurredOn" type="datetime-local" asp-format="{0:yyyy-MM-ddTHH:mm}" class="form-control" required /></div>
-        <div class="form-group"><label asp-for="Address">Address</label><input asp-for="Address" class="form-control" maxlength="500" /></div>
-        <div class="form-group"><label asp-for="Nature">Nature of Call</label><textarea asp-for="Nature" class="form-control" rows="5" maxlength="16000"></textarea></div>
-        <button type="submit" class="btn btn-primary">Create and link Call</button>
-        <a asp-action="Edit" asp-controller="Records" asp-area="User" asp-route-id="@Model.RecordId" class="btn btn-default">Return to Run</a>
-    </form>
-</div></div></div>
+@inject IStringLocalizer<Resgrid.Localization.Areas.User.Records.Records> localizer
+@{
+    ViewBag.Title = "Resgrid | " + localizer["NewRunCallHeader"];
+    ViewData["Title"] = localizer["NewRunCallHeader"].Value;
+    ViewData["Subtitle"] = localizer["NewRunCallIntro"].Value;
+    ViewData["ParentText"] = localizer["EditRecordHeader"].Value;
+    ViewData["ParentAction"] = "Edit";
+    ViewData["ParentId"] = Model.RecordId;
+}
+
+@await Html.PartialAsync("_RmsShell")
+
+<div class="wrapper wrapper-content">
+    <div class="ibox float-e-margins">
+        <div class="ibox-title"><h5>@localizer["NewRunCallHeader"]</h5></div>
+        <div class="ibox-content">
+
+            <div class="alert alert-info"><i class="fa fa-info-circle"></i> @localizer["NewRunCallIntro"]</div>
+
+            @if (!string.IsNullOrEmpty(Model.ErrorMessage))
+            {
+                <div class="alert alert-danger" role="alert">@Model.ErrorMessage</div>
+            }
+
+            <form method="post" asp-action="NewRunCall" asp-controller="Records" asp-area="User">
+                @Html.AntiForgeryToken()
+                <input type="hidden" asp-for="RecordId" />
+                <input type="hidden" asp-for="RowVersion" />
+                <div class="rgw-grid">
+                    <div class="form-group">
+                        <label asp-for="Name">@localizer["NewRunCallName"]</label>
+                        <input asp-for="Name" class="form-control" maxlength="200" required />
+                    </div>
+                    <div class="form-group">
+                        <label asp-for="OccurredOn">@localizer["NewRunCallOccurredOn"]</label>
+                        <input asp-for="OccurredOn" type="datetime-local" asp-format="{0:yyyy-MM-ddTHH:mm}" class="form-control" required />
+                    </div>
+                    <div class="form-group rgw-wide">
+                        <label asp-for="Address">@localizer["NewRunCallAddress"]</label>
+                        <input asp-for="Address" class="form-control" maxlength="500" />
+                    </div>
+                    <div class="form-group rgw-wide">
+                        <label asp-for="Nature">@localizer["NewRunCallNature"]</label>
+                        <textarea asp-for="Nature" class="form-control" rows="5" maxlength="16000"></textarea>
+                    </div>
+                </div>
+                <div class="rgw-wizard-actions">
+                    <div class="rgw-wizard-spacer"></div>
+                    <a asp-action="Edit" asp-controller="Records" asp-area="User" asp-route-id="@Model.RecordId" class="btn btn-white">@localizer["Cancel"]</a>
+                    <button type="submit" class="btn btn-primary">@localizer["NewRunCallAction"]</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+@section Styles {
+    <link rel="stylesheet" href="~/css/workspace.css" asp-append-version="true" />
+}

--- a/Web/Resgrid.Web/Areas/User/Views/Records/_CustomFields.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Records/_CustomFields.cshtml
@@ -2,6 +2,7 @@
 @using Newtonsoft.Json
 @model RecordUdfSection
 @inject Resgrid.Model.Services.IUdfRenderingService UdfRenderer
+@inject IStringLocalizer<Resgrid.Localization.Areas.User.Records.Records> localizer
 @if (Model != null)
 {
     var definition = new UdfDefinition { UdfDefinitionId = Model.DefinitionId, EntityType = (int)UdfEntityType.Record, Version = Model.ExtensionVersion };
@@ -9,7 +10,7 @@
     var values = Model.Fields.Select(e => new UdfFieldValue { UdfFieldId = e.Field.UdfFieldId, Value = e.Value }).ToList();
     // Drafts can be incomplete. The service applies the pinned requiredness at finalization.
     foreach (var field in fields) { if (field.IsRequired) field.Label += " (required before finalization)"; field.IsRequired = false; }
-    <section class="ibox rms-custom-fields"><div class="ibox-title"><h3>Department custom fields</h3></div><div class="ibox-content">
+    <section class="ibox rms-custom-fields"><div class="ibox-title"><h3>@localizer["CustomFieldsHeader"]</h3></div><div class="ibox-content">
         <p>Form version @Model.ExtensionVersion</p>
         <input type="hidden" name="CustomFields.DefinitionId" value="@Model.DefinitionId" />
         @Html.Raw(UdfRenderer.GenerateHtmlFormFields(definition, fields.Where(f => !f.IsReadOnly).ToList(), values))

--- a/Web/Resgrid.Web/Areas/User/Views/RecordsAnalytics/Accreditation.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/RecordsAnalytics/Accreditation.cshtml
@@ -28,7 +28,7 @@
 						<dt>@L["AnalyticsMembersTrained"]</dt><dd>@a.Training.MembersTrained</dd>
 						<dt>@L["AnalyticsHoursPerMember"]</dt><dd>@RmsAnalyticsDisplay.Number(a.Training.HoursPerMember)</dd>
 					</dl>
-					@await Html.PartialAsync("_AnalyticsCounts", a.Training.ByMonth, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { { "Title", L["AnalyticsByMonth"].Value }, { "Chart", "bar" }, { "ShowHours", true }, { "Take", 24 } })
+					@await Html.PartialAsync("_AnalyticsCounts", a.Training.ByMonth, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { ["Title"] = L["AnalyticsByMonth"].Value, ["Chart"] = "bar", ["ShowHours"] = true, ["Take"] = 24 })
 				</div></div>
 			</div>
 			<div class="col-md-6">
@@ -46,7 +46,7 @@
 							<dt>@L["AnalyticsCancelled"]</dt><dd>@i.Cancelled</dd>
 							<dt>@L["AnalyticsOpenNow"]</dt><dd>@i.OpenNow (@i.OverdueNow @L["Overdue"])</dd>
 						</dl>
-						@await Html.PartialAsync("_AnalyticsCounts", i.ByProgram, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { { "Title", L["AnalyticsByProgram"].Value } })
+						@await Html.PartialAsync("_AnalyticsCounts", i.ByProgram, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { ["Title"] = L["AnalyticsByProgram"].Value })
 					}
 				</div></div>
 				<div class="ibox"><div class="ibox-title"><h5>@L["Violations"]</h5></div><div class="ibox-content">
@@ -60,7 +60,7 @@
 							<dt>@L["AnalyticsDaysToCorrection"]</dt><dd>@RmsAnalyticsDisplay.Number(v.AverageDaysToCorrection)</dd>
 							<dt>@L["AnalyticsOpenNow"]</dt><dd>@v.OpenNow (@v.OverdueNow @L["Overdue"])</dd>
 						</dl>
-						@await Html.PartialAsync("_AnalyticsCounts", v.BySeverity, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { { "Title", L["AnalyticsBySeverity"].Value } })
+						@await Html.PartialAsync("_AnalyticsCounts", v.BySeverity, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { ["Title"] = L["AnalyticsBySeverity"].Value })
 					}
 				</div></div>
 			</div>
@@ -80,7 +80,7 @@
 							<dt>@L["AnalyticsActiveNow"]</dt><dd>@pm.ActiveNow</dd>
 							<dt>@L["AnalyticsDaysToIssue"]</dt><dd>@RmsAnalyticsDisplay.Number(pm.AverageDaysAppliedToIssued)</dd>
 						</dl>
-						@await Html.PartialAsync("_AnalyticsCounts", pm.ByType, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { { "Title", L["AnalyticsByType"].Value } })
+						@await Html.PartialAsync("_AnalyticsCounts", pm.ByType, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { ["Title"] = L["AnalyticsByType"].Value })
 					}
 				</div></div>
 			</div>
@@ -96,7 +96,7 @@
 							<dt>@L["AnalyticsTestedWithin12Months"]</dt><dd>@RmsAnalyticsDisplay.Percent(h.TestedWithin12MonthsPercent) (@h.TestedWithin12Months)</dd>
 							<dt>@L["AnalyticsFlowTests"]</dt><dd>@h.FlowTestsInWindow</dd>
 						</dl>
-						@await Html.PartialAsync("_AnalyticsCounts", h.ByFlowClass, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { { "Title", L["AnalyticsByFlowClass"].Value } })
+						@await Html.PartialAsync("_AnalyticsCounts", h.ByFlowClass, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { ["Title"] = L["AnalyticsByFlowClass"].Value })
 					}
 				</div></div>
 			</div>
@@ -113,10 +113,14 @@
 							<dt>@L["AnalyticsHazmat"]</dt><dd>@o.HazmatOnSite</dd>
 							<dt>@L["AnalyticsOpenViolations"]</dt><dd>@o.OpenViolations</dd>
 						</dl>
-						@await Html.PartialAsync("_AnalyticsCounts", o.ByType, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { { "Title", L["AnalyticsByType"].Value } })
+						@await Html.PartialAsync("_AnalyticsCounts", o.ByType, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { ["Title"] = L["AnalyticsByType"].Value })
 					}
 				</div></div>
 			</div>
 		</div>
 	}
 </div>
+
+@section Styles {
+	<link rel="stylesheet" href="~/css/workspace.css" asp-append-version="true" />
+}

--- a/Web/Resgrid.Web/Areas/User/Views/RecordsAnalytics/CommunityRisk.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/RecordsAnalytics/CommunityRisk.cshtml
@@ -12,11 +12,11 @@
 	{
 		<div class="ibox"><div class="ibox-title"><h5>@L["AnalyticsIncidents"]</h5><span class="text-muted pull-right">@L["AnalyticsIncidentReports"]: @r.Incidents.IncidentReports · @L["AnalyticsRunRecords"]: @r.Incidents.RunRecords</span></div><div class="ibox-content">
 			<div class="row">
-				<div class="col-md-4">@await Html.PartialAsync("_AnalyticsCounts", r.Incidents.ByMonth, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { { "Title", L["AnalyticsByMonth"].Value }, { "Chart", "line" }, { "Take", 24 } })</div>
-				<div class="col-md-4">@await Html.PartialAsync("_AnalyticsCounts", r.Incidents.ByHourOfDay.Where(c => c.Count > 0).ToList(), new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { { "Title", L["AnalyticsByHour"].Value }, { "Chart", "bar" }, { "Take", 24 } })</div>
+				<div class="col-md-4">@await Html.PartialAsync("_AnalyticsCounts", r.Incidents.ByMonth, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { ["Title"] = L["AnalyticsByMonth"].Value, ["Chart"] = "line", ["Take"] = 24 })</div>
+				<div class="col-md-4">@await Html.PartialAsync("_AnalyticsCounts", r.Incidents.ByHourOfDay.Where(c => c.Count > 0).ToList(), new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { ["Title"] = L["AnalyticsByHour"].Value, ["Chart"] = "bar", ["Take"] = 24 })</div>
 				<div class="col-md-4">
-					@await Html.PartialAsync("_AnalyticsCounts", r.Incidents.ByIncidentType, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { { "Title", L["AnalyticsByIncidentType"].Value } })
-					@await Html.PartialAsync("_AnalyticsCounts", r.Incidents.ByCallType, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { { "Title", L["AnalyticsByCallType"].Value } })
+					@await Html.PartialAsync("_AnalyticsCounts", r.Incidents.ByIncidentType, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { ["Title"] = L["AnalyticsByIncidentType"].Value })
+					@await Html.PartialAsync("_AnalyticsCounts", r.Incidents.ByCallType, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { ["Title"] = L["AnalyticsByCallType"].Value })
 				</div>
 			</div>
 		</div></div>
@@ -32,8 +32,8 @@
 							<dt>@L["SmokeAlarmsInstalled"]</dt><dd>@r.Crr.SmokeAlarmsInstalled</dd>
 							<dt>@L["AnalyticsHours"]</dt><dd>@RmsAnalyticsDisplay.Hours(r.Crr.Hours)</dd>
 						</dl>
-						@await Html.PartialAsync("_AnalyticsCounts", r.Crr.ByKind, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { { "Title", L["AnalyticsByKind"].Value }, { "Chart", "doughnut" }, { "ShowHours", true } })
-						@await Html.PartialAsync("_AnalyticsCounts", r.Crr.ByMonth, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { { "Title", L["AnalyticsByMonth"].Value }, { "ShowHours", true }, { "Take", 24 } })
+						@await Html.PartialAsync("_AnalyticsCounts", r.Crr.ByKind, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { ["Title"] = L["AnalyticsByKind"].Value, ["Chart"] = "doughnut", ["ShowHours"] = true })
+						@await Html.PartialAsync("_AnalyticsCounts", r.Crr.ByMonth, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { ["Title"] = L["AnalyticsByMonth"].Value, ["ShowHours"] = true, ["Take"] = 24 })
 					}
 				</div></div>
 			</div>
@@ -52,8 +52,8 @@
 							<dt>@L["AnalyticsReviewOverdue"]</dt><dd>@o.ReviewOverdue</dd>
 							@if (r.InspectionsEnabled) { <dt>@L["AnalyticsOpenViolations"]</dt><dd>@o.OpenViolations</dd> }
 						</dl>
-						@await Html.PartialAsync("_AnalyticsCounts", o.ByType, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { { "Title", L["AnalyticsByType"].Value }, { "Chart", "doughnut" } })
-						@if (r.InspectionsEnabled) { @await Html.PartialAsync("_AnalyticsCounts", o.ViolationsBySeverity, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { { "Title", L["AnalyticsOpenViolations"].Value + " - " + L["AnalyticsBySeverity"].Value } }) }
+						@await Html.PartialAsync("_AnalyticsCounts", o.ByType, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { ["Title"] = L["AnalyticsByType"].Value, ["Chart"] = "doughnut" })
+						@if (r.InspectionsEnabled) { @await Html.PartialAsync("_AnalyticsCounts", o.ViolationsBySeverity, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { ["Title"] = L["AnalyticsOpenViolations"].Value + " - " + L["AnalyticsBySeverity"].Value }) }
 					}
 				</div></div>
 			</div>
@@ -67,10 +67,14 @@
 							<dt>@L["OutOfService"]</dt><dd class="@(r.Hydrants.OutOfService > 0 ? "text-danger" : "")">@r.Hydrants.OutOfService</dd>
 							<dt>@L["AnalyticsTestedWithin12Months"]</dt><dd>@RmsAnalyticsDisplay.Percent(r.Hydrants.TestedWithin12MonthsPercent)</dd>
 						</dl>
-						@await Html.PartialAsync("_AnalyticsCounts", r.Hydrants.ByFlowClass, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { { "Title", L["AnalyticsByFlowClass"].Value }, { "Chart", "doughnut" } })
+						@await Html.PartialAsync("_AnalyticsCounts", r.Hydrants.ByFlowClass, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { ["Title"] = L["AnalyticsByFlowClass"].Value, ["Chart"] = "doughnut" })
 					}
 				</div></div>
 			</div>
 		</div>
 	}
 </div>
+
+@section Styles {
+	<link rel="stylesheet" href="~/css/workspace.css" asp-append-version="true" />
+}

--- a/Web/Resgrid.Web/Areas/User/Views/RecordsAnalytics/Index.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/RecordsAnalytics/Index.cshtml
@@ -61,11 +61,15 @@
 				</div></div>
 			</div>
 			<div class="col-md-4">
-				@await Html.PartialAsync("_AnalyticsCounts", s.ByMonth, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { { "Title", L["AnalyticsByMonth"].Value }, { "Chart", "line" }, { "Take", 24 } })
+				@await Html.PartialAsync("_AnalyticsCounts", s.ByMonth, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { ["Title"] = L["AnalyticsByMonth"].Value, ["Chart"] = "line", ["Take"] = 24 })
 			</div>
 			<div class="col-md-4">
-				@await Html.PartialAsync("_AnalyticsCounts", s.ByDefinition, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { { "Title", L["ByDefinition"].Value }, { "Chart", "doughnut" }, { "ShowHours", true } })
+				@await Html.PartialAsync("_AnalyticsCounts", s.ByDefinition, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { ["Title"] = L["ByDefinition"].Value, ["Chart"] = "doughnut", ["ShowHours"] = true })
 			</div>
 		</div>
 	}
 </div>
+
+@section Styles {
+	<link rel="stylesheet" href="~/css/workspace.css" asp-append-version="true" />
+}

--- a/Web/Resgrid.Web/Areas/User/Views/RecordsAnalytics/Readiness.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/RecordsAnalytics/Readiness.cshtml
@@ -104,8 +104,8 @@
 							<div class="col-xs-3 rms-kpi"><div class="value">@RmsAnalyticsDisplay.Number(wo.MeanTimeToRepairHours)</div><div class="label">@L["ReadinessMttr"]</div><small class="text-muted">@wo.RepairSamples @L["ReadinessRepairSamples"] · @wo.MissingRepairTimes @L["ReadinessMissingRepairTimes"]</small></div>
 						</div>
 						<div class="row">
-							<div class="col-md-6">@await Html.PartialAsync("_AnalyticsCounts", wo.OpenByPriority, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { { "Title", L["ReadinessOpenByPriority"].Value }, { "Chart", "doughnut" } })</div>
-							<div class="col-md-6">@await Html.PartialAsync("_AnalyticsCounts", wo.OpenByAge, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { { "Title", L["ReadinessOpenByAge"].Value }, { "Chart", "bar" } })</div>
+							<div class="col-md-6">@await Html.PartialAsync("_AnalyticsCounts", wo.OpenByPriority, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { ["Title"] = L["ReadinessOpenByPriority"].Value, ["Chart"] = "doughnut" })</div>
+							<div class="col-md-6">@await Html.PartialAsync("_AnalyticsCounts", wo.OpenByAge, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { ["Title"] = L["ReadinessOpenByAge"].Value, ["Chart"] = "bar" })</div>
 						</div>
 						@if (wo.Costs.Count > 0)
 						{
@@ -141,7 +141,7 @@
 							<dt>@L["AnalyticsExpired"]</dt><dd class="@(eq.Expired > 0 ? "text-danger" : "")">@eq.Expired · @L["ReadinessExpiringSoon"] @eq.ExpiringWithin30Days</dd>
 							<dt>@L["ReadinessIssuancesOutstanding"]</dt><dd>@eq.IssuancesOutstanding · @L["ReadinessOverdueReturns"] <span class="@(eq.IssuancesOverdueReturn > 0 ? "text-danger" : "")">@eq.IssuancesOverdueReturn</span></dd>
 						</dl>
-						@await Html.PartialAsync("_AnalyticsCounts", eq.ByStatus, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { { "Title", L["ReadinessByStatus"].Value }, { "Chart", "doughnut" } })
+						@await Html.PartialAsync("_AnalyticsCounts", eq.ByStatus, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { ["Title"] = L["ReadinessByStatus"].Value, ["Chart"] = "doughnut" })
 						@if (eq.ByUnit.Count > 0)
 						{
 							<h5>@L["ByUnit"]</h5>
@@ -160,9 +160,13 @@
 						<div class="col-xs-4 rms-kpi"><div class="value">@r.Evidence.RecordsWithPacket / @r.Evidence.CallLinkedRecords</div><div class="label">@L["ReadinessRecordsWithPacket"]</div></div>
 						<div class="col-xs-4 rms-kpi"><div class="value">@RmsAnalyticsDisplay.Percent(r.Evidence.CoveragePercent)</div><div class="label">@L["ReadinessCoverage"]</div></div>
 					</div>
-					@await Html.PartialAsync("_AnalyticsCounts", r.Evidence.ByMonth, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { { "Title", L["AnalyticsByMonth"].Value }, { "Chart", "bar" }, { "Take", 24 } })
+					@await Html.PartialAsync("_AnalyticsCounts", r.Evidence.ByMonth, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { ["Title"] = L["AnalyticsByMonth"].Value, ["Chart"] = "bar", ["Take"] = 24 })
 				</div></div>
 			</div>
 		</div>
 	}
 </div>
+
+@section Styles {
+	<link rel="stylesheet" href="~/css/workspace.css" asp-append-version="true" />
+}

--- a/Web/Resgrid.Web/Areas/User/Views/RecordsAnalytics/ResponsePerformance.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/RecordsAnalytics/ResponsePerformance.cshtml
@@ -32,15 +32,19 @@
 			}
 		</div></div>
 		<div class="row">
-			<div class="col-md-6">@await Html.PartialAsync("_AnalyticsTimeRows", p.ByMonth, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { { "Title", L["AnalyticsByMonth"].Value }, { "Chart", "line" } })</div>
-			<div class="col-md-6">@await Html.PartialAsync("_AnalyticsTimeRows", p.ByHourOfDay, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { { "Title", L["AnalyticsByHour"].Value }, { "Chart", "bar" } })</div>
+			<div class="col-md-6">@await Html.PartialAsync("_AnalyticsTimeRows", p.ByMonth, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { ["Title"] = L["AnalyticsByMonth"].Value, ["Chart"] = "line" })</div>
+			<div class="col-md-6">@await Html.PartialAsync("_AnalyticsTimeRows", p.ByHourOfDay, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { ["Title"] = L["AnalyticsByHour"].Value, ["Chart"] = "bar" })</div>
 		</div>
 		<div class="row">
-			<div class="col-md-6">@await Html.PartialAsync("_AnalyticsTimeRows", p.ByUnit, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { { "Title", L["ByUnit"].Value }, { "Chart", "none" } })</div>
+			<div class="col-md-6">@await Html.PartialAsync("_AnalyticsTimeRows", p.ByUnit, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { ["Title"] = L["ByUnit"].Value, ["Chart"] = "none" })</div>
 			<div class="col-md-6">
-				@await Html.PartialAsync("_AnalyticsTimeRows", p.ByStationGroup, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { { "Title", L["AnalyticsByStationGroup"].Value }, { "Chart", "none" } })
-				@await Html.PartialAsync("_AnalyticsTimeRows", p.BySource, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { { "Title", L["AnalyticsBySource"].Value }, { "Chart", "none" } })
+				@await Html.PartialAsync("_AnalyticsTimeRows", p.ByStationGroup, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { ["Title"] = L["AnalyticsByStationGroup"].Value, ["Chart"] = "none" })
+				@await Html.PartialAsync("_AnalyticsTimeRows", p.BySource, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { ["Title"] = L["AnalyticsBySource"].Value, ["Chart"] = "none" })
 			</div>
 		</div>
 	}
 </div>
+
+@section Styles {
+	<link rel="stylesheet" href="~/css/workspace.css" asp-append-version="true" />
+}

--- a/Web/Resgrid.Web/Areas/User/Views/RecordsAnalytics/Workload.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/RecordsAnalytics/Workload.cshtml
@@ -23,8 +23,8 @@
 			</div>
 		</div></div>
 		<div class="row">
-			<div class="col-md-6">@await Html.PartialAsync("_AnalyticsCounts", w.ByMonth, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { { "Title", L["AnalyticsByMonth"].Value }, { "Chart", "bar" }, { "ShowHours", true }, { "Take", 24 } })</div>
-			<div class="col-md-6">@await Html.PartialAsync("_AnalyticsCounts", w.ByDefinition, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { { "Title", L["ByDefinition"].Value }, { "Chart", "doughnut" }, { "ShowHours", true } })</div>
+			<div class="col-md-6">@await Html.PartialAsync("_AnalyticsCounts", w.ByMonth, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { ["Title"] = L["AnalyticsByMonth"].Value, ["Chart"] = "bar", ["ShowHours"] = true, ["Take"] = 24 })</div>
+			<div class="col-md-6">@await Html.PartialAsync("_AnalyticsCounts", w.ByDefinition, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { ["Title"] = L["ByDefinition"].Value, ["Chart"] = "doughnut", ["ShowHours"] = true })</div>
 		</div>
 		<div class="ibox"><div class="ibox-title"><h5>@L["AnalyticsHeatMap"]</h5></div><div class="ibox-content">
 			@if (max == 0) { <p class="text-muted">@L["AnalyticsNoData"]</p> }
@@ -42,12 +42,16 @@
 			}
 		</div></div>
 		<div class="row">
-			<div class="col-md-4">@await Html.PartialAsync("_AnalyticsCounts", w.ByPerson, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { { "Title", L["AnalyticsByPerson"].Value }, { "ShowHours", true }, { "Take", 25 } })</div>
-			<div class="col-md-4">@await Html.PartialAsync("_AnalyticsCounts", w.ByUnit, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { { "Title", L["ByUnit"].Value }, { "Chart", "bar" }, { "ShowHours", true }, { "Take", 25 } })</div>
+			<div class="col-md-4">@await Html.PartialAsync("_AnalyticsCounts", w.ByPerson, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { ["Title"] = L["AnalyticsByPerson"].Value, ["ShowHours"] = true, ["Take"] = 25 })</div>
+			<div class="col-md-4">@await Html.PartialAsync("_AnalyticsCounts", w.ByUnit, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { ["Title"] = L["ByUnit"].Value, ["Chart"] = "bar", ["ShowHours"] = true, ["Take"] = 25 })</div>
 			<div class="col-md-4">
-				@await Html.PartialAsync("_AnalyticsCounts", w.ByAuthor, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { { "Title", L["ByAuthor"].Value }, { "ShowHours", true }, { "Take", 25 } })
-				@await Html.PartialAsync("_AnalyticsCounts", w.ByStationGroup, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { { "Title", L["AnalyticsByStationGroup"].Value }, { "ShowHours", true } })
+				@await Html.PartialAsync("_AnalyticsCounts", w.ByAuthor, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { ["Title"] = L["ByAuthor"].Value, ["ShowHours"] = true, ["Take"] = 25 })
+				@await Html.PartialAsync("_AnalyticsCounts", w.ByStationGroup, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { ["Title"] = L["AnalyticsByStationGroup"].Value, ["ShowHours"] = true })
 			</div>
 		</div>
 	}
 </div>
+
+@section Styles {
+	<link rel="stylesheet" href="~/css/workspace.css" asp-append-version="true" />
+}

--- a/Web/Resgrid.Web/Areas/User/Views/RecordsAnalytics/_AnalyticsShell.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/RecordsAnalytics/_AnalyticsShell.cshtml
@@ -16,15 +16,6 @@
 	};
 	var result = Model.Result;
 }
-<style>
-	.rms-kpi { text-align: center; padding: 10px 4px; }
-	.rms-kpi .value { font-size: 26px; font-weight: 600; }
-	.rms-kpi .label { color: #888; font-size: 12px; text-transform: uppercase; }
-	.rms-heat { border-collapse: collapse; width: 100%; font-size: 10px; }
-	.rms-heat td, .rms-heat th { border: 1px solid #eee; padding: 2px; text-align: center; width: 3.7%; }
-	.rms-heat .heat-0 { background: #fff; color: #ccc; } .rms-heat .heat-1 { background: #d9f3ee; } .rms-heat .heat-2 { background: #a7e2d5; } .rms-heat .heat-3 { background: #5fc9b2; } .rms-heat .heat-4 { background: #1ab394; color: #fff; }
-	.rms-chart { position: relative; height: 240px; }
-</style>
 <div class="row wrapper border-bottom white-bg page-heading">
 	<div class="col-sm-12">
 		<h2>@L["AnalyticsHeader"]</h2>

--- a/Web/Resgrid.Web/Areas/User/Views/RecordsInventory/Edit.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/RecordsInventory/Edit.cshtml
@@ -11,9 +11,18 @@
     var protectedForms = new System.Collections.Generic.List<string> { "#record-inventory-reopen", "#record-inventory-consume", "#record-inventory-evidence" };
     var correctionIndex = 0;
     var attachingConsumption = string.IsNullOrEmpty(Model.UsageId) && !string.IsNullOrWhiteSpace(Model.ExistingTransactionId);
+
+    ViewData["Title"] = inventoryLocalizer["RecordUsageTitle"].Value;
+    ViewData["Subtitle"] = inventoryLocalizer["RecordUsageHelp"].Value;
+    ViewData["ParentController"] = controller;
+    ViewData["ParentAction"] = "Details";
+    ViewData["ParentId"] = Model.RecordId;
 }
-<div class="wrapper wrapper-content"><div class="ibox"><div class="ibox-title"><h2>@inventoryLocalizer["RecordUsageTitle"]</h2></div><div class="ibox-content">
-    <p>@inventoryLocalizer["RecordUsageHelp"]</p>
+
+@await Html.PartialAsync("_RmsShell")
+
+<div class="wrapper wrapper-content"><div class="ibox float-e-margins"><div class="ibox-title"><h5>@inventoryLocalizer["RecordUsageTitle"]</h5></div><div class="ibox-content">
+    <div class="alert alert-info"><i class="fa fa-info-circle"></i> @inventoryLocalizer["RecordUsageHelp"]</div>
     @if (Model.ModernInventory) { <p>@inventoryLocalizer["RecordUsageWitnessHelp"]</p> }
     @if (!string.IsNullOrEmpty(Model.ErrorMessage)) { <div class="alert alert-info" role="status">@Model.ErrorMessage</div> }
     @if (Model.ProtectionEnforced) { @await Html.PartialAsync("_AdpRevealBanner", new AdpRevealView { BannerTitle = inventoryLocalizer["ProtectedDataRequired"].Value }) }

--- a/Web/Resgrid.Web/Areas/User/Views/Shared/_Navigation.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Shared/_Navigation.cshtml
@@ -81,15 +81,9 @@
 			}
 			@if (SettingsHelper.IsLogsEnabled() && recordsEnabled)
 			{
-				<li class="@Html.IsSelected(controller: "Records")">
-					<a asp-controller="Records" asp-action="Index" asp-route-area="User"><i class="fa fa-file"></i> <span class="nav-label" data-i18n="nav.records">@commonLocalizer["RecordsModule"]</span></a>
-				</li>
-				@if (await recordsAuthorization.HasPermissionAsync(ClaimsAuthorizationHelper.GetUserId(), ClaimsAuthorizationHelper.GetDepartmentId(), Resgrid.Model.PermissionTypes.ManageRecordLegalHold))
-				{
-					<li><a asp-controller="RecordLegalHolds" asp-action="Index" asp-route-area="User"><i class="fa fa-lock"></i> @commonLocalizer["RecordsLegalHoldsModule"]</a></li>
-				}
 				// RMS-5 prevention and investigation modules: each link only when its own flag is on (RMS plan section 4.3/4.4).
 				var navDepartmentId = ClaimsAuthorizationHelper.GetDepartmentId();
+				var legalHoldsOn = await recordsAuthorization.HasPermissionAsync(ClaimsAuthorizationHelper.GetUserId(), navDepartmentId, Resgrid.Model.PermissionTypes.ManageRecordLegalHold);
 				var preventionOccupancyOn = await featureToggleService.IsEnabledAsync(FeatureFlagKeys.RecordsPreventionOccupancy, navDepartmentId);
 				var preventionInspectionsOn = preventionOccupancyOn && await featureToggleService.IsEnabledAsync(FeatureFlagKeys.RecordsPreventionInspections, navDepartmentId);
 				var preventionHydrantsOn = await featureToggleService.IsEnabledAsync(FeatureFlagKeys.RecordsPreventionHydrants, navDepartmentId);
@@ -97,34 +91,71 @@
 				var preventionCrrOn = await featureToggleService.IsEnabledAsync(FeatureFlagKeys.RecordsPreventionCrr, navDepartmentId);
 				var investigationsOn = ClaimsAuthorizationHelper.CanViewRestrictedRecords() && await featureToggleService.IsEnabledAsync(FeatureFlagKeys.RecordsInvestigations, navDepartmentId);
 				var analyticsOn = await featureToggleService.IsEnabledAsync(FeatureFlagKeys.RecordsAnalytics, navDepartmentId);
-				@if (preventionOccupancyOn)
-				{
-					<li class="@Html.IsSelected(controller: "RecordOccupancies")"><a asp-controller="RecordOccupancies" asp-action="Index" asp-route-area="User"><i class="fa fa-building-o"></i> @recordsLocalizer["Occupancies"]</a></li>
-				}
-				@if (preventionInspectionsOn)
-				{
-					<li class="@Html.IsSelected(controller: "RecordInspections")"><a asp-controller="RecordInspections" asp-action="Index" asp-route-area="User"><i class="fa fa-clipboard"></i> @recordsLocalizer["Inspections"]</a></li>
-				}
-				@if (preventionHydrantsOn)
-				{
-					<li class="@Html.IsSelected(controller: "RecordHydrants")"><a asp-controller="RecordHydrants" asp-action="Index" asp-route-area="User"><i class="fa fa-tint"></i> @recordsLocalizer["Hydrants"]</a></li>
-				}
-				@if (preventionPermitsOn)
-				{
-					<li class="@Html.IsSelected(controller: "RecordPermits")"><a asp-controller="RecordPermits" asp-action="Index" asp-route-area="User"><i class="fa fa-file-text-o"></i> @recordsLocalizer["Permits"]</a></li>
-				}
-				@if (preventionCrrOn)
-				{
-					<li class="@Html.IsSelected(controller: "RecordCrr")"><a asp-controller="RecordCrr" asp-action="Index" asp-route-area="User"><i class="fa fa-bullhorn"></i> @recordsLocalizer["CrrActivities"]</a></li>
-				}
-				@if (investigationsOn)
-				{
-					<li class="@Html.IsSelected(controller: "RecordInvestigations")"><a asp-controller="RecordInvestigations" asp-action="Index" asp-route-area="User"><i class="fa fa-search"></i> @recordsLocalizer["Investigations"]</a></li>
-				}
-				@if (analyticsOn)
-				{
-					<li class="@Html.IsSelected(controller: "RecordsAnalytics")"><a asp-controller="RecordsAnalytics" asp-action="Index" asp-route-area="User"><i class="fa fa-bar-chart"></i> @recordsLocalizer["AnalyticsHeader"]</a></li>
-				}
+
+				// Records owns a lot of screens, so it is a collapsible group rather than a dozen
+				// top level entries. The group opens and highlights on any records page, including
+				// the ones reached from inside Records that have no link of their own.
+				var onRecordsPage = Html.IsController("Records", "RecordCrr", "RecordDefinitions", "RecordDeploymentConnectors",
+					"RecordDeployments", "RecordDocuments", "RecordEvidence", "RecordHydrants", "RecordInspections",
+					"RecordInvestigations", "RecordLegalHolds", "RecordOccupancies", "RecordPermits", "RecordSavedReports",
+					"RecordSubmissions", "RecordsAnalytics", "RecordsExportTemplates", "RecordsHealth", "RecordsInventory",
+					"RecordsQuality");
+
+				// The dashboard and the queue share the Records controller, so they are told apart by
+				// action. Drilling into a record (Details, Edit, New) keeps the queue highlighted.
+				var onRecordsDashboard = Html.IsController("Records")
+					&& string.Equals((string)ViewContext.RouteData.Values["action"], "Dashboard", StringComparison.OrdinalIgnoreCase);
+				var onRecordsQueue = Html.IsController("Records") && !onRecordsDashboard;
+
+				<li class="@(onRecordsPage ? "active mm-active" : null)">
+					<a href="#" aria-expanded="@(onRecordsPage ? "true" : "false")">
+						<i class="fa fa-file"></i>
+						<span class="nav-label" data-i18n="nav.records">@commonLocalizer["RecordsModule"]</span>
+						<span class="fa arrow"></span>
+					</a>
+					<ul class="nav nav-second-level">
+						<li class="@(onRecordsDashboard ? "active" : null)">
+							<a asp-controller="Records" asp-action="Dashboard" asp-route-area="User"><i class="fa fa-dashboard"></i> @recordsLocalizer["RecordsDashboard"]</a>
+						</li>
+						<li class="@(onRecordsQueue ? "active" : null)">
+							<a asp-controller="Records" asp-action="Index" asp-route-area="User"><i class="fa fa-list"></i> @commonLocalizer["RecordsAllModule"]</a>
+						</li>
+						@if (legalHoldsOn)
+						{
+							<li class="@Html.IsSelected(controller: "RecordLegalHolds")">
+								<a asp-controller="RecordLegalHolds" asp-action="Index" asp-route-area="User"><i class="fa fa-lock"></i> @commonLocalizer["RecordsLegalHoldsModule"]</a>
+							</li>
+						}
+						@if (preventionOccupancyOn)
+						{
+							<li class="@Html.IsSelected(controller: "RecordOccupancies")"><a asp-controller="RecordOccupancies" asp-action="Index" asp-route-area="User"><i class="fa fa-building-o"></i> @recordsLocalizer["Occupancies"]</a></li>
+						}
+						@if (preventionInspectionsOn)
+						{
+							<li class="@Html.IsSelected(controller: "RecordInspections")"><a asp-controller="RecordInspections" asp-action="Index" asp-route-area="User"><i class="fa fa-clipboard"></i> @recordsLocalizer["Inspections"]</a></li>
+						}
+						@if (preventionHydrantsOn)
+						{
+							<li class="@Html.IsSelected(controller: "RecordHydrants")"><a asp-controller="RecordHydrants" asp-action="Index" asp-route-area="User"><i class="fa fa-tint"></i> @recordsLocalizer["Hydrants"]</a></li>
+						}
+						@if (preventionPermitsOn)
+						{
+							<li class="@Html.IsSelected(controller: "RecordPermits")"><a asp-controller="RecordPermits" asp-action="Index" asp-route-area="User"><i class="fa fa-file-text-o"></i> @recordsLocalizer["Permits"]</a></li>
+						}
+						@if (preventionCrrOn)
+						{
+							<li class="@Html.IsSelected(controller: "RecordCrr")"><a asp-controller="RecordCrr" asp-action="Index" asp-route-area="User"><i class="fa fa-bullhorn"></i> @recordsLocalizer["CrrActivities"]</a></li>
+						}
+						@if (investigationsOn)
+						{
+							<li class="@Html.IsSelected(controller: "RecordInvestigations")"><a asp-controller="RecordInvestigations" asp-action="Index" asp-route-area="User"><i class="fa fa-search"></i> @recordsLocalizer["Investigations"]</a></li>
+						}
+						@if (analyticsOn)
+						{
+							<li class="@Html.IsSelected(controller: "RecordsAnalytics")"><a asp-controller="RecordsAnalytics" asp-action="Index" asp-route-area="User"><i class="fa fa-bar-chart"></i> @recordsLocalizer["AnalyticsHeader"]</a></li>
+						}
+					</ul>
+				</li>
 			}
 			else if (SettingsHelper.IsLogsEnabled())
 			{

--- a/Web/Resgrid.Web/Areas/User/Views/Shared/_RmsShell.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/Shared/_RmsShell.cshtml
@@ -1,0 +1,36 @@
+@inject IStringLocalizer<Resgrid.Localization.Areas.User.Records.Records> rmsLocalizer
+@*
+    Page heading shared by the records screens that sit outside the main Records controller
+    (preservation holds, evidence, submissions, document comparisons). Laid out the same way
+    as the rest of the application, and the same way Records/Index already does it.
+
+    ViewData["Title"]      heading and last breadcrumb crumb
+    ViewData["Subtitle"]   optional one line description under the breadcrumb
+    ViewData["ParentText"] optional intermediate crumb, with ParentController/ParentAction/ParentId
+*@
+@{
+    var title = (string)ViewData["Title"] ?? rmsLocalizer["RecordsHeader"].Value;
+    var subtitle = (string)ViewData["Subtitle"];
+    var parentText = (string)ViewData["ParentText"];
+    var parentController = (string)ViewData["ParentController"] ?? "Records";
+    var parentAction = (string)ViewData["ParentAction"] ?? "Index";
+    var parentId = (string)ViewData["ParentId"];
+}
+<div class="row wrapper border-bottom white-bg page-heading">
+    <div class="col-sm-12">
+        <h2>@title</h2>
+        <ol class="breadcrumb">
+            <li><a asp-controller="Home" asp-action="Dashboard" asp-route-area="User">@commonLocalizer["HomeModule"]</a></li>
+            <li><a asp-controller="Records" asp-action="Index" asp-route-area="User">@rmsLocalizer["RecordsHeader"]</a></li>
+            @if (!string.IsNullOrEmpty(parentText))
+            {
+                <li><a asp-controller="@parentController" asp-action="@parentAction" asp-route-id="@parentId" asp-route-area="User">@parentText</a></li>
+            }
+            <li class="active"><strong>@title</strong></li>
+        </ol>
+        @if (!string.IsNullOrEmpty(subtitle))
+        {
+            <small class="text-muted">@subtitle</small>
+        }
+    </div>
+</div>

--- a/Web/Resgrid.Web/Areas/User/Views/WorkOrders/Bulk.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/WorkOrders/Bulk.cshtml
@@ -1,35 +1,165 @@
 @model Resgrid.Web.Areas.User.Models.WorkOrders.WorkOrderBulkView
 @using Newtonsoft.Json
 @inject IStringLocalizer<Resgrid.Localization.Areas.User.WorkOrders.WorkOrders> localizer
-@{ ViewBag.Title = "Resgrid | " + localizer["BulkOperations"]; }
-<div class="wrapper wrapper-content"><div class="ibox"><div class="ibox-content">
-<h2>@localizer["BulkOperations"]</h2><a asp-action="Index">@localizer["WorkOrders"]</a>
-@await Html.PartialAsync("_Protection")
-<div class="work-order-protected"><p>@localizer["BulkHelp"]</p>
-@if (Model.Result != null) {
-<h3>@localizer[Model.Applied ? "BulkResults" : "BulkPreview"]</h3>
-<table class="table"><thead><tr><th>@localizer["RowNumber"]</th><th>@localizer["Number"]</th><th>@localizer["Title"]</th><th>@localizer["Status"]</th></tr></thead><tbody>
-@foreach (var row in Model.Result.Rows) { <tr><td>@row.RowNumber</td><td>@row.WorkOrderId</td><td>@row.Title</td><td>@localizer[row.ErrorCode ?? (row.Applied ? "BulkApplied" : "BulkReady")]</td></tr> }
-</tbody></table>
-@if (Model.Result.Rows.Any(r => r.ErrorCode == null && !r.Applied)) {
-<form class="work-order-form" method="post" asp-action="ApplyBulk">@Html.AntiForgeryToken()
-<input type="hidden" name="payload" value="@JsonConvert.SerializeObject(Model.Input)"/><button class="btn btn-primary" type="submit">@localizer["BulkApply"]</button></form>
+@{
+    ViewBag.Title = "Resgrid | " + localizer["BulkOperations"];
+    ViewData["Tab"] = "Bulk";
+    ViewData["Title"] = localizer["BulkOperations"].Value;
+    ViewData["Subtitle"] = localizer["BulkHelp"].Value;
+    ViewData["CanWrite"] = true;
 }
-<a asp-action="Bulk">@localizer["BulkOperations"]</a>
-} else {
-<h3>@localizer["ImportWorkOrders"]</h3><p>@localizer["ImportHelp"]</p><a asp-action="ImportTemplate">@localizer["ImportTemplate"]</a>
-<form class="work-order-form" method="post" asp-action="PreviewBulk">@Html.AntiForgeryToken()<input type="hidden" name="RequestId" value="@Model.Form.RequestId"/>
-<label for="bulk-csv">@localizer["ImportCsv"]</label><textarea id="bulk-csv" name="Csv" class="form-control" rows="8" maxlength="1048576" required></textarea>
-<button class="btn btn-default" type="submit">@localizer["BulkPreview"]</button></form>
-<h3>@localizer["BulkAssignment"]</h3>
-<form class="work-order-form" method="post" asp-action="PreviewBulk">@Html.AntiForgeryToken()<input type="hidden" name="RequestId" value="@Guid.NewGuid().ToString("D")"/>
-<label>@localizer["AssignedTo"]<select class="form-control" name="UserId"><option value="">@localizer["None"]</option>@foreach (var u in Model.Choices.Users) { <option value="@u.Id">@u.Name</option> }</select></label>
-<label>@localizer["Role"]<select class="form-control" name="RoleId"><option value="">@localizer["None"]</option>@foreach (var r in Model.Choices.Roles) { <option value="@r.Id">@r.Name</option> }</select></label>
-<table class="table"><thead><tr><th>@localizer["Select"]</th><th>@localizer["Number"]</th><th>@localizer["Title"]</th><th>@localizer["Status"]</th></tr></thead><tbody>
-@for (var i = 0; i < Model.Orders.Items.Count; i++) { var row = Model.Orders.Items[i]; <tr><td><input aria-label="@row.Number" type="checkbox" name="Selections[@i].Selected" value="true"/><input type="hidden" name="Selections[@i].Id" value="@row.Id"/><input type="hidden" name="Selections[@i].Revision" value="@row.Revision"/></td><td>@row.Number</td><td>@row.Title</td><td>@localizer["Status" + row.Status]</td></tr> }
-</tbody></table><button class="btn btn-default" type="submit">@localizer["BulkPreview"]</button></form>
-@if (Model.Page > 0) { <a asp-action="Bulk" asp-route-page="@(Model.Page-1)">@localizer["Previous"]</a> }
-@if (Model.Orders.HasMore) { <a asp-action="Bulk" asp-route-page="@(Model.Page+1)">@localizer["Next"]</a> }
+
+@await Html.PartialAsync("_Shell")
+
+<div class="wrapper wrapper-content">
+    <div class="ibox float-e-margins">
+        <div class="ibox-title"><h5>@localizer["BulkOperations"]</h5></div>
+        <div class="ibox-content">
+            @await Html.PartialAsync("_Tabs")
+            @await Html.PartialAsync("_Protection")
+
+            <div class="alert alert-info"><i class="fa fa-info-circle"></i> @localizer["BulkHelp"]</div>
+
+            <div class="work-order-protected">
+                @if (Model.Result != null)
+                {
+                    <div class="rgw-toolbar">
+                        <a class="btn btn-default btn-sm" asp-action="Bulk"><i class="fa fa-arrow-left"></i> @localizer["BulkOperations"]</a>
+                        <div class="rgw-toolbar-spacer"></div>
+                        @if (Model.Result.Rows.Any(r => r.ErrorCode == null && !r.Applied))
+                        {
+                            <form class="work-order-form" method="post" asp-action="ApplyBulk">
+                                @Html.AntiForgeryToken()
+                                <input type="hidden" name="payload" value="@JsonConvert.SerializeObject(Model.Input)" />
+                                <button class="btn btn-primary" type="submit"><i class="fa fa-check"></i> @localizer["BulkApply"]</button>
+                            </form>
+                        }
+                    </div>
+
+                    <h3>@localizer[Model.Applied ? "BulkResults" : "BulkPreview"]</h3>
+                    <div class="table-responsive">
+                        <table class="table table-striped rgw-table">
+                            <thead><tr><th class="text-right">@localizer["RowNumber"]</th><th>@localizer["Number"]</th><th>@localizer["Title"]</th><th>@localizer["Status"]</th></tr></thead>
+                            <tbody>
+                                @foreach (var row in Model.Result.Rows)
+                                {
+                                    <tr>
+                                        <td class="text-right">@row.RowNumber</td>
+                                        <td>@row.WorkOrderId</td>
+                                        <td>@row.Title</td>
+                                        <td>
+                                            <span class="label @(row.ErrorCode != null ? "label-danger" : row.Applied ? "label-success" : "label-info")">
+                                                @localizer[row.ErrorCode ?? (row.Applied ? "BulkApplied" : "BulkReady")]
+                                            </span>
+                                        </td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    </div>
+                }
+                else
+                {
+                    <div class="panel panel-default">
+                        <div class="panel-heading">@localizer["ImportWorkOrders"]</div>
+                        <div class="panel-body">
+                            <p class="text-muted">@localizer["ImportHelp"]</p>
+                            <p><a class="btn btn-default btn-sm" asp-action="ImportTemplate"><i class="fa fa-download"></i> @localizer["ImportTemplate"]</a></p>
+                            <form class="work-order-form" method="post" asp-action="PreviewBulk">
+                                @Html.AntiForgeryToken()
+                                <input type="hidden" name="RequestId" value="@Model.Form.RequestId" />
+                                <div class="rgw-grid">
+                                    <div class="form-group rgw-wide">
+                                        <label for="bulk-csv">@localizer["ImportCsv"]</label>
+                                        <textarea id="bulk-csv" name="Csv" class="form-control" rows="8" maxlength="1048576" required></textarea>
+                                    </div>
+                                </div>
+                                <div class="rgw-wizard-actions">
+                                    <div class="rgw-wizard-spacer"></div>
+                                    <button class="btn btn-primary" type="submit">@localizer["BulkPreview"]</button>
+                                </div>
+                            </form>
+                        </div>
+                    </div>
+
+                    <div class="panel panel-default">
+                        <div class="panel-heading">@localizer["BulkAssignment"]</div>
+                        <div class="panel-body">
+                            <form class="work-order-form" method="post" asp-action="PreviewBulk">
+                                @Html.AntiForgeryToken()
+                                <input type="hidden" name="RequestId" value="@Guid.NewGuid().ToString("D")" />
+                                <div class="rgw-grid">
+                                    <div class="form-group">
+                                        <label for="bulk-user">@localizer["AssignedTo"]</label>
+                                        <select class="form-control" id="bulk-user" name="UserId">
+                                            <option value="">@localizer["None"]</option>
+                                            @foreach (var u in Model.Choices.Users)
+                                            {
+                                                <option value="@u.Id">@u.Name</option>
+                                            }
+                                        </select>
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="bulk-role">@localizer["Role"]</label>
+                                        <select class="form-control" id="bulk-role" name="RoleId">
+                                            <option value="">@localizer["None"]</option>
+                                            @foreach (var r in Model.Choices.Roles)
+                                            {
+                                                <option value="@r.Id">@r.Name</option>
+                                            }
+                                        </select>
+                                    </div>
+                                </div>
+                                <div class="table-responsive">
+                                    <table class="table table-striped rgw-table">
+                                        <thead><tr><th>@localizer["Select"]</th><th>@localizer["Number"]</th><th>@localizer["Title"]</th><th>@localizer["Status"]</th></tr></thead>
+                                        <tbody>
+                                            @for (var i = 0; i < Model.Orders.Items.Count; i++)
+                                            {
+                                                var row = Model.Orders.Items[i];
+                                                <tr>
+                                                    <td>
+                                                        <input aria-label="@row.Number" type="checkbox" name="Selections[@i].Selected" value="true" />
+                                                        <input type="hidden" name="Selections[@i].Id" value="@row.Id" />
+                                                        <input type="hidden" name="Selections[@i].Revision" value="@row.Revision" />
+                                                    </td>
+                                                    <td>@row.Number</td>
+                                                    <td>@row.Title</td>
+                                                    <td><span class="label">@localizer["Status" + row.Status]</span></td>
+                                                </tr>
+                                            }
+                                        </tbody>
+                                    </table>
+                                </div>
+                                <div class="rgw-wizard-actions">
+                                    <div class="rgw-wizard-spacer"></div>
+                                    <button class="btn btn-primary" type="submit">@localizer["BulkPreview"]</button>
+                                </div>
+                            </form>
+
+                            @if (Model.Page > 0 || Model.Orders.HasMore)
+                            {
+                                <div class="rgw-pager">
+                                    @if (Model.Page > 0)
+                                    {
+                                        <a class="btn btn-default btn-sm" asp-action="Bulk" asp-route-page="@(Model.Page - 1)"><i class="fa fa-chevron-left"></i> @localizer["Previous"]</a>
+                                    }
+                                    @if (Model.Orders.HasMore)
+                                    {
+                                        <a class="btn btn-default btn-sm" asp-action="Bulk" asp-route-page="@(Model.Page + 1)">@localizer["Next"] <i class="fa fa-chevron-right"></i></a>
+                                    }
+                                    <span class="text-muted">@(Model.Page + 1)</span>
+                                </div>
+                            }
+                        </div>
+                    </div>
+                }
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Styles {
+    <link rel="stylesheet" href="~/css/workspace.css" asp-append-version="true" />
 }
-</div></div></div></div>
 @section Scripts { @await Html.PartialAsync("_Scripts") }

--- a/Web/Resgrid.Web/Areas/User/Views/WorkOrders/Detail.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/WorkOrders/Detail.cshtml
@@ -1,71 +1,725 @@
 @model Resgrid.Web.Areas.User.Models.WorkOrders.WorkOrderDetailView
 @using Resgrid.Model.WorkOrders
 @inject IStringLocalizer<Resgrid.Localization.Areas.User.WorkOrders.WorkOrders> localizer
-@{ var d = Model.Detail; var o = d.Order; var c = d.Input.Content; ViewBag.Title = "Resgrid | " + o.Number; }
-<div class="wrapper wrapper-content"><div class="ibox"><div class="ibox-content">
-@await Html.PartialAsync("_Protection")
-<div class="work-order-protected">
-<h2>@o.Number — @o.Title</h2><p>@localizer["Status" + o.Status] · @localizer["Priority" + o.Priority] · @localizer["DueOn"]: @o.DueOn?.ToString("u")</p>
-@if (!d.CanWrite) { <p class="alert alert-info">@localizer["ReadOnlyHistory"]</p> }
-<p style="white-space:pre-wrap">@c.Description</p><p>@c.LocationText</p>
-<p>@localizer["ReportedBy"]: @d.ReportedBy · @localizer["AssignedTo"]: @(Model.Choices.Users.FirstOrDefault(x => x.Id == o.AssignedToUserId)?.Name ?? Model.Choices.Roles.FirstOrDefault(x => x.Id == o.AssignedToRoleId?.ToString())?.Name ?? localizer["None"].Value)</p>
-<p>@localizer["Currency"]: @c.Currency · @localizer["EstimatedCost"]: @c.EstimatedCost · @localizer["ApprovedCost"]: @c.ApprovedCost · @localizer["CostCenter"]: @c.CostCenter</p>
-<p>@localizer["VendorDetails"]: @c.VendorDetails</p><p>@localizer["WarrantyReference"]: @c.WarrantyReference</p>
-<p><a asp-action="Operations" asp-route-id="@o.Id">@localizer["Operations"]</a></p>
-@if (c.SafetyCritical || c.HazardousWork) { <p class="alert alert-warning">@localizer[c.HazardousWork ? "HazardousWork" : "SafetyCritical"] — @localizer["SafetyNotice"]</p> }
-<dl><dt>@localizer["ProcedureReference"] / @localizer["ProcedureVersion"]</dt><dd>@c.ProcedureReference / @c.ProcedureVersion</dd><dt>@localizer["PermitReference"]</dt><dd>@c.PermitReference</dd><dt>@localizer["IsolationReference"]</dt><dd>@c.IsolationReference</dd><dt>@localizer["QualifiedPersonnel"]</dt><dd>@c.QualifiedPersonnel</dd></dl>
-@if (c.Steps.Count > 0) { <h3>@localizer["TaskSteps"]</h3><ol>@foreach (var step in c.Steps) { <li>@step.Text — @localizer[step.Completed ? "Done" : "Pending"]</li> }</ol> }
-@if (d.CompletedOn.HasValue) { <h3>@localizer["Resolution"]</h3><p>@c.Resolution</p><p>@localizer["Cause"]: @c.Cause</p> }
-@if (d.ClosedOn.HasValue) { <p>@localizer["VerificationEvidence"]: @c.VerificationEvidence</p><p>@localizer["VerifiedBy"]: @d.VerifiedBy · @d.ClosedOn?.ToString("u")</p> }
-@if (d.CanEdit) { <a class="btn btn-default" asp-action="Edit" asp-route-id="@o.Id">@localizer["EditWorkOrder"]</a> }
-<form class="work-order-form work-order-export" asp-action="Export" method="post">@Html.AntiForgeryToken()<input type="hidden" name="id" value="@o.Id"/><button type="submit" class="btn btn-default">@localizer["Export"]</button></form>
-@if (d.CanAccept) { <form class="work-order-form work-order-command" asp-action="Accept" method="post">@Html.AntiForgeryToken()<input type="hidden" name="id" value="@o.Id"/><input type="hidden" name="revision" value="@o.Revision"/><button type="submit" class="btn btn-primary">@localizer["AcceptAssignment"]</button></form> }
-@if (d.CanManage && o.Status is WorkOrderStatus.Accepted or WorkOrderStatus.Assigned or WorkOrderStatus.InProgress or WorkOrderStatus.OnHold)
-{
-    <h3>@localizer["Assign"]</h3><form class="work-order-form work-order-command form-inline" asp-action="Assign" method="post">
-    @Html.AntiForgeryToken()<input type="hidden" name="id" value="@o.Id"/><input type="hidden" name="Revision" value="@o.Revision"/>
-    <label>@localizer["User"] <select class="form-control work-order-user" name="UserId"><option value="">@localizer["None"]</option>@foreach (var x in Model.Choices.Users) { <option value="@x.Id">@x.Name</option> }</select></label>
-    <label>@localizer["Role"] <select class="form-control work-order-role" name="RoleId"><option value="">@localizer["None"]</option>@foreach (var x in Model.Choices.Roles) { <option value="@x.Id">@x.Name</option> }</select></label>
-    <button class="btn btn-primary" type="submit">@localizer["Assign"]</button></form>
+@functions {
+    string StatusPill(WorkOrderStatus status) => status switch
+    {
+        WorkOrderStatus.Requested => "label-info",
+        WorkOrderStatus.Accepted or WorkOrderStatus.Assigned => "label-primary",
+        WorkOrderStatus.InProgress or WorkOrderStatus.OnHold => "label-warning",
+        WorkOrderStatus.Completed or WorkOrderStatus.Closed => "label-success",
+        _ => "label-danger"
+    };
+
+    string PriorityPill(WorkOrderPriority priority) => priority switch
+    {
+        WorkOrderPriority.Emergency => "label-danger",
+        WorkOrderPriority.High => "label-warning",
+        _ => ""
+    };
 }
-@if (d.Transitions.Length > 0)
-{
-    <h3>@localizer["ChangeStatus"]</h3><form class="work-order-form work-order-command" asp-action="Transition" method="post">
-    @Html.AntiForgeryToken()<input type="hidden" name="id" value="@o.Id"/><input type="hidden" name="Revision" value="@o.Revision"/>
-    <label>@localizer["Status"] <select class="form-control" name="Status">@foreach (var status in d.Transitions) { <option value="@((int)status)">@localizer["Status" + status]</option> }</select></label>
-    <div class="form-group"><label>@localizer["Reason"]<textarea class="form-control" name="Reason" maxlength="4000"></textarea></label></div>
-    <div class="form-group"><label>@localizer["DuplicateOf"]<input class="form-control" type="number" name="DuplicateOfId" min="1"/></label></div>
-    <div class="form-group"><label>@localizer["Resolution"]<textarea class="form-control" name="Resolution" maxlength="4000"></textarea></label></div>
-    <div class="form-group"><label>@localizer["Cause"]<textarea class="form-control" name="Cause" maxlength="4000"></textarea></label></div>
-    <div class="form-group"><label>@localizer["VerificationEvidence"]<textarea class="form-control" name="VerificationEvidence" maxlength="4000"></textarea></label></div>
-    <label><input type="checkbox" name="ConfirmTasksComplete" value="true"/> @localizer["ConfirmTasksComplete"]</label><button class="btn btn-primary" type="submit">@localizer["ChangeStatus"]</button></form>
+@{
+    var d = Model.Detail;
+    var o = d.Order;
+    var c = d.Input.Content;
+    ViewBag.Title = "Resgrid | " + o.Number;
+    ViewData["Tab"] = "Index";
+    ViewData["Title"] = o.Number + " — " + o.Title;
+    ViewData["CanWrite"] = d.CanWrite;
+
+    var assignedTo = Model.Choices.Users.FirstOrDefault(x => x.Id == o.AssignedToUserId)?.Name
+        ?? Model.Choices.Roles.FirstOrDefault(x => x.Id == o.AssignedToRoleId?.ToString())?.Name
+        ?? localizer["None"].Value;
+    var canComment = d.CanWrite
+        && o.Status is not (WorkOrderStatus.Closed or WorkOrderStatus.Cancelled or WorkOrderStatus.Rejected or WorkOrderStatus.Duplicate)
+        && (d.CanContribute || d.ReportedBy == User.Identity.Name || d.ReportedBy == Resgrid.Web.Helpers.ClaimsAuthorizationHelper.GetUserId());
+    var canUpload = d.CanContribute
+        || (d.CanWrite && o.Status == WorkOrderStatus.Requested && d.ReportedBy == Resgrid.Web.Helpers.ClaimsAuthorizationHelper.GetUserId());
 }
-@await Html.PartialAsync("_Maintenance", Model)
-<h3>@localizer["Activity"]</h3><ol>@foreach (var a in d.Activities) { <li><strong>@localizer["Activity" + a.Type]</strong> · @a.CreatedOn.ToString("u") · @a.UserId @if (a.NewStatus.HasValue) { <span>→ @localizer["Status" + (WorkOrderStatus)a.NewStatus.Value]</span> }<p style="white-space:pre-wrap">@a.Note</p>
-@if (a.AssignedToUserId != null || a.AssignedToRoleId.HasValue) { <p>@localizer["AssignedTo"]: @(a.AssignedToUserId ?? a.AssignedToRoleId.ToString())</p> }
-@if (a.RevisedDueOn.HasValue) { <p>@localizer["OriginalDue"]: @a.OriginalDueOn?.ToString("u") → @localizer["RevisedDue"]: @a.RevisedDueOn.Value.ToString("u")</p> }
-@if (a.Snapshot != null) { <details><summary>@localizer["Description"]: @a.Snapshot.Title</summary>
-<p>@a.Snapshot.Description</p><p>@localizer["Resolution"]: @a.Snapshot.Resolution</p><p>@localizer["Cause"]: @a.Snapshot.Cause</p>
-<p>@localizer["VerificationEvidence"]: @a.Snapshot.VerificationEvidence</p><p>@localizer["ProcedureReference"]: @a.Snapshot.ProcedureReference (@a.Snapshot.ProcedureVersion)</p>
-</details> }</li> }</ol>
-@if (d.CanWrite && o.Status is not (WorkOrderStatus.Closed or WorkOrderStatus.Cancelled or WorkOrderStatus.Rejected or WorkOrderStatus.Duplicate) && (d.CanContribute || d.ReportedBy == User.Identity.Name || d.ReportedBy == Resgrid.Web.Helpers.ClaimsAuthorizationHelper.GetUserId()))
-{
-    <form class="work-order-form work-order-command" asp-action="Comment" method="post">@Html.AntiForgeryToken()<input type="hidden" name="id" value="@o.Id"/><input type="hidden" name="revision" value="@o.Revision"/><label>@localizer["Comment"]<textarea name="note" class="form-control" required maxlength="10000"></textarea></label><button class="btn btn-primary" type="submit">@localizer["AddComment"]</button></form>
+
+@await Html.PartialAsync("_Shell")
+
+<div class="wrapper wrapper-content">
+    <div class="ibox float-e-margins">
+        <div class="ibox-title"><h5>@o.Number — @o.Title</h5></div>
+        <div class="ibox-content">
+            @await Html.PartialAsync("_Tabs")
+            @await Html.PartialAsync("_Protection")
+
+            <div class="work-order-protected">
+                <div class="rgw-toolbar">
+                    <a class="btn btn-default btn-sm" asp-action="Index"><i class="fa fa-arrow-left"></i> @localizer["WorkOrders"]</a>
+                    <div class="rgw-toolbar-spacer"></div>
+                    @if (d.CanAccept)
+                    {
+                        <form class="work-order-form work-order-command" asp-action="Accept" method="post">
+                            @Html.AntiForgeryToken()
+                            <input type="hidden" name="id" value="@o.Id" />
+                            <input type="hidden" name="revision" value="@o.Revision" />
+                            <button type="submit" class="btn btn-primary"><i class="fa fa-check"></i> @localizer["AcceptAssignment"]</button>
+                        </form>
+                    }
+                    @if (d.Transitions.Length > 0)
+                    {
+                        <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#work-order-transition"><i class="fa fa-exchange"></i> @localizer["ChangeStatus"]</button>
+                    }
+                    @if (d.CanManage && o.Status is WorkOrderStatus.Accepted or WorkOrderStatus.Assigned or WorkOrderStatus.InProgress or WorkOrderStatus.OnHold)
+                    {
+                        <button type="button" class="btn btn-default" data-toggle="modal" data-target="#work-order-assign"><i class="fa fa-user"></i> @localizer["Assign"]</button>
+                    }
+                    @if (d.CanEdit)
+                    {
+                        <a class="btn btn-default" asp-action="Edit" asp-route-id="@o.Id"><i class="fa fa-pencil"></i> @localizer["EditWorkOrder"]</a>
+                    }
+                    <a class="btn btn-default" asp-action="Operations" asp-route-id="@o.Id"><i class="fa fa-cogs"></i> @localizer["Operations"]</a>
+                    <form class="work-order-form work-order-export" asp-action="Export" method="post">
+                        @Html.AntiForgeryToken()
+                        <input type="hidden" name="id" value="@o.Id" />
+                        <button type="submit" class="btn btn-default"><i class="fa fa-download"></i> @localizer["Export"]</button>
+                    </form>
+                </div>
+
+                <p class="text-muted">
+                    <span class="label @StatusPill(o.Status)">@localizer["Status" + o.Status]</span>
+                    <span class="label @PriorityPill(o.Priority)">@localizer["Priority" + o.Priority]</span>
+                    @localizer["DueOn"]: @o.DueOn?.ToString("u")
+                </p>
+
+                @if (!d.CanWrite)
+                {
+                    <div class="alert alert-info">@localizer["ReadOnlyHistory"]</div>
+                }
+                @if (c.SafetyCritical || c.HazardousWork)
+                {
+                    <div class="alert alert-warning">
+                        <i class="fa fa-exclamation-triangle"></i>
+                        <strong>@localizer[c.HazardousWork ? "HazardousWork" : "SafetyCritical"]</strong> — @localizer["SafetyNotice"]
+                    </div>
+                }
+
+                @if (!string.IsNullOrEmpty(c.Description))
+                {
+                    <p style="white-space:pre-wrap">@c.Description</p>
+                }
+
+                <dl class="dl-horizontal">
+                    <dt>@localizer["LocationText"]</dt><dd>@c.LocationText</dd>
+                    <dt>@localizer["ReportedBy"]</dt><dd>@d.ReportedBy</dd>
+                    <dt>@localizer["AssignedTo"]</dt><dd>@assignedTo</dd>
+                    <dt>@localizer["Costs"]</dt><dd>@localizer["EstimatedCost"]: @c.EstimatedCost @c.Currency &middot; @localizer["ApprovedCost"]: @c.ApprovedCost &middot; @localizer["CostCenter"]: @c.CostCenter</dd>
+                    <dt>@localizer["VendorDetails"]</dt><dd>@c.VendorDetails</dd>
+                    <dt>@localizer["WarrantyReference"]</dt><dd>@c.WarrantyReference</dd>
+                    <dt>@localizer["ProcedureReference"]</dt><dd>@c.ProcedureReference / @c.ProcedureVersion</dd>
+                    <dt>@localizer["PermitReference"]</dt><dd>@c.PermitReference</dd>
+                    <dt>@localizer["IsolationReference"]</dt><dd>@c.IsolationReference</dd>
+                    <dt>@localizer["QualifiedPersonnel"]</dt><dd>@c.QualifiedPersonnel</dd>
+                </dl>
+
+                @if (c.Steps.Count > 0)
+                {
+                    <div class="panel panel-default">
+                        <div class="panel-heading">@localizer["TaskSteps"]</div>
+                        <ul class="list-group">
+                            @foreach (var step in c.Steps)
+                            {
+                                <li class="list-group-item">
+                                    <span class="label @(step.Completed ? "label-success" : "")">@localizer[step.Completed ? "Done" : "Pending"]</span>
+                                    @step.Text
+                                </li>
+                            }
+                        </ul>
+                    </div>
+                }
+
+                @if (d.CompletedOn.HasValue)
+                {
+                    <div class="panel panel-default">
+                        <div class="panel-heading">@localizer["Resolution"]</div>
+                        <div class="panel-body">
+                            <p style="white-space:pre-wrap">@c.Resolution</p>
+                            <p class="text-muted">@localizer["Cause"]: @c.Cause</p>
+                            @if (d.ClosedOn.HasValue)
+                            {
+                                <p class="text-muted">@localizer["VerificationEvidence"]: @c.VerificationEvidence</p>
+                                <p class="text-muted">@localizer["VerifiedBy"]: @d.VerifiedBy &middot; @d.ClosedOn?.ToString("u")</p>
+                            }
+                        </div>
+                    </div>
+                }
+
+                @await Html.PartialAsync("_Maintenance", Model)
+
+                <div class="hr-line-dashed"></div>
+
+                @* ── Labor ──────────────────────────────────────────────────────── *@
+                <div class="rgw-toolbar">
+                    <h3 class="m-t-none m-b-none">@localizer["Labor"]</h3>
+                    <div class="rgw-toolbar-spacer"></div>
+                    @if (d.CanContribute)
+                    {
+                        <button type="button" class="btn btn-default btn-sm" data-toggle="modal" data-target="#work-order-labor"><i class="fa fa-plus"></i> @localizer["AddLabor"]</button>
+                    }
+                </div>
+                @if (d.Labor.Count == 0)
+                {
+                    <p class="text-muted">@localizer["None"]</p>
+                }
+                else
+                {
+                    <div class="table-responsive">
+                        <table class="table table-striped rgw-table">
+                            <thead><tr><th>@localizer["User"]</th><th>@localizer["WorkDate"]</th><th class="text-right">@localizer["Hours"]</th><th class="text-right">@localizer["Rate"]</th><th>@localizer["Note"]</th></tr></thead>
+                            <tbody>
+                                @foreach (var l in d.Labor)
+                                {
+                                    <tr>
+                                        <td>@l.UserId</td>
+                                        <td>@l.WorkDate.ToString("d")</td>
+                                        <td class="text-right">@l.Content.Hours</td>
+                                        <td class="text-right">@l.Content.RatePerHour @c.Currency</td>
+                                        <td>@l.Content.Note</td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    </div>
+                }
+
+                @* ── Parts ──────────────────────────────────────────────────────── *@
+                <div class="rgw-toolbar">
+                    <h3 class="m-t-none m-b-none">@localizer["Parts"]</h3>
+                    <div class="rgw-toolbar-spacer"></div>
+                    @if (d.CanContribute)
+                    {
+                        <button type="button" class="btn btn-default btn-sm" data-toggle="modal" data-target="#work-order-part"><i class="fa fa-plus"></i> @localizer["AddPart"]</button>
+                    }
+                </div>
+                @if (d.Parts.Count == 0)
+                {
+                    <p class="text-muted">@localizer["None"]</p>
+                }
+                else
+                {
+                    <div class="table-responsive">
+                        <table class="table table-striped rgw-table">
+                            <thead><tr><th>@localizer["Description"]</th><th class="text-right">@localizer["Quantity"]</th><th class="text-right">@localizer["UnitCost"]</th><th class="rgw-row-actions">@localizer["Actions"]</th></tr></thead>
+                            <tbody>
+                                @foreach (var p in d.Parts)
+                                {
+                                    <tr>
+                                        <td>
+                                            @p.Content.Description
+                                            @if (p.InventoryItemId != null)
+                                            {
+                                                <small class="text-muted rgw-sub">
+                                                    <a asp-controller="Inventory" asp-action="Index" asp-route-tab="History" asp-route-itemId="@p.InventoryItemId">@localizer["InventoryParts"]</a>
+                                                    @p.InventoryTransactionId
+                                                </small>
+                                            }
+                                        </td>
+                                        <td class="text-right">@p.Content.Quantity</td>
+                                        <td class="text-right">@p.Content.UnitCost @(p.Content.Currency ?? c.Currency)</td>
+                                        <td class="rgw-row-actions">
+                                            @if (p.VoidedOn.HasValue)
+                                            {
+                                                <span class="label label-danger">@localizer["Voided"]</span>
+                                                <small class="text-muted rgw-sub">@p.Content.VoidReason</small>
+                                            }
+                                            else if (p.AwaitingWitness)
+                                            {
+                                                <span class="label label-warning">@localizer["InventoryWitnessPending"]</span>
+                                                <small class="text-muted rgw-sub">@p.InventoryWitnessRequestId</small>
+                                                @if (d.CanContribute)
+                                                {
+                                                    <button type="button" class="btn btn-xs btn-default" data-toggle="modal" data-target="#part-witness-@p.Id">@localizer["Cancel"]</button>
+                                                }
+                                            }
+                                            else if (p.Staged)
+                                            {
+                                                <a class="btn btn-xs btn-info" asp-action="Operations" asp-route-id="@o.Id">@localizer["PartsAllocation"]</a>
+                                            }
+                                            else if (d.CanContribute)
+                                            {
+                                                <button type="button" class="btn btn-xs btn-danger" data-toggle="modal" data-target="#part-void-@p.Id">@localizer["Void"]</button>
+                                            }
+                                        </td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    </div>
+                }
+
+                @* ── Files ──────────────────────────────────────────────────────── *@
+                <div class="rgw-toolbar">
+                    <h3 class="m-t-none m-b-none">@localizer["Files"]</h3>
+                    <div class="rgw-toolbar-spacer"></div>
+                    @if (canUpload)
+                    {
+                        <button type="button" class="btn btn-default btn-sm" data-toggle="modal" data-target="#work-order-upload"><i class="fa fa-upload"></i> @localizer["Upload"]</button>
+                    }
+                </div>
+                @if (d.Files.Count == 0)
+                {
+                    <p class="text-muted">@localizer["None"]</p>
+                }
+                else
+                {
+                    <div class="table-responsive">
+                        <table class="table table-striped rgw-table">
+                            <thead><tr><th>@localizer["File"]</th><th class="text-right">@localizer["Quantity"]</th><th class="rgw-row-actions">@localizer["Actions"]</th></tr></thead>
+                            <tbody>
+                                @foreach (var f in d.Files)
+                                {
+                                    <tr>
+                                        <td><a class="work-order-evidence" asp-action="Evidence" asp-route-id="@f.Id">@f.Name</a></td>
+                                        <td class="text-right">@f.Size</td>
+                                        <td class="rgw-row-actions">
+                                            @if (f.WithdrawnOn.HasValue)
+                                            {
+                                                <span class="label">@localizer["Withdrawn"]</span>
+                                            }
+                                            else if (d.CanContribute)
+                                            {
+                                                <button type="button" class="btn btn-xs btn-danger" data-toggle="modal" data-target="#file-withdraw-@f.Id">@localizer["Withdraw"]</button>
+                                            }
+                                        </td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    </div>
+                }
+
+                @* ── Activity ───────────────────────────────────────────────────── *@
+                <div class="rgw-toolbar">
+                    <h3 class="m-t-none m-b-none">@localizer["Activity"]</h3>
+                    <div class="rgw-toolbar-spacer"></div>
+                    @if (canComment)
+                    {
+                        <button type="button" class="btn btn-default btn-sm" data-toggle="modal" data-target="#work-order-comment"><i class="fa fa-comment-o"></i> @localizer["AddComment"]</button>
+                    }
+                </div>
+                <div class="table-responsive">
+                    <table class="table table-striped rgw-table">
+                        <thead><tr><th>@localizer["CreatedOn"]</th><th>@localizer["Activity"]</th><th>@localizer["User"]</th><th>@localizer["Note"]</th></tr></thead>
+                        <tbody>
+                            @foreach (var a in d.Activities)
+                            {
+                                <tr>
+                                    <td>@a.CreatedOn.ToString("u")</td>
+                                    <td>
+                                        <span class="label">@localizer["Activity" + a.Type]</span>
+                                        @if (a.NewStatus.HasValue)
+                                        {
+                                            <span class="label @StatusPill((WorkOrderStatus)a.NewStatus.Value)">@localizer["Status" + (WorkOrderStatus)a.NewStatus.Value]</span>
+                                        }
+                                    </td>
+                                    <td>@a.UserId</td>
+                                    <td>
+                                        @if (!string.IsNullOrEmpty(a.Note))
+                                        {
+                                            <div style="white-space:pre-wrap">@a.Note</div>
+                                        }
+                                        @if (a.AssignedToUserId != null || a.AssignedToRoleId.HasValue)
+                                        {
+                                            <small class="text-muted rgw-sub">@localizer["AssignedTo"]: @(a.AssignedToUserId ?? a.AssignedToRoleId.ToString())</small>
+                                        }
+                                        @if (a.RevisedDueOn.HasValue)
+                                        {
+                                            <small class="text-muted rgw-sub">@localizer["OriginalDue"]: @a.OriginalDueOn?.ToString("u") → @localizer["RevisedDue"]: @a.RevisedDueOn.Value.ToString("u")</small>
+                                        }
+                                        @if (a.Snapshot != null)
+                                        {
+                                            <details>
+                                                <summary>@localizer["Description"]: @a.Snapshot.Title</summary>
+                                                <p>@a.Snapshot.Description</p>
+                                                <p>@localizer["Resolution"]: @a.Snapshot.Resolution</p>
+                                                <p>@localizer["Cause"]: @a.Snapshot.Cause</p>
+                                                <p>@localizer["VerificationEvidence"]: @a.Snapshot.VerificationEvidence</p>
+                                                <p>@localizer["ProcedureReference"]: @a.Snapshot.ProcedureReference (@a.Snapshot.ProcedureVersion)</p>
+                                            </details>
+                                        }
+                                    </td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                </div>
+
+                @* ── Dialogs ────────────────────────────────────────────────────── *@
+                @if (d.Transitions.Length > 0)
+                {
+                    <div class="modal fade rgw-modal" id="work-order-transition" tabindex="-1" role="dialog" aria-labelledby="work-order-transition-title">
+                        <div class="modal-dialog modal-lg" role="document">
+                            <div class="modal-content">
+                                <div class="modal-header">
+                                    <button type="button" class="close" data-dismiss="modal" aria-label="@localizer["Close"]"><span aria-hidden="true">&times;</span></button>
+                                    <h4 class="modal-title" id="work-order-transition-title">@localizer["ChangeStatus"]</h4>
+                                </div>
+                                <div class="modal-body">
+                                    <form class="work-order-form work-order-command" asp-action="Transition" method="post">
+                                        @Html.AntiForgeryToken()
+                                        <input type="hidden" name="id" value="@o.Id" />
+                                        <input type="hidden" name="Revision" value="@o.Revision" />
+                                        <div class="rgw-grid">
+                                            <div class="form-group">
+                                                <label for="transition-status">@localizer["Status"]</label>
+                                                <select class="form-control" id="transition-status" name="Status">
+                                                    @foreach (var status in d.Transitions)
+                                                    {
+                                                        <option value="@((int)status)">@localizer["Status" + status]</option>
+                                                    }
+                                                </select>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="transition-duplicate">@localizer["DuplicateOf"]</label>
+                                                <input class="form-control" id="transition-duplicate" type="number" name="DuplicateOfId" min="1" />
+                                            </div>
+                                            <div class="form-group rgw-wide">
+                                                <label for="transition-reason">@localizer["Reason"]</label>
+                                                <textarea class="form-control" id="transition-reason" name="Reason" rows="2" maxlength="4000"></textarea>
+                                            </div>
+                                            <div class="form-group rgw-wide">
+                                                <label for="transition-resolution">@localizer["Resolution"]</label>
+                                                <textarea class="form-control" id="transition-resolution" name="Resolution" rows="2" maxlength="4000"></textarea>
+                                            </div>
+                                            <div class="form-group rgw-wide">
+                                                <label for="transition-cause">@localizer["Cause"]</label>
+                                                <textarea class="form-control" id="transition-cause" name="Cause" rows="2" maxlength="4000"></textarea>
+                                            </div>
+                                            <div class="form-group rgw-wide">
+                                                <label for="transition-evidence">@localizer["VerificationEvidence"]</label>
+                                                <textarea class="form-control" id="transition-evidence" name="VerificationEvidence" rows="2" maxlength="4000"></textarea>
+                                            </div>
+                                            <div class="form-group rgw-wide">
+                                                <div class="checkbox"><label><input type="checkbox" name="ConfirmTasksComplete" value="true" /> @localizer["ConfirmTasksComplete"]</label></div>
+                                            </div>
+                                        </div>
+                                        <div class="rgw-wizard-actions">
+                                            <div class="rgw-wizard-spacer"></div>
+                                            <button type="button" class="btn btn-white" data-dismiss="modal">@localizer["Close"]</button>
+                                            <button class="btn btn-primary" type="submit">@localizer["ChangeStatus"]</button>
+                                        </div>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                }
+
+                @if (d.CanManage && o.Status is WorkOrderStatus.Accepted or WorkOrderStatus.Assigned or WorkOrderStatus.InProgress or WorkOrderStatus.OnHold)
+                {
+                    <div class="modal fade rgw-modal" id="work-order-assign" tabindex="-1" role="dialog" aria-labelledby="work-order-assign-title">
+                        <div class="modal-dialog" role="document">
+                            <div class="modal-content">
+                                <div class="modal-header">
+                                    <button type="button" class="close" data-dismiss="modal" aria-label="@localizer["Close"]"><span aria-hidden="true">&times;</span></button>
+                                    <h4 class="modal-title" id="work-order-assign-title">@localizer["Assign"]</h4>
+                                </div>
+                                <div class="modal-body">
+                                    <form class="work-order-form work-order-command" asp-action="Assign" method="post">
+                                        @Html.AntiForgeryToken()
+                                        <input type="hidden" name="id" value="@o.Id" />
+                                        <input type="hidden" name="Revision" value="@o.Revision" />
+                                        <div class="rgw-grid">
+                                            <div class="form-group">
+                                                <label for="assign-user">@localizer["User"]</label>
+                                                <select class="form-control work-order-user" id="assign-user" name="UserId">
+                                                    <option value="">@localizer["None"]</option>
+                                                    @foreach (var x in Model.Choices.Users)
+                                                    {
+                                                        <option value="@x.Id">@x.Name</option>
+                                                    }
+                                                </select>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="assign-role">@localizer["Role"]</label>
+                                                <select class="form-control work-order-role" id="assign-role" name="RoleId">
+                                                    <option value="">@localizer["None"]</option>
+                                                    @foreach (var x in Model.Choices.Roles)
+                                                    {
+                                                        <option value="@x.Id">@x.Name</option>
+                                                    }
+                                                </select>
+                                            </div>
+                                        </div>
+                                        <div class="rgw-wizard-actions">
+                                            <div class="rgw-wizard-spacer"></div>
+                                            <button type="button" class="btn btn-white" data-dismiss="modal">@localizer["Close"]</button>
+                                            <button class="btn btn-primary" type="submit">@localizer["Assign"]</button>
+                                        </div>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                }
+
+                @if (canComment)
+                {
+                    <div class="modal fade rgw-modal" id="work-order-comment" tabindex="-1" role="dialog" aria-labelledby="work-order-comment-title">
+                        <div class="modal-dialog" role="document">
+                            <div class="modal-content">
+                                <div class="modal-header">
+                                    <button type="button" class="close" data-dismiss="modal" aria-label="@localizer["Close"]"><span aria-hidden="true">&times;</span></button>
+                                    <h4 class="modal-title" id="work-order-comment-title">@localizer["AddComment"]</h4>
+                                </div>
+                                <div class="modal-body">
+                                    <form class="work-order-form work-order-command" asp-action="Comment" method="post">
+                                        @Html.AntiForgeryToken()
+                                        <input type="hidden" name="id" value="@o.Id" />
+                                        <input type="hidden" name="revision" value="@o.Revision" />
+                                        <div class="rgw-grid">
+                                            <div class="form-group rgw-wide">
+                                                <label for="comment-note">@localizer["Comment"]</label>
+                                                <textarea id="comment-note" name="note" class="form-control" rows="3" required maxlength="10000"></textarea>
+                                            </div>
+                                        </div>
+                                        <div class="rgw-wizard-actions">
+                                            <div class="rgw-wizard-spacer"></div>
+                                            <button type="button" class="btn btn-white" data-dismiss="modal">@localizer["Close"]</button>
+                                            <button class="btn btn-primary" type="submit">@localizer["AddComment"]</button>
+                                        </div>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                }
+
+                @if (d.CanContribute)
+                {
+                    <div class="modal fade rgw-modal" id="work-order-labor" tabindex="-1" role="dialog" aria-labelledby="work-order-labor-title">
+                        <div class="modal-dialog" role="document">
+                            <div class="modal-content">
+                                <div class="modal-header">
+                                    <button type="button" class="close" data-dismiss="modal" aria-label="@localizer["Close"]"><span aria-hidden="true">&times;</span></button>
+                                    <h4 class="modal-title" id="work-order-labor-title">@localizer["AddLabor"]</h4>
+                                </div>
+                                <div class="modal-body">
+                                    <form class="work-order-form work-order-command" asp-action="Labor" method="post">
+                                        @Html.AntiForgeryToken()
+                                        <input type="hidden" name="id" value="@o.Id" />
+                                        <input type="hidden" name="Revision" value="@o.Revision" />
+                                        <div class="rgw-grid">
+                                            @if (d.CanManage)
+                                            {
+                                                <div class="form-group">
+                                                    <label for="labor-user">@localizer["User"]</label>
+                                                    <select class="form-control" id="labor-user" name="UserId">
+                                                        <option value="">@localizer["CurrentUser"]</option>
+                                                        @foreach (var x in Model.Choices.Users)
+                                                        {
+                                                            <option value="@x.Id">@x.Name</option>
+                                                        }
+                                                    </select>
+                                                </div>
+                                            }
+                                            <div class="form-group">
+                                                <label for="labor-date">@localizer["WorkDate"]</label>
+                                                <input class="form-control" id="labor-date" name="WorkDate" type="date" value="@DateTime.UtcNow.ToString("yyyy-MM-dd")" required />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="labor-hours">@localizer["Hours"]</label>
+                                                <input class="form-control" id="labor-hours" name="Content.Hours" type="number" step="0.01" min="0.01" max="24" required />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="labor-rate">@localizer["Rate"]</label>
+                                                <input class="form-control" id="labor-rate" name="Content.RatePerHour" type="number" step="0.01" min="0" />
+                                            </div>
+                                            <div class="form-group rgw-wide">
+                                                <label for="labor-note">@localizer["Note"]</label>
+                                                <input class="form-control" id="labor-note" name="Content.Note" maxlength="4000" />
+                                            </div>
+                                        </div>
+                                        <div class="rgw-wizard-actions">
+                                            <div class="rgw-wizard-spacer"></div>
+                                            <button type="button" class="btn btn-white" data-dismiss="modal">@localizer["Close"]</button>
+                                            <button class="btn btn-primary" type="submit">@localizer["AddLabor"]</button>
+                                        </div>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="modal fade rgw-modal" id="work-order-part" tabindex="-1" role="dialog" aria-labelledby="work-order-part-title">
+                        <div class="modal-dialog modal-lg" role="document">
+                            <div class="modal-content">
+                                <div class="modal-header">
+                                    <button type="button" class="close" data-dismiss="modal" aria-label="@localizer["Close"]"><span aria-hidden="true">&times;</span></button>
+                                    <h4 class="modal-title" id="work-order-part-title">@localizer["AddPart"]</h4>
+                                </div>
+                                <div class="modal-body">
+                                    <form class="work-order-form work-order-command" asp-action="Part" method="post">
+                                        @Html.AntiForgeryToken()
+                                        <input type="hidden" name="id" value="@o.Id" />
+                                        <input type="hidden" name="Revision" value="@o.Revision" />
+                                        <div class="rgw-grid">
+                                            <div class="form-group rgw-wide">
+                                                <label for="part-description">@localizer["Description"]</label>
+                                                <input class="form-control" id="part-description" name="Content.Description" required maxlength="2000" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="part-quantity">@localizer["Quantity"]</label>
+                                                <input class="form-control" id="part-quantity" name="Content.Quantity" type="number" min="0.000001" step="0.000001" required />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="part-cost">@localizer["UnitCost"]</label>
+                                                <input class="form-control" id="part-cost" name="Content.UnitCost" type="number" min="0" step="0.01" />
+                                            </div>
+                                        </div>
+                                        @await Html.PartialAsync("_PartInventory")
+                                        <div class="rgw-wizard-actions">
+                                            <div class="rgw-wizard-spacer"></div>
+                                            <button type="button" class="btn btn-white" data-dismiss="modal">@localizer["Close"]</button>
+                                            <button class="btn btn-primary" type="submit">@localizer["AddPart"]</button>
+                                        </div>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    @foreach (var p in d.Parts.Where(x => !x.VoidedOn.HasValue && x.AwaitingWitness))
+                    {
+                        <div class="modal fade rgw-modal" id="part-witness-@p.Id" tabindex="-1" role="dialog" aria-labelledby="part-witness-@(p.Id)-title">
+                            <div class="modal-dialog" role="document">
+                                <div class="modal-content">
+                                    <div class="modal-header">
+                                        <button type="button" class="close" data-dismiss="modal" aria-label="@localizer["Close"]"><span aria-hidden="true">&times;</span></button>
+                                        <h4 class="modal-title" id="part-witness-@(p.Id)-title">@localizer["Cancel"] &middot; @p.Content.Description</h4>
+                                    </div>
+                                    <div class="modal-body">
+                                        <form class="work-order-form work-order-command" asp-action="CancelPartWitness" method="post">
+                                            @Html.AntiForgeryToken()
+                                            <input type="hidden" name="id" value="@o.Id" />
+                                            <input type="hidden" name="revision" value="@o.Revision" />
+                                            <input type="hidden" name="partId" value="@p.Id" />
+                                            <div class="rgw-grid">
+                                                <div class="form-group rgw-wide">
+                                                    <label for="part-witness-reason-@p.Id">@localizer["Reason"]</label>
+                                                    <input class="form-control" id="part-witness-reason-@p.Id" name="reason" required maxlength="4000" />
+                                                </div>
+                                            </div>
+                                            <div class="rgw-wizard-actions">
+                                                <div class="rgw-wizard-spacer"></div>
+                                                <button type="button" class="btn btn-white" data-dismiss="modal">@localizer["Close"]</button>
+                                                <button class="btn btn-warning" type="submit">@localizer["Cancel"]</button>
+                                            </div>
+                                        </form>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    }
+
+                    @foreach (var p in d.Parts.Where(x => !x.VoidedOn.HasValue && !x.AwaitingWitness && !x.Staged))
+                    {
+                        <div class="modal fade rgw-modal" id="part-void-@p.Id" tabindex="-1" role="dialog" aria-labelledby="part-void-@(p.Id)-title">
+                            <div class="modal-dialog" role="document">
+                                <div class="modal-content">
+                                    <div class="modal-header">
+                                        <button type="button" class="close" data-dismiss="modal" aria-label="@localizer["Close"]"><span aria-hidden="true">&times;</span></button>
+                                        <h4 class="modal-title" id="part-void-@(p.Id)-title">@localizer["Void"] &middot; @p.Content.Description</h4>
+                                    </div>
+                                    <div class="modal-body">
+                                        <form class="work-order-form work-order-command" asp-action="VoidPart" method="post">
+                                            @Html.AntiForgeryToken()
+                                            <input type="hidden" name="id" value="@o.Id" />
+                                            <input type="hidden" name="revision" value="@o.Revision" />
+                                            <input type="hidden" name="partId" value="@p.Id" />
+                                            <div class="rgw-grid">
+                                                <div class="form-group rgw-wide">
+                                                    <label for="part-void-reason-@p.Id">@localizer["Reason"]</label>
+                                                    <input class="form-control" id="part-void-reason-@p.Id" name="reason" required maxlength="4000" />
+                                                </div>
+                                            </div>
+                                            <div class="rgw-wizard-actions">
+                                                <div class="rgw-wizard-spacer"></div>
+                                                <button type="button" class="btn btn-white" data-dismiss="modal">@localizer["Close"]</button>
+                                                <button class="btn btn-danger" type="submit">@localizer["Void"]</button>
+                                            </div>
+                                        </form>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    }
+
+                    @foreach (var f in d.Files.Where(x => !x.WithdrawnOn.HasValue))
+                    {
+                        <div class="modal fade rgw-modal" id="file-withdraw-@f.Id" tabindex="-1" role="dialog" aria-labelledby="file-withdraw-@(f.Id)-title">
+                            <div class="modal-dialog" role="document">
+                                <div class="modal-content">
+                                    <div class="modal-header">
+                                        <button type="button" class="close" data-dismiss="modal" aria-label="@localizer["Close"]"><span aria-hidden="true">&times;</span></button>
+                                        <h4 class="modal-title" id="file-withdraw-@(f.Id)-title">@localizer["Withdraw"] &middot; @f.Name</h4>
+                                    </div>
+                                    <div class="modal-body">
+                                        <form class="work-order-form work-order-command" asp-action="WithdrawFile" method="post">
+                                            @Html.AntiForgeryToken()
+                                            <input type="hidden" name="id" value="@o.Id" />
+                                            <input type="hidden" name="revision" value="@o.Revision" />
+                                            <input type="hidden" name="fileId" value="@f.Id" />
+                                            <div class="rgw-grid">
+                                                <div class="form-group rgw-wide">
+                                                    <label for="file-reason-@f.Id">@localizer["Reason"]</label>
+                                                    <input class="form-control" id="file-reason-@f.Id" name="reason" required maxlength="4000" />
+                                                </div>
+                                            </div>
+                                            <div class="rgw-wizard-actions">
+                                                <div class="rgw-wizard-spacer"></div>
+                                                <button type="button" class="btn btn-white" data-dismiss="modal">@localizer["Close"]</button>
+                                                <button class="btn btn-danger" type="submit">@localizer["Withdraw"]</button>
+                                            </div>
+                                        </form>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    }
+                }
+
+                @if (canUpload)
+                {
+                    <div class="modal fade rgw-modal" id="work-order-upload" tabindex="-1" role="dialog" aria-labelledby="work-order-upload-title">
+                        <div class="modal-dialog" role="document">
+                            <div class="modal-content">
+                                <div class="modal-header">
+                                    <button type="button" class="close" data-dismiss="modal" aria-label="@localizer["Close"]"><span aria-hidden="true">&times;</span></button>
+                                    <h4 class="modal-title" id="work-order-upload-title">@localizer["Upload"]</h4>
+                                </div>
+                                <div class="modal-body">
+                                    <form class="work-order-form work-order-command" asp-action="Upload" method="post" enctype="multipart/form-data">
+                                        @Html.AntiForgeryToken()
+                                        <input type="hidden" name="id" value="@o.Id" />
+                                        <input type="hidden" name="revision" value="@o.Revision" />
+                                        <div class="rgw-grid">
+                                            <div class="form-group rgw-wide">
+                                                <label for="upload-file">@localizer["File"]</label>
+                                                <input class="form-control" id="upload-file" name="file" type="file" accept=".pdf,.png,.jpg,.jpeg" required />
+                                                <span class="help-block">@localizer["FileHelp"]</span>
+                                            </div>
+                                        </div>
+                                        <div class="rgw-wizard-actions">
+                                            <div class="rgw-wizard-spacer"></div>
+                                            <button type="button" class="btn btn-white" data-dismiss="modal">@localizer["Close"]</button>
+                                            <button class="btn btn-primary" type="submit">@localizer["Upload"]</button>
+                                        </div>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                }
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Styles {
+    <link rel="stylesheet" href="~/css/workspace.css" asp-append-version="true" />
 }
-<h3>@localizer["Labor"]</h3><table class="table"><thead><tr><th>@localizer["User"]</th><th>@localizer["WorkDate"]</th><th>@localizer["Hours"]</th><th>@localizer["Rate"]</th><th>@localizer["Note"]</th></tr></thead><tbody>@foreach (var l in d.Labor) { <tr><td>@l.UserId</td><td>@l.WorkDate.ToString("d")</td><td>@l.Content.Hours</td><td>@l.Content.RatePerHour @c.Currency</td><td>@l.Content.Note</td></tr> }</tbody></table>
-@if (d.CanContribute)
-{
-    <form class="work-order-form work-order-command form-inline" asp-action="Labor" method="post">@Html.AntiForgeryToken()<input type="hidden" name="id" value="@o.Id"/><input type="hidden" name="Revision" value="@o.Revision"/>
-    @if (d.CanManage) { <label>@localizer["User"] <select class="form-control" name="UserId"><option value="">@localizer["CurrentUser"]</option>@foreach (var x in Model.Choices.Users) { <option value="@x.Id">@x.Name</option> }</select></label> }
-    <label>@localizer["WorkDate"] <input class="form-control" name="WorkDate" type="date" value="@DateTime.UtcNow.ToString("yyyy-MM-dd")" required/></label><label>@localizer["Hours"] <input class="form-control" name="Content.Hours" type="number" step="0.01" min="0.01" max="24" required/></label>
-    <label>@localizer["Rate"] <input class="form-control" name="Content.RatePerHour" type="number" step="0.01" min="0"/></label><label>@localizer["Note"] <input class="form-control" name="Content.Note" maxlength="4000"/></label><button class="btn btn-primary" type="submit">@localizer["AddLabor"]</button></form>
-}
-<h3>@localizer["Parts"]</h3><table class="table"><thead><tr><th>@localizer["Description"]</th><th>@localizer["Quantity"]</th><th>@localizer["UnitCost"]</th><th>@localizer["Actions"]</th></tr></thead><tbody>
-@foreach (var p in d.Parts) { <tr><td>@p.Content.Description @if (p.InventoryItemId != null) { <p><a asp-controller="Inventory" asp-action="Index" asp-route-tab="History" asp-route-itemId="@p.InventoryItemId">@localizer["InventoryParts"]</a><code>@p.InventoryTransactionId</code></p> }</td><td>@p.Content.Quantity</td><td>@p.Content.UnitCost @(p.Content.Currency ?? c.Currency)</td><td>@if (p.VoidedOn.HasValue) { <span>@localizer["Voided"]: @p.Content.VoidReason</span> } else if (p.AwaitingWitness) { <span>@localizer["InventoryWitnessPending"]</span><code>@p.InventoryWitnessRequestId</code><a asp-controller="Inventory" asp-action="Index" asp-route-tab="History">@localizer["InventoryParts"]</a>
-@if (d.CanContribute) { <form class="work-order-form work-order-command" asp-action="CancelPartWitness" method="post">@Html.AntiForgeryToken()<input type="hidden" name="id" value="@o.Id"/><input type="hidden" name="revision" value="@o.Revision"/><input type="hidden" name="partId" value="@p.Id"/><label>@localizer["Reason"]<input name="reason" required maxlength="4000"/></label><button class="btn btn-default" type="submit">@localizer["Cancel"]</button></form> } } else if (p.Staged) { <a asp-action="Operations" asp-route-id="@o.Id">@localizer["PartsAllocation"]</a> } else if (d.CanContribute) { <form class="work-order-form work-order-command" asp-action="VoidPart" method="post">@Html.AntiForgeryToken()<input type="hidden" name="id" value="@o.Id"/><input type="hidden" name="revision" value="@o.Revision"/><input type="hidden" name="partId" value="@p.Id"/><label>@localizer["Reason"]<input name="reason" required maxlength="4000"/></label><button class="btn btn-default" type="submit">@localizer["Void"]</button></form> }</td></tr> }
-</tbody></table>
-@if (d.CanContribute) { <form class="work-order-form work-order-command form-inline" asp-action="Part" method="post">@Html.AntiForgeryToken()<input type="hidden" name="id" value="@o.Id"/><input type="hidden" name="Revision" value="@o.Revision"/><label>@localizer["Description"] <input class="form-control" name="Content.Description" required maxlength="2000"/></label><label>@localizer["Quantity"] <input class="form-control" name="Content.Quantity" type="number" min="0.000001" step="0.000001" required/></label><label>@localizer["UnitCost"] <input class="form-control" name="Content.UnitCost" type="number" min="0" step="0.01"/></label>@await Html.PartialAsync("_PartInventory")<button class="btn btn-primary" type="submit">@localizer["AddPart"]</button></form> }
-<h3>@localizer["Files"]</h3><ul>@foreach (var f in d.Files) { <li><a class="work-order-evidence" asp-action="Evidence" asp-route-id="@f.Id">@f.Name</a> (@f.Size) @if (f.WithdrawnOn.HasValue) { <span>@localizer["Withdrawn"]</span> } else if (d.CanContribute) { <form class="work-order-form work-order-command" asp-action="WithdrawFile" method="post">@Html.AntiForgeryToken()<input type="hidden" name="id" value="@o.Id"/><input type="hidden" name="revision" value="@o.Revision"/><input type="hidden" name="fileId" value="@f.Id"/><label>@localizer["Reason"]<input name="reason" required maxlength="4000"/></label><button class="btn btn-default" type="submit">@localizer["Withdraw"]</button></form> }</li> }</ul>
-@if (d.CanContribute || d.CanWrite && o.Status == WorkOrderStatus.Requested && d.ReportedBy == Resgrid.Web.Helpers.ClaimsAuthorizationHelper.GetUserId()) { <form class="work-order-form work-order-command" asp-action="Upload" method="post" enctype="multipart/form-data">@Html.AntiForgeryToken()<input type="hidden" name="id" value="@o.Id"/><input type="hidden" name="revision" value="@o.Revision"/><label>@localizer["File"] <input name="file" type="file" accept=".pdf,.png,.jpg,.jpeg" required/></label><p>@localizer["FileHelp"]</p><button class="btn btn-primary" type="submit">@localizer["Upload"]</button></form> }
-</div></div></div></div>
 @section Scripts { @await Html.PartialAsync("_Scripts") }

--- a/Web/Resgrid.Web/Areas/User/Views/WorkOrders/Edit.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/WorkOrders/Edit.cshtml
@@ -1,13 +1,55 @@
 @model Resgrid.Web.Areas.User.Models.WorkOrders.WorkOrderEditView
 @using Resgrid.Model.WorkOrders
 @inject IStringLocalizer<Resgrid.Localization.Areas.User.WorkOrders.WorkOrders> localizer
-@{ ViewBag.Title = "Resgrid | " + localizer[Model.Id == 0 ? "NewWorkOrder" : "EditWorkOrder"]; }
-<div class="wrapper wrapper-content"><div class="ibox"><div class="ibox-content">
-<h2>@localizer[Model.Id == 0 ? "NewWorkOrder" : "EditWorkOrder"]</h2>
-@await Html.PartialAsync("_Protection")
-<form class="work-order-form work-order-command work-order-protected" asp-action="Save" method="post">
-@Html.AntiForgeryToken()<input type="hidden" name="id" value="@Model.Id"/><input asp-for="Input.RequestId" type="hidden"/><input asp-for="Input.Revision" type="hidden"/>
-@await Html.PartialAsync("_OrderFields", Model.Input, new ViewDataDictionary(ViewData) { TemplateInfo = { HtmlFieldPrefix = "Input" }, ["Choices"] = Model.Choices, ["CanManage"] = Model.CanManage })
-<button class="btn btn-primary" type="submit">@localizer["Save"]</button><a class="btn btn-default" asp-action="Index">@localizer["Cancel"]</a>
-</form></div></div></div>
-@section Scripts { @await Html.PartialAsync("_Scripts") }
+@{
+    var isNew = Model.Id == 0;
+    ViewBag.Title = "Resgrid | " + localizer[isNew ? "NewWorkOrder" : "EditWorkOrder"];
+    ViewData["Tab"] = "Index";
+    ViewData["Title"] = localizer[isNew ? "NewWorkOrder" : "EditWorkOrder"].Value;
+    ViewData["CanWrite"] = Model.CanManage;
+}
+
+@await Html.PartialAsync("_Shell")
+
+<div class="wrapper wrapper-content">
+    <div class="ibox float-e-margins">
+        <div class="ibox-title"><h5>@localizer[isNew ? "NewWorkOrder" : "EditWorkOrder"]</h5></div>
+        <div class="ibox-content">
+            @await Html.PartialAsync("_Protection")
+
+            <form class="work-order-form work-order-command work-order-protected rgw-wizard" asp-action="Save" method="post">
+                @Html.AntiForgeryToken()
+                <input type="hidden" name="id" value="@Model.Id" />
+                <input asp-for="Input.RequestId" type="hidden" />
+                <input asp-for="Input.Revision" type="hidden" />
+
+                <ol class="rgw-steps"></ol>
+
+                @await Html.PartialAsync("_OrderFields", Model.Input, new ViewDataDictionary(ViewData) { TemplateInfo = { HtmlFieldPrefix = "Input" }, ["Choices"] = Model.Choices, ["CanManage"] = Model.CanManage })
+
+                <div class="rgw-step" data-title="@localizer["Review"]">
+                    <h4>@localizer["Review"]</h4>
+                    <p class="text-muted">@localizer["ReviewHint"]</p>
+                    <dl class="rgw-review"></dl>
+                </div>
+
+                <div class="rgw-wizard-actions">
+                    <button type="button" class="btn btn-white rgw-step-prev">@localizer["Previous"]</button>
+                    <div class="rgw-wizard-spacer"></div>
+                    <a class="btn btn-white" asp-action="Index">@localizer["Cancel"]</a>
+                    <button type="button" class="btn btn-primary rgw-step-next">@localizer["Continue"]</button>
+                    <button type="submit" class="btn btn-primary rgw-step-submit">@localizer["Save"]</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+@section Styles {
+    <link rel="stylesheet" href="~/css/workspace.css" asp-append-version="true" />
+}
+@section Scripts {
+    <script id="workspace-settings" type="application/json">@Html.Raw(Newtonsoft.Json.JsonConvert.SerializeObject(new { required = localizer["RequiredFieldsMissing"].Value, nothingEntered = localizer["None"].Value, yes = localizer["Done"].Value, no = localizer["Pending"].Value }, new Newtonsoft.Json.JsonSerializerSettings { StringEscapeHandling = Newtonsoft.Json.StringEscapeHandling.EscapeHtml }))</script>
+    <script src="~/js/app/common/workspace/resgrid.common.workspace.js" asp-append-version="true"></script>
+    @await Html.PartialAsync("_Scripts")
+}

--- a/Web/Resgrid.Web/Areas/User/Views/WorkOrders/EditRecurrence.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/WorkOrders/EditRecurrence.cshtml
@@ -2,38 +2,228 @@
 @using Resgrid.Model.WorkOrders
 @using System.Globalization
 @inject IStringLocalizer<Resgrid.Localization.Areas.User.WorkOrders.WorkOrders> localizer
-@{ ViewBag.Title = "Resgrid | " + localizer["PreventiveMaintenance"]; }
-<div class="wrapper wrapper-content"><div class="ibox"><div class="ibox-content">
-<h2>@localizer["PreventiveMaintenance"]</h2>@await Html.PartialAsync("_Protection")
-<form class="work-order-form work-order-command work-order-protected" asp-action="SaveRecurrence" method="post" data-destination="Recurrence" data-step-prefix="Input.Template.Content.Steps">
-@Html.AntiForgeryToken()<input asp-for="Input.Id" type="hidden"/><input asp-for="Input.Revision" type="hidden"/><input asp-for="Input.Template.RequestId" type="hidden"/>
-<label><input asp-for="Input.IsActive"/> @localizer["Active"]</label>
-@await Html.PartialAsync("_OrderFields", Model.Input.Template, new ViewDataDictionary(ViewData) { TemplateInfo = { HtmlFieldPrefix = "Input.Template" }, ["Choices"] = Model.Choices, ["CanManage"] = true, ["Recurrence"] = true })
-<h3>@localizer["Schedule"]</h3><p>@localizer["RecurrenceHelp"]</p>
-<div class="row"><div class="col-sm-4 form-group"><label asp-for="Input.Calendar">@localizer["Calendar"]</label><select asp-for="Input.Calendar" class="form-control">@foreach (var x in Enum.GetValues<MaintenanceCalendar>()) { <option value="@((int)x)">@localizer["Calendar" + x]</option> }</select></div>
-<div class="col-sm-4 form-group"><label asp-for="Input.Interval">@localizer["Interval"]</label><input asp-for="Input.Interval" type="number" min="1" max="120" class="form-control" required/></div>
-<div class="col-sm-4 form-group"><label asp-for="Input.LeadDays">@localizer["LeadDays"]</label><input asp-for="Input.LeadDays" type="number" min="0" max="90" class="form-control" required/></div></div>
-<div class="form-group"><label asp-for="Input.TimeZoneId">@localizer["TimeZone"]</label><select asp-for="Input.TimeZoneId" class="form-control">@foreach (var zone in TimeZoneInfo.GetSystemTimeZones()) { <option value="@zone.Id">@zone.Id</option> }</select></div>
-<div class="row"><div class="col-sm-6 form-group"><label asp-for="Input.AnchorLocal">@localizer["FirstDueLocal"]</label><input asp-for="Input.AnchorLocal" type="datetime-local" asp-format="{0:yyyy-MM-ddTHH:mm:ss.fffffff}" step="any" class="form-control" required/></div><div class="col-sm-6 form-group"><label asp-for="Input.EndOn">@localizer["EndDate"]</label><input asp-for="Input.EndOn" type="date" class="form-control"/></div></div>
-<label><input asp-for="Input.CompletionBased"/> @localizer["CompletionBased"]</label>
-<h3>@localizer["ServiceWindow"]</h3><input asp-for="Input.ServiceWeekdays" type="hidden" id="maintenance-weekdays"/>
-@for (var day = 0; day < 7; day++) { <label><input type="checkbox" class="maintenance-weekday" value="@day" checked="@((Model.Input.ServiceWeekdays & (1 << day)) != 0)"/> @CultureInfo.CurrentCulture.DateTimeFormat.GetDayName((DayOfWeek)day)</label> }
-<div class="row"><div class="col-sm-6 form-group"><label>@localizer["ServiceStart"]<input name="serviceStart" type="time" class="form-control" value="@TimeOnly.FromTimeSpan(TimeSpan.FromMinutes(Model.Input.ServiceStartMinute)).ToString("HH:mm")" required/></label></div>
-<div class="col-sm-6 form-group"><label>@localizer["ServiceEnd"]<input name="serviceEnd" type="time" class="form-control" value="@TimeOnly.FromTimeSpan(TimeSpan.FromMinutes(Model.Input.ServiceEndMinute)).ToString("HH:mm")" required/></label></div></div>
-<div class="row"><div class="col-sm-6 form-group"><label asp-for="Input.BlackoutFrom">@localizer["BlackoutFrom"]</label><input asp-for="Input.BlackoutFrom" type="date" class="form-control"/></div><div class="col-sm-6 form-group"><label asp-for="Input.BlackoutUntil">@localizer["BlackoutUntil"]</label><input asp-for="Input.BlackoutUntil" type="date" class="form-control"/></div></div>
-<h3>@localizer["UsageAndCondition"]</h3>
-<div class="row"><div class="col-sm-4 form-group"><label asp-for="Input.MeterUnit">@localizer["MeterUnit"]</label><select asp-for="Input.MeterUnit" class="form-control">@foreach (var x in Enum.GetValues<MaintenanceMeterUnit>()) { <option value="@((int)x)">@localizer["Meter" + x]</option> }</select></div>
-<div class="col-sm-4 form-group"><label asp-for="Input.MeterInterval">@localizer["MeterInterval"]</label><input asp-for="Input.MeterInterval" type="number" min="0.000001" step="0.000001" class="form-control"/></div>
-<div class="col-sm-4 form-group"><label asp-for="Input.MeterBaseline">@localizer["MeterBaseline"]</label><input asp-for="Input.MeterBaseline" readonly="@(Model.Input.Id != 0)" type="number" min="0" step="0.000001" class="form-control"/></div></div>
-<div class="row"><div class="col-sm-4 form-group"><label asp-for="Input.Condition">@localizer["Condition"]</label><select asp-for="Input.Condition" class="form-control">@foreach (var x in Enum.GetValues<MaintenanceCondition>()) { <option value="@((int)x)">@localizer["Condition" + x]</option> }</select></div>
-<div class="col-sm-4 form-group"><label asp-for="Input.ConditionThreshold">@localizer["ConditionThreshold"]</label><input asp-for="Input.ConditionThreshold" type="number" step="any" class="form-control"/></div>
-<div class="col-sm-4 form-group"><label asp-for="Input.ConditionUnit">@localizer["ConditionUnit"]</label><input asp-for="Input.ConditionUnit" maxlength="100" class="form-control"/></div></div>
-<h3>@localizer["AssignmentAndEscalation"]</h3>
-<label>@localizer["User"] <select asp-for="Input.AssignedToUserId" class="form-control work-order-user"><option value="">@localizer["None"]</option>@foreach (var x in Model.Choices.Users) { <option value="@x.Id">@x.Name</option> }</select></label>
-<label>@localizer["Role"] <select asp-for="Input.AssignedToRoleId" class="form-control work-order-role"><option value="">@localizer["None"]</option>@foreach (var x in Model.Choices.Roles) { <option value="@x.Id">@x.Name</option> }</select></label>
-<label asp-for="Input.EscalateAfterMinutes">@localizer["EscalateAfter"]</label><input asp-for="Input.EscalateAfterMinutes" type="number" min="0" max="525600" class="form-control"/>
-<label>@localizer["EscalationRole"] <select asp-for="Input.EscalationRoleId" class="form-control"><option value="">@localizer["None"]</option>@foreach (var x in Model.Choices.Roles) { <option value="@x.Id">@x.Name</option> }</select></label>
-<label asp-for="Input.Reason">@localizer["Reason"]</label><textarea asp-for="Input.Reason" class="form-control" maxlength="4000" required="@(Model.Input.Id != 0)"></textarea>
-<button class="btn btn-primary" type="submit">@localizer["Save"]</button><a asp-action="Recurrences" class="btn btn-default">@localizer["Cancel"]</a>
-</form></div></div></div>
-@section Scripts { @await Html.PartialAsync("_Scripts") }
+@*
+    A recurrence is the work order template plus its schedule, so the wizard is the shared
+    order steps followed by the schedule, usage and assignment steps. Field names and the
+    hidden weekday mask that work-orders.js maintains are unchanged.
+*@
+@{
+    ViewBag.Title = "Resgrid | " + localizer["PreventiveMaintenance"];
+    ViewData["Tab"] = "Recurrences";
+    ViewData["Title"] = localizer["PreventiveMaintenance"].Value;
+    ViewData["ParentText"] = localizer["PreventiveMaintenance"].Value;
+    ViewData["ParentAction"] = "Recurrences";
+    ViewData["CanWrite"] = true;
+}
+
+@await Html.PartialAsync("_Shell")
+
+<div class="wrapper wrapper-content">
+    <div class="ibox float-e-margins">
+        <div class="ibox-title"><h5>@localizer["PreventiveMaintenance"]</h5></div>
+        <div class="ibox-content">
+            @await Html.PartialAsync("_Protection")
+
+            <form class="work-order-form work-order-command work-order-protected rgw-wizard" asp-action="SaveRecurrence" method="post" data-destination="Recurrence" data-step-prefix="Input.Template.Content.Steps">
+                @Html.AntiForgeryToken()
+                <input asp-for="Input.Id" type="hidden" />
+                <input asp-for="Input.Revision" type="hidden" />
+                <input asp-for="Input.Template.RequestId" type="hidden" />
+
+                <ol class="rgw-steps"></ol>
+
+                @await Html.PartialAsync("_OrderFields", Model.Input.Template, new ViewDataDictionary(ViewData) { TemplateInfo = { HtmlFieldPrefix = "Input.Template" }, ["Choices"] = Model.Choices, ["CanManage"] = true, ["Recurrence"] = true })
+
+                <div class="rgw-step" data-title="@localizer["Schedule"]">
+                    <h4>@localizer["Schedule"]</h4>
+                    <p class="text-muted">@localizer["StepRecurrenceScheduleHint"]</p>
+                    <div class="alert alert-info"><i class="fa fa-info-circle"></i> @localizer["RecurrenceHelp"]</div>
+                    <div class="rgw-grid">
+                        <div class="form-group">
+                            <div class="checkbox"><label><input asp-for="Input.IsActive" /> @localizer["Active"]</label></div>
+                        </div>
+                        <div class="form-group">
+                            <label asp-for="Input.Calendar">@localizer["Calendar"]</label>
+                            <select asp-for="Input.Calendar" class="form-control">
+                                @foreach (var x in Enum.GetValues<MaintenanceCalendar>())
+                                {
+                                    <option value="@((int)x)">@localizer["Calendar" + x]</option>
+                                }
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label asp-for="Input.Interval">@localizer["Interval"]</label>
+                            <input asp-for="Input.Interval" type="number" min="1" max="120" class="form-control" required />
+                        </div>
+                        <div class="form-group">
+                            <label asp-for="Input.LeadDays">@localizer["LeadDays"]</label>
+                            <input asp-for="Input.LeadDays" type="number" min="0" max="90" class="form-control" required />
+                        </div>
+                        <div class="form-group">
+                            <label asp-for="Input.TimeZoneId">@localizer["TimeZone"]</label>
+                            <select asp-for="Input.TimeZoneId" class="form-control">
+                                @foreach (var zone in TimeZoneInfo.GetSystemTimeZones())
+                                {
+                                    <option value="@zone.Id">@zone.Id</option>
+                                }
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label asp-for="Input.AnchorLocal">@localizer["FirstDueLocal"]</label>
+                            <input asp-for="Input.AnchorLocal" type="datetime-local" asp-format="{0:yyyy-MM-ddTHH:mm:ss.fffffff}" step="any" class="form-control" required />
+                        </div>
+                        <div class="form-group">
+                            <label asp-for="Input.EndOn">@localizer["EndDate"]</label>
+                            <input asp-for="Input.EndOn" type="date" class="form-control" />
+                        </div>
+                        <div class="form-group">
+                            <div class="checkbox"><label><input asp-for="Input.CompletionBased" /> @localizer["CompletionBased"]</label></div>
+                        </div>
+                    </div>
+
+                    <h4>@localizer["ServiceWindow"]</h4>
+                    <input asp-for="Input.ServiceWeekdays" type="hidden" id="maintenance-weekdays" />
+                    <div class="rgw-grid">
+                        <div class="form-group rgw-wide">
+                            <label>@localizer["ServiceWeekdays"]</label>
+                            <div>
+                                @for (var day = 0; day < 7; day++)
+                                {
+                                    <label class="checkbox-inline">
+                                        <input type="checkbox" class="maintenance-weekday" value="@day" data-review-skip="true" checked="@((Model.Input.ServiceWeekdays & (1 << day)) != 0)" />
+                                        @CultureInfo.CurrentCulture.DateTimeFormat.GetDayName((DayOfWeek)day)
+                                    </label>
+                                }
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label for="service-start">@localizer["ServiceStart"]</label>
+                            <input id="service-start" name="serviceStart" type="time" class="form-control" value="@TimeOnly.FromTimeSpan(TimeSpan.FromMinutes(Model.Input.ServiceStartMinute)).ToString("HH:mm")" required />
+                        </div>
+                        <div class="form-group">
+                            <label for="service-end">@localizer["ServiceEnd"]</label>
+                            <input id="service-end" name="serviceEnd" type="time" class="form-control" value="@TimeOnly.FromTimeSpan(TimeSpan.FromMinutes(Model.Input.ServiceEndMinute)).ToString("HH:mm")" required />
+                        </div>
+                        <div class="form-group">
+                            <label asp-for="Input.BlackoutFrom">@localizer["BlackoutFrom"]</label>
+                            <input asp-for="Input.BlackoutFrom" type="date" class="form-control" />
+                        </div>
+                        <div class="form-group">
+                            <label asp-for="Input.BlackoutUntil">@localizer["BlackoutUntil"]</label>
+                            <input asp-for="Input.BlackoutUntil" type="date" class="form-control" />
+                        </div>
+                    </div>
+                </div>
+
+                <div class="rgw-step" data-title="@localizer["UsageAndCondition"]">
+                    <h4>@localizer["UsageAndCondition"]</h4>
+                    <p class="text-muted">@localizer["StepRecurrenceUsageHint"]</p>
+                    <div class="rgw-grid">
+                        <div class="form-group">
+                            <label asp-for="Input.MeterUnit">@localizer["MeterUnit"]</label>
+                            <select asp-for="Input.MeterUnit" class="form-control">
+                                @foreach (var x in Enum.GetValues<MaintenanceMeterUnit>())
+                                {
+                                    <option value="@((int)x)">@localizer["Meter" + x]</option>
+                                }
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label asp-for="Input.MeterInterval">@localizer["MeterInterval"]</label>
+                            <input asp-for="Input.MeterInterval" type="number" min="0.000001" step="0.000001" class="form-control" />
+                        </div>
+                        <div class="form-group">
+                            <label asp-for="Input.MeterBaseline">@localizer["MeterBaseline"]</label>
+                            <input asp-for="Input.MeterBaseline" readonly="@(Model.Input.Id != 0)" type="number" min="0" step="0.000001" class="form-control" />
+                        </div>
+                        <div class="form-group">
+                            <label asp-for="Input.Condition">@localizer["Condition"]</label>
+                            <select asp-for="Input.Condition" class="form-control">
+                                @foreach (var x in Enum.GetValues<MaintenanceCondition>())
+                                {
+                                    <option value="@((int)x)">@localizer["Condition" + x]</option>
+                                }
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label asp-for="Input.ConditionThreshold">@localizer["ConditionThreshold"]</label>
+                            <input asp-for="Input.ConditionThreshold" type="number" step="any" class="form-control" />
+                        </div>
+                        <div class="form-group">
+                            <label asp-for="Input.ConditionUnit">@localizer["ConditionUnit"]</label>
+                            <input asp-for="Input.ConditionUnit" maxlength="100" class="form-control" />
+                        </div>
+                    </div>
+                </div>
+
+                <div class="rgw-step" data-title="@localizer["AssignmentAndEscalation"]">
+                    <h4>@localizer["AssignmentAndEscalation"]</h4>
+                    <p class="text-muted">@localizer["StepRecurrenceAssignmentHint"]</p>
+                    <div class="rgw-grid">
+                        <div class="form-group">
+                            <label asp-for="Input.AssignedToUserId">@localizer["User"]</label>
+                            <select asp-for="Input.AssignedToUserId" class="form-control work-order-user">
+                                <option value="">@localizer["None"]</option>
+                                @foreach (var x in Model.Choices.Users)
+                                {
+                                    <option value="@x.Id">@x.Name</option>
+                                }
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label asp-for="Input.AssignedToRoleId">@localizer["Role"]</label>
+                            <select asp-for="Input.AssignedToRoleId" class="form-control work-order-role">
+                                <option value="">@localizer["None"]</option>
+                                @foreach (var x in Model.Choices.Roles)
+                                {
+                                    <option value="@x.Id">@x.Name</option>
+                                }
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label asp-for="Input.EscalateAfterMinutes">@localizer["EscalateAfter"]</label>
+                            <input asp-for="Input.EscalateAfterMinutes" type="number" min="0" max="525600" class="form-control" />
+                        </div>
+                        <div class="form-group">
+                            <label asp-for="Input.EscalationRoleId">@localizer["EscalationRole"]</label>
+                            <select asp-for="Input.EscalationRoleId" class="form-control">
+                                <option value="">@localizer["None"]</option>
+                                @foreach (var x in Model.Choices.Roles)
+                                {
+                                    <option value="@x.Id">@x.Name</option>
+                                }
+                            </select>
+                        </div>
+                        <div class="form-group rgw-wide">
+                            <label asp-for="Input.Reason">@localizer["Reason"]</label>
+                            <textarea asp-for="Input.Reason" class="form-control" rows="3" maxlength="4000" required="@(Model.Input.Id != 0)"></textarea>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="rgw-step" data-title="@localizer["Review"]">
+                    <h4>@localizer["Review"]</h4>
+                    <p class="text-muted">@localizer["ReviewHint"]</p>
+                    <dl class="rgw-review"></dl>
+                </div>
+
+                <div class="rgw-wizard-actions">
+                    <button type="button" class="btn btn-white rgw-step-prev">@localizer["Previous"]</button>
+                    <div class="rgw-wizard-spacer"></div>
+                    <a class="btn btn-white" asp-action="Recurrences">@localizer["Cancel"]</a>
+                    <button type="button" class="btn btn-primary rgw-step-next">@localizer["Continue"]</button>
+                    <button type="submit" class="btn btn-primary rgw-step-submit">@localizer["Save"]</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+@section Styles {
+    <link rel="stylesheet" href="~/css/workspace.css" asp-append-version="true" />
+}
+@section Scripts {
+    <script id="workspace-settings" type="application/json">@Html.Raw(Newtonsoft.Json.JsonConvert.SerializeObject(new { required = localizer["RequiredFieldsMissing"].Value, nothingEntered = localizer["None"].Value, yes = localizer["Done"].Value, no = localizer["Pending"].Value }, new Newtonsoft.Json.JsonSerializerSettings { StringEscapeHandling = Newtonsoft.Json.StringEscapeHandling.EscapeHtml }))</script>
+    <script src="~/js/app/common/workspace/resgrid.common.workspace.js" asp-append-version="true"></script>
+    @await Html.PartialAsync("_Scripts")
+}

--- a/Web/Resgrid.Web/Areas/User/Views/WorkOrders/EditRecurrence.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/WorkOrders/EditRecurrence.cshtml
@@ -70,7 +70,7 @@
                         </div>
                         <div class="form-group">
                             <label asp-for="Input.AnchorLocal">@localizer["FirstDueLocal"]</label>
-                            <input asp-for="Input.AnchorLocal" type="datetime-local" asp-format="{0:yyyy-MM-ddTHH:mm:ss.fffffff}" step="any" class="form-control" required />
+                            <input asp-for="Input.AnchorLocal" type="datetime-local" asp-format="{0:yyyy-MM-ddTHH:mm:ss.fffffff}" class="form-control" required />
                         </div>
                         <div class="form-group">
                             <label asp-for="Input.EndOn">@localizer["EndDate"]</label>

--- a/Web/Resgrid.Web/Areas/User/Views/WorkOrders/Index.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/WorkOrders/Index.cshtml
@@ -1,33 +1,207 @@
 @model Resgrid.Web.Areas.User.Models.WorkOrders.WorkOrderIndexView
 @using Resgrid.Model.WorkOrders
 @inject IStringLocalizer<Resgrid.Localization.Areas.User.WorkOrders.WorkOrders> localizer
-@{ ViewBag.Title = "Resgrid | " + localizer["WorkOrders"]; }
-<div class="row wrapper border-bottom white-bg page-heading"><div class="col-sm-12"><h2>@localizer["WorkOrders"]</h2><a class="btn btn-default" asp-action="Recurrences">@localizer["PreventiveMaintenance"]</a><p>Readiness Pro</p></div></div>
-<div class="wrapper wrapper-content"><div class="ibox"><div class="ibox-content">
-@await Html.PartialAsync("_Protection")
-<a class="btn btn-default" asp-action="Reports">@localizer["MaintenanceReports"]</a>
-<a class="btn btn-default" asp-action="History" asp-route-unitId="@Model.Filter.UnitId" asp-route-assetId="@Model.Filter.AssetId">@localizer["ServiceHistory"]</a>
-@if (Model.Orders.CanWrite) { <a class="btn btn-primary" asp-action="New">@localizer["NewWorkOrder"]</a> <a class="btn btn-default" asp-action="Bulk">@localizer["BulkOperations"]</a> <a class="btn btn-default" asp-action="Policy">@localizer["OperationsPolicy"]</a> }
-else { <p class="alert alert-info">@localizer["ReadOnlyHistory"] <a asp-controller="ReadinessProBilling" asp-action="Index">Readiness Pro</a></p> }
-<form method="post" asp-action="Reopen" class="form-inline work-order-form">
-    @Html.AntiForgeryToken()<input type="hidden" name="destination" value="Index"/>
-    <input type="hidden" name="ChecklistCompletionId" value="@Model.Filter.ChecklistCompletionId"/><label>@localizer["Status"] <select class="form-control" name="Status"><option value="">@localizer["All"]</option>@foreach (var s in Enum.GetValues<WorkOrderStatus>()) { <option value="@((int)s)" selected="@(Model.Filter.Status == s)">@localizer["Status" + s]</option> }</select></label>
-    <label>@localizer["Priority"] <select class="form-control" name="Priority"><option value="">@localizer["All"]</option>@foreach (var p in Enum.GetValues<WorkOrderPriority>()) { <option value="@((int)p)" selected="@(Model.Filter.Priority == p)">@localizer["Priority" + p]</option> }</select></label>
-    <label>@localizer["Unit"] <select class="form-control" name="UnitId"><option value="">@localizer["All"]</option>@foreach (var u in Model.Choices.Units) { <option value="@u.Id" selected="@(Model.Filter.UnitId?.ToString() == u.Id)">@u.Name</option> }</select></label>
-    <label>@localizer["Group"] <select class="form-control" name="GroupId"><option value="">@localizer["All"]</option>@foreach (var g in Model.Choices.Groups) { <option value="@g.Id" selected="@(Model.Filter.GroupId?.ToString() == g.Id)">@g.Name</option> }</select></label>
-    @if (Model.Choices.Assets.Count > 0) { <label>@localizer["Asset"] <select class="form-control" name="AssetId"><option value="">@localizer["All"]</option>@foreach (var a in Model.Choices.Assets) { <option value="@a.Id" selected="@(Model.Filter.AssetId == a.Id)">@a.Name</option> }</select></label> }
-    <label><input type="checkbox" name="AssignedToMe" value="true" checked="@Model.Filter.AssignedToMe"/> @localizer["AssignedToMe"]</label>
-    <button class="btn btn-default" type="submit">@localizer["Filter"]</button>
-</form>
-<div class="work-order-protected"><table class="table table-striped"><thead><tr><th>@localizer["Number"]</th><th>@localizer["Title"]</th><th>@localizer["Status"]</th><th>@localizer["Priority"]</th><th>@localizer["DueOn"]</th><th>@localizer["Actions"]</th></tr></thead><tbody>
-@foreach (var item in Model.Orders.Items) { <tr><td>@item.Number</td><td><a asp-action="Detail" asp-route-id="@item.Id">@item.Title</a></td><td>@localizer["Status" + item.Status]</td><td>@localizer["Priority" + item.Priority]</td><td>@item.DueOn?.ToString("u")</td><td>@if (item.QuickStatus.HasValue) {
-<form class="work-order-form work-order-command" asp-action="Transition" method="post">@Html.AntiForgeryToken()
-<input type="hidden" name="id" value="@item.Id"/><input type="hidden" name="Revision" value="@item.Revision"/><input type="hidden" name="Status" value="@((int)item.QuickStatus.Value)"/>
-<button class="btn btn-sm btn-default" type="submit">@localizer["Status" + item.QuickStatus.Value]</button></form>
-}</td></tr> }
-</tbody></table></div>
-@if (Model.Orders.Items.Count == 0) { <p>@localizer["NoWorkOrders"]</p> }
-@if (Model.Filter.Page > 0) { <a asp-action="Index" asp-route-page="@(Model.Filter.Page - 1)" asp-route-status="@Model.Filter.Status" asp-route-priority="@Model.Filter.Priority" asp-route-unitId="@Model.Filter.UnitId" asp-route-groupId="@Model.Filter.GroupId" asp-route-assetId="@Model.Filter.AssetId" asp-route-checklistCompletionId="@Model.Filter.ChecklistCompletionId" asp-route-assignedToMe="@Model.Filter.AssignedToMe">@localizer["Previous"]</a> }
-@if (Model.Orders.HasMore) { <a asp-action="Index" asp-route-page="@(Model.Filter.Page + 1)" asp-route-status="@Model.Filter.Status" asp-route-priority="@Model.Filter.Priority" asp-route-unitId="@Model.Filter.UnitId" asp-route-groupId="@Model.Filter.GroupId" asp-route-assetId="@Model.Filter.AssetId" asp-route-checklistCompletionId="@Model.Filter.ChecklistCompletionId" asp-route-assignedToMe="@Model.Filter.AssignedToMe">@localizer["Next"]</a> }
-</div></div></div>
+@functions {
+    string StatusPill(WorkOrderStatus status) => status switch
+    {
+        WorkOrderStatus.Requested => "label-info",
+        WorkOrderStatus.Accepted or WorkOrderStatus.Assigned => "label-primary",
+        WorkOrderStatus.InProgress => "label-warning",
+        WorkOrderStatus.OnHold => "label-warning",
+        WorkOrderStatus.Completed or WorkOrderStatus.Closed => "label-success",
+        _ => "label-danger"
+    };
+
+    string PriorityPill(WorkOrderPriority priority) => priority switch
+    {
+        WorkOrderPriority.Emergency => "label-danger",
+        WorkOrderPriority.High => "label-warning",
+        _ => ""
+    };
+}
+@{
+    ViewBag.Title = "Resgrid | " + localizer["WorkOrders"];
+    ViewData["Tab"] = "Index";
+    ViewData["Title"] = localizer["WorkOrders"].Value;
+    ViewData["Subtitle"] = localizer["WorkOrdersIntro"].Value;
+    ViewData["CanWrite"] = Model.Orders.CanWrite;
+}
+
+@await Html.PartialAsync("_Shell")
+
+<div class="wrapper wrapper-content">
+    <div class="ibox float-e-margins">
+        <div class="ibox-title"><h5>@localizer["WorkOrders"]</h5></div>
+        <div class="ibox-content">
+            @await Html.PartialAsync("_Tabs")
+            @await Html.PartialAsync("_Protection")
+
+            <div class="alert alert-info"><i class="fa fa-info-circle"></i> @localizer["HelpWorkOrders"]</div>
+
+            @if (!Model.Orders.CanWrite)
+            {
+                <div class="alert alert-warning">
+                    @localizer["ReadOnlyHistory"]
+                    <a asp-controller="ReadinessProBilling" asp-action="Index">@localizer["ReadinessPro"]</a>
+                </div>
+            }
+
+            <div class="rgw-filter">
+                <form method="post" asp-action="Reopen" class="work-order-form">
+                    @Html.AntiForgeryToken()
+                    <input type="hidden" name="destination" value="Index" />
+                    <input type="hidden" name="ChecklistCompletionId" value="@Model.Filter.ChecklistCompletionId" />
+                    <div class="rgw-grid">
+                        <div class="form-group">
+                            <label for="filter-status">@localizer["Status"]</label>
+                            <select class="form-control" id="filter-status" name="Status">
+                                <option value="">@localizer["All"]</option>
+                                @foreach (var s in Enum.GetValues<WorkOrderStatus>())
+                                {
+                                    <option value="@((int)s)" selected="@(Model.Filter.Status == s)">@localizer["Status" + s]</option>
+                                }
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label for="filter-priority">@localizer["Priority"]</label>
+                            <select class="form-control" id="filter-priority" name="Priority">
+                                <option value="">@localizer["All"]</option>
+                                @foreach (var p in Enum.GetValues<WorkOrderPriority>())
+                                {
+                                    <option value="@((int)p)" selected="@(Model.Filter.Priority == p)">@localizer["Priority" + p]</option>
+                                }
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label for="filter-unit">@localizer["Unit"]</label>
+                            <select class="form-control" id="filter-unit" name="UnitId">
+                                <option value="">@localizer["All"]</option>
+                                @foreach (var u in Model.Choices.Units)
+                                {
+                                    <option value="@u.Id" selected="@(Model.Filter.UnitId?.ToString() == u.Id)">@u.Name</option>
+                                }
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label for="filter-group">@localizer["Group"]</label>
+                            <select class="form-control" id="filter-group" name="GroupId">
+                                <option value="">@localizer["All"]</option>
+                                @foreach (var g in Model.Choices.Groups)
+                                {
+                                    <option value="@g.Id" selected="@(Model.Filter.GroupId?.ToString() == g.Id)">@g.Name</option>
+                                }
+                            </select>
+                        </div>
+                        @if (Model.Choices.Assets.Count > 0)
+                        {
+                            <div class="form-group">
+                                <label for="filter-asset">@localizer["Asset"]</label>
+                                <select class="form-control" id="filter-asset" name="AssetId">
+                                    <option value="">@localizer["All"]</option>
+                                    @foreach (var a in Model.Choices.Assets)
+                                    {
+                                        <option value="@a.Id" selected="@(Model.Filter.AssetId == a.Id)">@a.Name</option>
+                                    }
+                                </select>
+                            </div>
+                        }
+                        <div class="form-group">
+                            <div class="checkbox"><label><input type="checkbox" name="AssignedToMe" value="true" checked="@Model.Filter.AssignedToMe" /> @localizer["AssignedToMe"]</label></div>
+                        </div>
+                    </div>
+                    <div class="rgw-filter-actions">
+                        <button class="btn btn-primary" type="submit"><i class="fa fa-filter"></i> @localizer["Filter"]</button>
+                    </div>
+                </form>
+            </div>
+
+            @if (Model.Orders.CanWrite)
+            {
+                <div class="rgw-toolbar">
+                    <div class="rgw-toolbar-spacer"></div>
+                    <a class="btn btn-primary" asp-action="New"><i class="fa fa-plus"></i> @localizer["NewWorkOrder"]</a>
+                </div>
+            }
+
+            <div class="work-order-protected">
+                @if (Model.Orders.Items.Count == 0)
+                {
+                    <div class="text-center m-t-lg m-b-lg">
+                        <i class="fa fa-wrench fa-3x text-muted"></i>
+                        <h4 class="m-t-sm">@localizer["NoWorkOrders"]</h4>
+                        <p class="text-muted">@localizer["NoRowsHelp"]</p>
+                    </div>
+                }
+                else
+                {
+                    <div class="table-responsive">
+                        <table class="table table-striped rgw-table">
+                            <thead>
+                                <tr>
+                                    <th>@localizer["Number"]</th>
+                                    <th>@localizer["Title"]</th>
+                                    <th>@localizer["Status"]</th>
+                                    <th>@localizer["Priority"]</th>
+                                    <th>@localizer["DueOn"]</th>
+                                    <th class="rgw-row-actions">@localizer["Actions"]</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach (var item in Model.Orders.Items)
+                                {
+                                    var overdue = item.DueOn.HasValue && item.DueOn.Value < DateTime.UtcNow
+                                        && item.Status is not (WorkOrderStatus.Closed or WorkOrderStatus.Cancelled or WorkOrderStatus.Rejected or WorkOrderStatus.Duplicate);
+                                    <tr>
+                                        <td>@item.Number</td>
+                                        <td><a asp-action="Detail" asp-route-id="@item.Id">@item.Title</a></td>
+                                        <td><span class="label @StatusPill(item.Status)">@localizer["Status" + item.Status]</span></td>
+                                        <td><span class="label @PriorityPill(item.Priority)">@localizer["Priority" + item.Priority]</span></td>
+                                        <td>
+                                            @if (item.DueOn.HasValue)
+                                            {
+                                                <span class="label @(overdue ? "label-danger" : "")">@item.DueOn.Value.ToString("yyyy-MM-dd HH:mm")</span>
+                                            }
+                                        </td>
+                                        <td class="rgw-row-actions">
+                                            @if (item.QuickStatus.HasValue)
+                                            {
+                                                <form class="work-order-form work-order-command" asp-action="Transition" method="post">
+                                                    @Html.AntiForgeryToken()
+                                                    <input type="hidden" name="id" value="@item.Id" />
+                                                    <input type="hidden" name="Revision" value="@item.Revision" />
+                                                    <input type="hidden" name="Status" value="@((int)item.QuickStatus.Value)" />
+                                                    <button class="btn btn-xs btn-primary" type="submit">@localizer["Status" + item.QuickStatus.Value]</button>
+                                                </form>
+                                            }
+                                            <a class="btn btn-xs btn-info" asp-action="Detail" asp-route-id="@item.Id">@localizer["Edit"]</a>
+                                        </td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    </div>
+                }
+
+                @if (Model.Filter.Page > 0 || Model.Orders.HasMore)
+                {
+                    <div class="rgw-pager">
+                        @if (Model.Filter.Page > 0)
+                        {
+                            <a class="btn btn-default btn-sm" asp-action="Index" asp-route-page="@(Model.Filter.Page - 1)" asp-route-status="@Model.Filter.Status" asp-route-priority="@Model.Filter.Priority" asp-route-unitId="@Model.Filter.UnitId" asp-route-groupId="@Model.Filter.GroupId" asp-route-assetId="@Model.Filter.AssetId" asp-route-checklistCompletionId="@Model.Filter.ChecklistCompletionId" asp-route-assignedToMe="@Model.Filter.AssignedToMe"><i class="fa fa-chevron-left"></i> @localizer["Previous"]</a>
+                        }
+                        @if (Model.Orders.HasMore)
+                        {
+                            <a class="btn btn-default btn-sm" asp-action="Index" asp-route-page="@(Model.Filter.Page + 1)" asp-route-status="@Model.Filter.Status" asp-route-priority="@Model.Filter.Priority" asp-route-unitId="@Model.Filter.UnitId" asp-route-groupId="@Model.Filter.GroupId" asp-route-assetId="@Model.Filter.AssetId" asp-route-checklistCompletionId="@Model.Filter.ChecklistCompletionId" asp-route-assignedToMe="@Model.Filter.AssignedToMe">@localizer["Next"] <i class="fa fa-chevron-right"></i></a>
+                        }
+                        <span class="text-muted">@(Model.Filter.Page + 1)</span>
+                    </div>
+                }
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Styles {
+    <link rel="stylesheet" href="~/css/workspace.css" asp-append-version="true" />
+}
 @section Scripts { @await Html.PartialAsync("_Scripts") }

--- a/Web/Resgrid.Web/Areas/User/Views/WorkOrders/Locked.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/WorkOrders/Locked.cshtml
@@ -1,14 +1,43 @@
 @model Resgrid.Web.Areas.User.Models.WorkOrders.WorkOrderLockedView
 @inject IStringLocalizer<Resgrid.Localization.Areas.User.WorkOrders.WorkOrders> localizer
-@{ ViewBag.Title = "Resgrid | " + localizer["WorkOrders"]; ViewBag.ProtectionEnforced = true; }
-<div class="wrapper wrapper-content"><div class="ibox"><div class="ibox-content">
-    <h2>@localizer["WorkOrders"]</h2>
-    @await Html.PartialAsync("_Protection")
-    <form class="work-order-form" asp-action="Reopen" method="post">
-        @Html.AntiForgeryToken()<input type="hidden" name="destination" value="@Model.Page"/><input type="hidden" name="id" value="@Model.Id"/>
-        @if (Model.Page is "Reports" or "History" or "ExportCsv") { @await Html.PartialAsync("_ReportFields", Model.Query) }
-        else { @await Html.PartialAsync("_FilterFields", Model.Filter) }
-        <button class="btn btn-primary" type="submit">@localizer["Unlock"]</button>
-    </form>
-</div></div></div>
+@{
+    ViewBag.Title = "Resgrid | " + localizer["WorkOrders"];
+    ViewBag.ProtectionEnforced = true;
+    ViewData["Title"] = localizer["WorkOrders"].Value;
+}
+
+@await Html.PartialAsync("_Shell")
+
+<div class="wrapper wrapper-content">
+    <div class="ibox float-e-margins">
+        <div class="ibox-title"><h5>@localizer["WorkOrders"]</h5></div>
+        <div class="ibox-content">
+            @await Html.PartialAsync("_Protection")
+
+            <form class="work-order-form" asp-action="Reopen" method="post">
+                @Html.AntiForgeryToken()
+                <input type="hidden" name="destination" value="@Model.Page" />
+                <input type="hidden" name="id" value="@Model.Id" />
+                @if (Model.Page is "Reports" or "History" or "ExportCsv")
+                {
+                    @await Html.PartialAsync("_ReportFields", Model.Query)
+                }
+                else
+                {
+                    @await Html.PartialAsync("_FilterFields", Model.Filter)
+                }
+                <div class="text-center m-t-lg m-b-lg">
+                    <i class="fa fa-lock fa-3x text-muted"></i>
+                    <h4 class="m-t-sm">@localizer["ProtectedDataRequired"]</h4>
+                    <p class="text-muted">@commonLocalizer["AdpProtectedBannerDescription"]</p>
+                    <button class="btn btn-primary m-t" type="submit">@localizer["Unlock"]</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+@section Styles {
+    <link rel="stylesheet" href="~/css/workspace.css" asp-append-version="true" />
+}
 @section Scripts { @await Html.PartialAsync("_Scripts") }

--- a/Web/Resgrid.Web/Areas/User/Views/WorkOrders/Operations.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/WorkOrders/Operations.cshtml
@@ -1,55 +1,515 @@
 @model Resgrid.Web.Areas.User.Models.WorkOrders.WorkOrderOperationsView
 @using Resgrid.Model.WorkOrders
 @inject IStringLocalizer<Resgrid.Localization.Areas.User.WorkOrders.WorkOrders> localizer
-@{ var d = Model.Detail; var id = d.Order.Id; var c = d.Input.Content; ViewBag.Title = "Resgrid | " + localizer["Operations"]; }
-<div class="wrapper wrapper-content"><div class="ibox"><div class="ibox-content">
-<h2>@localizer["Operations"]</h2><a asp-action="Detail" asp-route-id="@id">@d.Order.Number</a>
-@await Html.PartialAsync("_Protection")
-<div class="work-order-protected"><h3>@d.Order.Title</h3><div class="alert alert-danger work-order-error" hidden role="alert"></div>
-<dl><dt>@localizer["ResponseDue"]</dt><dd>@d.ResponseDueOn?.ToString("u")</dd><dt>@localizer["RepairDue"]</dt><dd>@d.RepairDueOn?.ToString("u")</dd><dt>@localizer["RespondedOn"]</dt><dd>@d.ResponseOn?.ToString("u")</dd></dl>
-<h3>@localizer["SpendingApprovals"]</h3>
-@if (c.Approval != null) { <p>@localizer["ApprovalState" + c.Approval.State]: @c.Approval.Amount @c.Approval.Currency</p><p>@c.Approval.Reason</p> }
-@if (d.CanContribute || d.CanEdit) {
-<form class="work-order-form work-order-command" data-destination="Operations" method="post" asp-action="RequestApproval">@Html.AntiForgeryToken()<input type="hidden" name="id" value="@id"/><input type="hidden" name="Revision" value="@d.Order.Revision"/>
-<label>@localizer["ApprovalAmount"] (@c.Currency)<input class="form-control" name="Amount" type="number" min="0" max="100000000" step="0.01" required/></label><label>@localizer["Reason"]<textarea name="Reason" class="form-control" maxlength="4000" required></textarea></label><button class="btn btn-default" type="submit">@localizer["RequestApproval"]</button></form>
+@*
+    The operations desk for one work order: spending approvals, vendor charges and the parts
+    that were reserved, issued, consumed or returned. Every command that asks for a reason
+    opens in a dialog rather than sitting inline in a table cell.
+*@
+@{
+    var d = Model.Detail;
+    var id = d.Order.Id;
+    var c = d.Input.Content;
+    ViewBag.Title = "Resgrid | " + localizer["Operations"];
+    ViewData["Tab"] = "Index";
+    ViewData["Title"] = localizer["Operations"].Value;
+    ViewData["ParentText"] = d.Order.Number;
+    ViewData["ParentAction"] = "Detail";
+    ViewData["ParentId"] = id.ToString();
+    ViewData["CanWrite"] = d.CanWrite;
+    var staged = d.Parts.Where(p => p.Staged).ToList();
 }
-@if (d.CanManage && c.Approval?.State == WorkOrderApprovalState.Requested) {
-<form class="work-order-form work-order-command" data-destination="Operations" method="post" asp-action="DecideApproval">@Html.AntiForgeryToken()<input type="hidden" name="id" value="@id"/><input type="hidden" name="Revision" value="@d.Order.Revision"/>
-<label>@localizer["Decision"]<select class="form-control" name="Approve"><option value="true">@localizer["ApproveSpending"]</option><option value="false">@localizer["RejectSpending"]</option></select></label><label>@localizer["Reason"]<textarea name="Reason" class="form-control" maxlength="4000" required></textarea></label><p>@localizer["IndependentApprovalHelp"]</p><button class="btn btn-primary" type="submit">@localizer["Save"]</button></form>
+
+@await Html.PartialAsync("_Shell")
+
+<div class="wrapper wrapper-content">
+    <div class="ibox float-e-margins">
+        <div class="ibox-title"><h5>@localizer["Operations"] &middot; @d.Order.Title</h5></div>
+        <div class="ibox-content">
+            @await Html.PartialAsync("_Tabs")
+            @await Html.PartialAsync("_Protection")
+
+            <div class="work-order-protected">
+                <div class="alert alert-danger work-order-error" hidden role="alert"></div>
+
+                <div class="rgw-toolbar">
+                    <a class="btn btn-default btn-sm" asp-action="Detail" asp-route-id="@id"><i class="fa fa-arrow-left"></i> @d.Order.Number</a>
+                </div>
+
+                <div class="row">
+                    <div class="col-lg-4 col-md-6">
+                        <div class="ibox"><div class="ibox-title"><h5>@localizer["ResponseDue"]</h5></div>
+                            <div class="ibox-content"><h3 class="no-margins">@d.ResponseDueOn?.ToString("u")</h3><small>@localizer["RespondedOn"]: @d.ResponseOn?.ToString("u")</small></div></div>
+                    </div>
+                    <div class="col-lg-4 col-md-6">
+                        <div class="ibox"><div class="ibox-title"><h5>@localizer["RepairDue"]</h5></div>
+                            <div class="ibox-content"><h3 class="no-margins">@d.RepairDueOn?.ToString("u")</h3></div></div>
+                    </div>
+                </div>
+
+                @* ── Spending approvals ─────────────────────────────────────────── *@
+                <div class="rgw-toolbar">
+                    <h3 class="m-t-none m-b-none">@localizer["SpendingApprovals"]</h3>
+                    <div class="rgw-toolbar-spacer"></div>
+                    @if (d.CanContribute || d.CanEdit)
+                    {
+                        <button type="button" class="btn btn-default btn-sm" data-toggle="modal" data-target="#approval-request"><i class="fa fa-paper-plane-o"></i> @localizer["RequestApproval"]</button>
+                    }
+                    @if (d.CanManage && c.Approval?.State == WorkOrderApprovalState.Requested)
+                    {
+                        <button type="button" class="btn btn-primary btn-sm" data-toggle="modal" data-target="#approval-decide"><i class="fa fa-gavel"></i> @localizer["Decision"]</button>
+                    }
+                </div>
+                @if (c.Approval != null)
+                {
+                    <p class="text-muted">
+                        <span class="label @(c.Approval.State == WorkOrderApprovalState.Approved ? "label-success" : c.Approval.State == WorkOrderApprovalState.Rejected ? "label-danger" : "label-warning")">@localizer["ApprovalState" + c.Approval.State]</span>
+                        @c.Approval.Amount @c.Approval.Currency &mdash; @c.Approval.Reason
+                    </p>
+                }
+                else
+                {
+                    <p class="text-muted">@localizer["ApprovalStateNone"]</p>
+                }
+
+                @* ── Vendor charges ─────────────────────────────────────────────── *@
+                <div class="rgw-toolbar">
+                    <h3 class="m-t-none m-b-none">@localizer["VendorCharges"]</h3>
+                    <div class="rgw-toolbar-spacer"></div>
+                    @if (d.CanContribute)
+                    {
+                        <button type="button" class="btn btn-default btn-sm" data-toggle="modal" data-target="#vendor-charge"><i class="fa fa-plus"></i> @localizer["AddVendorCharge"]</button>
+                    }
+                </div>
+                @if (Model.VendorCharges.Count == 0)
+                {
+                    <p class="text-muted">@localizer["None"]</p>
+                }
+                else
+                {
+                    <div class="table-responsive">
+                        <table class="table table-striped rgw-table">
+                            <thead><tr><th>@localizer["VendorDetails"]</th><th>@localizer["InvoiceReference"]</th><th>@localizer["Description"]</th><th class="text-right">@localizer["TotalCost"]</th><th class="rgw-row-actions">@localizer["Actions"]</th></tr></thead>
+                            <tbody>
+                                @foreach (var charge in Model.VendorCharges)
+                                {
+                                    <tr>
+                                        <td>@charge.Content.VendorName</td>
+                                        <td>@charge.Content.InvoiceReference</td>
+                                        <td>@charge.Content.Description</td>
+                                        <td class="text-right">
+                                            @charge.Content.Amount @charge.Content.Currency
+                                            @if (charge.VoidedOn.HasValue)
+                                            {
+                                                <span class="label label-danger">@localizer["Voided"]</span>
+                                            }
+                                        </td>
+                                        <td class="rgw-row-actions">
+                                            @if (d.CanContribute && d.CanManage && !charge.VoidedOn.HasValue)
+                                            {
+                                                <button type="button" class="btn btn-xs btn-warning" data-toggle="modal" data-target="#charge-void-@charge.Id">@localizer["VoidCharge"]</button>
+                                            }
+                                        </td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    </div>
+                }
+                @if (Model.VendorCharges.Count == 50)
+                {
+                    <div class="rgw-pager">
+                        <a class="btn btn-default btn-sm" asp-action="Operations" asp-route-id="@id" asp-route-vendorAfterId="@Model.VendorCharges.Last().Id">@localizer["Next"] <i class="fa fa-chevron-right"></i></a>
+                    </div>
+                }
+
+                @* ── Parts allocation ───────────────────────────────────────────── *@
+                <div class="rgw-toolbar">
+                    <h3 class="m-t-none m-b-none">@localizer["PartsAllocation"]</h3>
+                    <div class="rgw-toolbar-spacer"></div>
+                    @if (d.CanContribute)
+                    {
+                        <button type="button" class="btn btn-default btn-sm" data-toggle="modal" data-target="#part-reserve"><i class="fa fa-plus"></i> @localizer["PartMovementReserve"]</button>
+                    }
+                </div>
+                <div class="alert alert-info"><i class="fa fa-info-circle"></i> @localizer["PartsAllocationHelp"]</div>
+                @if (staged.Count == 0)
+                {
+                    <p class="text-muted">@localizer["None"]</p>
+                }
+                else
+                {
+                    <div class="table-responsive">
+                        <table class="table table-striped rgw-table">
+                            <thead><tr><th>@localizer["Description"]</th><th class="text-right">@localizer["ReservedParts"]</th><th class="text-right">@localizer["IssuedParts"]</th><th class="text-right">@localizer["ConsumedParts"]</th><th class="text-right">@localizer["ReturnedParts"]</th><th class="rgw-row-actions">@localizer["Actions"]</th></tr></thead>
+                            <tbody>
+                                @foreach (var part in staged)
+                                {
+                                    <tr>
+                                        <td>@part.Content.Description</td>
+                                        <td class="text-right">@part.ReservedQuantity</td>
+                                        <td class="text-right">@part.IssuedQuantity</td>
+                                        <td class="text-right">@part.ConsumedQuantity</td>
+                                        <td class="text-right">@part.ReturnedQuantity</td>
+                                        <td class="rgw-row-actions">
+                                            @if (d.CanContribute && (part.ReservedQuantity > 0 || part.IssuedQuantity > 0))
+                                            {
+                                                <button type="button" class="btn btn-xs btn-primary" data-toggle="modal" data-target="#part-move-@part.Id">@localizer["Actions"]</button>
+                                            }
+                                        </td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    </div>
+                }
+
+                @* ── Part movements ─────────────────────────────────────────────── *@
+                <h3>@localizer["PartMovements"]</h3>
+                @if (Model.Movements.Count == 0)
+                {
+                    <p class="text-muted">@localizer["None"]</p>
+                }
+                else
+                {
+                    <div class="table-responsive">
+                        <table class="table table-striped rgw-table">
+                            <thead><tr><th>@localizer["Parts"]</th><th>@localizer["Actions"]</th><th class="text-right">@localizer["Quantity"]</th><th>@localizer["CreatedOn"]</th><th>@localizer["Status"]</th></tr></thead>
+                            <tbody>
+                                @foreach (var movement in Model.Movements)
+                                {
+                                    var pending = !movement.Cancelled && movement.InventoryOperationId != null && movement.InventoryTransactionId == null;
+                                    <tr>
+                                        <td>@movement.PartId</td>
+                                        <td><span class="label">@localizer["PartMovement" + (WorkOrderPartMovementKind)movement.Kind]</span></td>
+                                        <td class="text-right">@movement.Quantity</td>
+                                        <td>@movement.CreatedOn.ToString("u")</td>
+                                        <td>
+                                            <span class="label @(movement.Cancelled ? "label-danger" : pending ? "label-warning" : "label-success")">
+                                                @localizer[movement.Cancelled ? "StatusCancelled" : pending ? "InventoryWitnessPending" : "Done"]
+                                            </span>
+                                            @if (pending)
+                                            {
+                                                <small class="text-muted rgw-sub">@movement.RequestId</small>
+                                                <a asp-controller="Inventory" asp-action="Index" asp-route-tab="History">@localizer["InventoryParts"]</a>
+                                                @if (d.CanContribute)
+                                                {
+                                                    <button type="button" class="btn btn-xs btn-warning" data-toggle="modal" data-target="#movement-cancel-@movement.Id">@localizer["Cancel"]</button>
+                                                }
+                                            }
+                                        </td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    </div>
+                }
+                @if (Model.Movements.Count == 50)
+                {
+                    <div class="rgw-pager">
+                        <a class="btn btn-default btn-sm" asp-action="Operations" asp-route-id="@id" asp-route-movementAfterId="@Model.Movements.Last().Id">@localizer["Next"] <i class="fa fa-chevron-right"></i></a>
+                    </div>
+                }
+
+                @* ── Dialogs ────────────────────────────────────────────────────── *@
+                @if (d.CanContribute || d.CanEdit)
+                {
+                    <div class="modal fade rgw-modal" id="approval-request" tabindex="-1" role="dialog" aria-labelledby="approval-request-title">
+                        <div class="modal-dialog" role="document">
+                            <div class="modal-content">
+                                <div class="modal-header">
+                                    <button type="button" class="close" data-dismiss="modal" aria-label="@localizer["Cancel"]"><span aria-hidden="true">&times;</span></button>
+                                    <h4 class="modal-title" id="approval-request-title">@localizer["RequestApproval"]</h4>
+                                </div>
+                                <div class="modal-body">
+                                    <form class="work-order-form work-order-command" data-destination="Operations" method="post" asp-action="RequestApproval">
+                                        @Html.AntiForgeryToken()
+                                        <input type="hidden" name="id" value="@id" />
+                                        <input type="hidden" name="Revision" value="@d.Order.Revision" />
+                                        <div class="rgw-grid">
+                                            <div class="form-group">
+                                                <label for="approval-amount">@localizer["ApprovalAmount"] (@c.Currency)</label>
+                                                <input class="form-control" id="approval-amount" name="Amount" type="number" min="0" max="100000000" step="0.01" required />
+                                            </div>
+                                            <div class="form-group rgw-wide">
+                                                <label for="approval-reason">@localizer["Reason"]</label>
+                                                <textarea id="approval-reason" name="Reason" class="form-control" rows="3" maxlength="4000" required></textarea>
+                                            </div>
+                                        </div>
+                                        <div class="rgw-wizard-actions">
+                                            <div class="rgw-wizard-spacer"></div>
+                                            <button type="button" class="btn btn-white" data-dismiss="modal">@localizer["Cancel"]</button>
+                                            <button class="btn btn-primary" type="submit">@localizer["RequestApproval"]</button>
+                                        </div>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                }
+
+                @if (d.CanManage && c.Approval?.State == WorkOrderApprovalState.Requested)
+                {
+                    <div class="modal fade rgw-modal" id="approval-decide" tabindex="-1" role="dialog" aria-labelledby="approval-decide-title">
+                        <div class="modal-dialog" role="document">
+                            <div class="modal-content">
+                                <div class="modal-header">
+                                    <button type="button" class="close" data-dismiss="modal" aria-label="@localizer["Cancel"]"><span aria-hidden="true">&times;</span></button>
+                                    <h4 class="modal-title" id="approval-decide-title">@localizer["Decision"]</h4>
+                                </div>
+                                <div class="modal-body">
+                                    <p class="text-muted">@localizer["IndependentApprovalHelp"]</p>
+                                    <form class="work-order-form work-order-command" data-destination="Operations" method="post" asp-action="DecideApproval">
+                                        @Html.AntiForgeryToken()
+                                        <input type="hidden" name="id" value="@id" />
+                                        <input type="hidden" name="Revision" value="@d.Order.Revision" />
+                                        <div class="rgw-grid">
+                                            <div class="form-group">
+                                                <label for="approval-decision">@localizer["Decision"]</label>
+                                                <select class="form-control" id="approval-decision" name="Approve">
+                                                    <option value="true">@localizer["ApproveSpending"]</option>
+                                                    <option value="false">@localizer["RejectSpending"]</option>
+                                                </select>
+                                            </div>
+                                            <div class="form-group rgw-wide">
+                                                <label for="decision-reason">@localizer["Reason"]</label>
+                                                <textarea id="decision-reason" name="Reason" class="form-control" rows="3" maxlength="4000" required></textarea>
+                                            </div>
+                                        </div>
+                                        <div class="rgw-wizard-actions">
+                                            <div class="rgw-wizard-spacer"></div>
+                                            <button type="button" class="btn btn-white" data-dismiss="modal">@localizer["Cancel"]</button>
+                                            <button class="btn btn-primary" type="submit">@localizer["Save"]</button>
+                                        </div>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                }
+
+                @if (d.CanContribute)
+                {
+                    <div class="modal fade rgw-modal" id="vendor-charge" tabindex="-1" role="dialog" aria-labelledby="vendor-charge-title">
+                        <div class="modal-dialog modal-lg" role="document">
+                            <div class="modal-content">
+                                <div class="modal-header">
+                                    <button type="button" class="close" data-dismiss="modal" aria-label="@localizer["Cancel"]"><span aria-hidden="true">&times;</span></button>
+                                    <h4 class="modal-title" id="vendor-charge-title">@localizer["AddVendorCharge"]</h4>
+                                </div>
+                                <div class="modal-body">
+                                    <form class="work-order-form work-order-command" data-destination="Operations" method="post" asp-action="AddVendorCharge">
+                                        @Html.AntiForgeryToken()
+                                        <input type="hidden" name="id" value="@id" />
+                                        <input type="hidden" name="Revision" value="@d.Order.Revision" />
+                                        <input type="hidden" name="RequestId" value="@Guid.NewGuid().ToString("D")" />
+                                        <div class="rgw-grid">
+                                            <div class="form-group">
+                                                <label for="charge-vendor">@localizer["VendorDetails"]</label>
+                                                <input id="charge-vendor" name="Content.VendorName" class="form-control" maxlength="200" required />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="charge-invoice">@localizer["InvoiceReference"]</label>
+                                                <input id="charge-invoice" name="Content.InvoiceReference" class="form-control" maxlength="200" required />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="charge-currency">@localizer["Currency"]</label>
+                                                <input id="charge-currency" name="Content.Currency" value="@c.Currency" class="form-control" pattern="[A-Z]{3}" maxlength="3" required />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="charge-amount">@localizer["TotalCost"]</label>
+                                                <input id="charge-amount" name="Content.Amount" class="form-control" type="number" min="0.01" max="100000000" step="0.01" required />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="charge-date">@localizer["ServiceDate"]</label>
+                                                <input id="charge-date" name="Content.ServiceDate" class="form-control" type="date" required />
+                                            </div>
+                                            <div class="form-group rgw-wide">
+                                                <label for="charge-description">@localizer["Description"]</label>
+                                                <textarea id="charge-description" name="Content.Description" class="form-control" rows="3" maxlength="4000" required></textarea>
+                                            </div>
+                                        </div>
+                                        <div class="rgw-wizard-actions">
+                                            <div class="rgw-wizard-spacer"></div>
+                                            <button type="button" class="btn btn-white" data-dismiss="modal">@localizer["Cancel"]</button>
+                                            <button class="btn btn-primary" type="submit">@localizer["AddVendorCharge"]</button>
+                                        </div>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="modal fade rgw-modal" id="part-reserve" tabindex="-1" role="dialog" aria-labelledby="part-reserve-title">
+                        <div class="modal-dialog modal-lg" role="document">
+                            <div class="modal-content">
+                                <div class="modal-header">
+                                    <button type="button" class="close" data-dismiss="modal" aria-label="@localizer["Cancel"]"><span aria-hidden="true">&times;</span></button>
+                                    <h4 class="modal-title" id="part-reserve-title">@localizer["PartMovementReserve"]</h4>
+                                </div>
+                                <div class="modal-body">
+                                    <form class="work-order-form work-order-command" data-destination="Operations" method="post" asp-action="ReservePart">
+                                        @Html.AntiForgeryToken()
+                                        <input type="hidden" name="id" value="@id" />
+                                        <input type="hidden" name="Revision" value="@d.Order.Revision" />
+                                        @await Html.PartialAsync("_PartInventory")
+                                        <div class="rgw-grid">
+                                            <div class="form-group rgw-wide">
+                                                <label for="reserve-description">@localizer["Description"]</label>
+                                                <input id="reserve-description" name="Content.Description" class="form-control" maxlength="2000" required />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="reserve-quantity">@localizer["Quantity"]</label>
+                                                <input id="reserve-quantity" name="Content.Quantity" class="form-control" type="number" min="0.000001" max="100000" step="0.000001" required />
+                                            </div>
+                                        </div>
+                                        <div class="rgw-wizard-actions">
+                                            <div class="rgw-wizard-spacer"></div>
+                                            <button type="button" class="btn btn-white" data-dismiss="modal">@localizer["Cancel"]</button>
+                                            <button class="btn btn-primary" type="submit">@localizer["PartMovementReserve"]</button>
+                                        </div>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    @foreach (var part in staged.Where(p => p.ReservedQuantity > 0 || p.IssuedQuantity > 0))
+                    {
+                        <div class="modal fade rgw-modal" id="part-move-@part.Id" tabindex="-1" role="dialog" aria-labelledby="part-move-@(part.Id)-title">
+                            <div class="modal-dialog modal-lg" role="document">
+                                <div class="modal-content">
+                                    <div class="modal-header">
+                                        <button type="button" class="close" data-dismiss="modal" aria-label="@localizer["Cancel"]"><span aria-hidden="true">&times;</span></button>
+                                        <h4 class="modal-title" id="part-move-@(part.Id)-title">@localizer["PartMovements"] &middot; @part.Content.Description</h4>
+                                    </div>
+                                    <div class="modal-body">
+                                        <form class="work-order-form work-order-command" data-destination="Operations" method="post" asp-action="MovePart">
+                                            @Html.AntiForgeryToken()
+                                            <input type="hidden" name="id" value="@id" />
+                                            <input type="hidden" name="partId" value="@part.Id" />
+                                            <input type="hidden" name="Revision" value="@d.Order.Revision" />
+                                            <input type="hidden" name="RequestId" value="@Guid.NewGuid().ToString("D")" />
+                                            <div class="rgw-grid">
+                                                <div class="form-group">
+                                                    <label for="move-kind-@part.Id">@localizer["Actions"]</label>
+                                                    <select class="form-control" id="move-kind-@part.Id" name="Kind">
+                                                        @foreach (var kind in Enum.GetValues<WorkOrderPartMovementKind>().Where(k => k != WorkOrderPartMovementKind.Reserve))
+                                                        {
+                                                            <option value="@((int)kind)">@localizer["PartMovement" + kind]</option>
+                                                        }
+                                                    </select>
+                                                </div>
+                                                <div class="form-group">
+                                                    <label for="move-quantity-@part.Id">@localizer["Quantity"]</label>
+                                                    <input id="move-quantity-@part.Id" name="Quantity" class="form-control" type="number" min="0.000001" max="100000" step="0.000001" required />
+                                                </div>
+                                                <div class="form-group rgw-wide">
+                                                    <label for="move-reason-@part.Id">@localizer["Reason"]</label>
+                                                    <input id="move-reason-@part.Id" name="Reason" class="form-control" maxlength="4000" required />
+                                                </div>
+                                            </div>
+                                            <fieldset class="work-order-inventory" data-url="@Url.Action("PartChoices")">
+                                                <div class="rgw-grid">
+                                                    <div class="form-group">
+                                                        <label for="move-location-@part.Id">@localizer["IssueLocation"]</label>
+                                                        <select id="move-location-@part.Id" name="LocationId" class="form-control inventory-part-choice" data-kind="location">
+                                                            <option value="">@localizer["None"]</option>
+                                                        </select>
+                                                    </div>
+                                                    <div class="form-group">
+                                                        <label>&nbsp;</label>
+                                                        <div><button type="button" class="btn btn-default inventory-part-load" data-kind="location" data-page="0">@localizer["LoadChoices"]</button></div>
+                                                    </div>
+                                                </div>
+                                            </fieldset>
+                                            <div class="rgw-wizard-actions">
+                                                <div class="rgw-wizard-spacer"></div>
+                                                <button type="button" class="btn btn-white" data-dismiss="modal">@localizer["Cancel"]</button>
+                                                <button type="submit" class="btn btn-primary">@localizer["Save"]</button>
+                                            </div>
+                                        </form>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    }
+
+                    @foreach (var movement in Model.Movements.Where(m => !m.Cancelled && m.InventoryOperationId != null && m.InventoryTransactionId == null))
+                    {
+                        <div class="modal fade rgw-modal" id="movement-cancel-@movement.Id" tabindex="-1" role="dialog" aria-labelledby="movement-cancel-@(movement.Id)-title">
+                            <div class="modal-dialog" role="document">
+                                <div class="modal-content">
+                                    <div class="modal-header">
+                                        <button type="button" class="close" data-dismiss="modal" aria-label="@localizer["Cancel"]"><span aria-hidden="true">&times;</span></button>
+                                        <h4 class="modal-title" id="movement-cancel-@(movement.Id)-title">@localizer["Cancel"]</h4>
+                                    </div>
+                                    <div class="modal-body">
+                                        <form class="work-order-form work-order-command" data-destination="Operations" method="post" asp-action="CancelPartMovement">
+                                            @Html.AntiForgeryToken()
+                                            <input type="hidden" name="id" value="@id" />
+                                            <input type="hidden" name="movementId" value="@movement.Id" />
+                                            <input type="hidden" name="revision" value="@d.Order.Revision" />
+                                            <div class="rgw-grid">
+                                                <div class="form-group rgw-wide">
+                                                    <label for="movement-reason-@movement.Id">@localizer["Reason"]</label>
+                                                    <input class="form-control" id="movement-reason-@movement.Id" name="reason" maxlength="4000" required />
+                                                </div>
+                                            </div>
+                                            <div class="rgw-wizard-actions">
+                                                <div class="rgw-wizard-spacer"></div>
+                                                <button type="button" class="btn btn-white" data-dismiss="modal">@localizer["Close"]</button>
+                                                <button type="submit" class="btn btn-warning">@localizer["Cancel"]</button>
+                                            </div>
+                                        </form>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    }
+                }
+
+                @if (d.CanContribute && d.CanManage)
+                {
+                    foreach (var charge in Model.VendorCharges.Where(x => !x.VoidedOn.HasValue))
+                    {
+                        <div class="modal fade rgw-modal" id="charge-void-@charge.Id" tabindex="-1" role="dialog" aria-labelledby="charge-void-@(charge.Id)-title">
+                            <div class="modal-dialog" role="document">
+                                <div class="modal-content">
+                                    <div class="modal-header">
+                                        <button type="button" class="close" data-dismiss="modal" aria-label="@localizer["Cancel"]"><span aria-hidden="true">&times;</span></button>
+                                        <h4 class="modal-title" id="charge-void-@(charge.Id)-title">@localizer["VoidCharge"] &middot; @charge.Content.VendorName</h4>
+                                    </div>
+                                    <div class="modal-body">
+                                        <form class="work-order-form work-order-command" data-destination="Operations" method="post" asp-action="VoidVendorCharge">
+                                            @Html.AntiForgeryToken()
+                                            <input type="hidden" name="id" value="@id" />
+                                            <input type="hidden" name="chargeId" value="@charge.Id" />
+                                            <input type="hidden" name="revision" value="@d.Order.Revision" />
+                                            <div class="rgw-grid">
+                                                <div class="form-group rgw-wide">
+                                                    <label for="charge-reason-@charge.Id">@localizer["Reason"]</label>
+                                                    <input id="charge-reason-@charge.Id" name="reason" class="form-control" maxlength="4000" required />
+                                                </div>
+                                            </div>
+                                            <div class="rgw-wizard-actions">
+                                                <div class="rgw-wizard-spacer"></div>
+                                                <button type="button" class="btn btn-white" data-dismiss="modal">@localizer["Close"]</button>
+                                                <button class="btn btn-warning" type="submit">@localizer["VoidCharge"]</button>
+                                            </div>
+                                        </form>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    }
+                }
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Styles {
+    <link rel="stylesheet" href="~/css/workspace.css" asp-append-version="true" />
 }
-<h3>@localizer["VendorCharges"]</h3>
-<table class="table"><thead><tr><th>@localizer["VendorDetails"]</th><th>@localizer["InvoiceReference"]</th><th>@localizer["Description"]</th><th>@localizer["TotalCost"]</th><th>@localizer["Actions"]</th></tr></thead><tbody>
-@foreach (var charge in Model.VendorCharges) { <tr><td>@charge.Content.VendorName</td><td>@charge.Content.InvoiceReference</td><td>@charge.Content.Description</td><td>@charge.Content.Amount @charge.Content.Currency @if (charge.VoidedOn.HasValue) { <span>@localizer["Voided"]</span> }</td><td>@if (d.CanContribute && d.CanManage && !charge.VoidedOn.HasValue) { <form class="work-order-form work-order-command" data-destination="Operations" method="post" asp-action="VoidVendorCharge">@Html.AntiForgeryToken()<input type="hidden" name="id" value="@id"/><input type="hidden" name="chargeId" value="@charge.Id"/><input type="hidden" name="revision" value="@d.Order.Revision"/><input name="reason" class="form-control" aria-label="@localizer["Reason"]" maxlength="4000" required/><button class="btn btn-warning" type="submit">@localizer["VoidCharge"]</button></form> }</td></tr> }
-</tbody></table>
-@if (Model.VendorCharges.Count == 50) { <a asp-action="Operations" asp-route-id="@id" asp-route-vendorAfterId="@Model.VendorCharges.Last().Id">@localizer["Next"]</a> }
-@if (d.CanContribute) {
-<form class="work-order-form work-order-command" data-destination="Operations" method="post" asp-action="AddVendorCharge">@Html.AntiForgeryToken()<input type="hidden" name="id" value="@id"/><input type="hidden" name="Revision" value="@d.Order.Revision"/><input type="hidden" name="RequestId" value="@Guid.NewGuid().ToString("D")"/>
-<label>@localizer["VendorDetails"]<input name="Content.VendorName" class="form-control" maxlength="200" required/></label><label>@localizer["InvoiceReference"]<input name="Content.InvoiceReference" class="form-control" maxlength="200" required/></label>
-<label>@localizer["Description"]<textarea name="Content.Description" class="form-control" maxlength="4000" required></textarea></label>
-<label>@localizer["Currency"]<input name="Content.Currency" value="@c.Currency" class="form-control" pattern="[A-Z]{3}" maxlength="3" required/></label><label>@localizer["TotalCost"]<input name="Content.Amount" class="form-control" type="number" min="0.01" max="100000000" step="0.01" required/></label>
-<label>@localizer["ServiceDate"]<input name="Content.ServiceDate" class="form-control" type="date" required/></label><button class="btn btn-primary" type="submit">@localizer["AddVendorCharge"]</button></form>
-}
-<h3>@localizer["PartsAllocation"]</h3><p>@localizer["PartsAllocationHelp"]</p>
-<table class="table"><thead><tr><th>@localizer["Description"]</th><th>@localizer["ReservedParts"]</th><th>@localizer["IssuedParts"]</th><th>@localizer["ConsumedParts"]</th><th>@localizer["ReturnedParts"]</th><th>@localizer["Actions"]</th></tr></thead><tbody>
-@foreach (var part in d.Parts.Where(p => p.Staged)) { <tr><td>@part.Content.Description</td><td>@part.ReservedQuantity</td><td>@part.IssuedQuantity</td><td>@part.ConsumedQuantity</td><td>@part.ReturnedQuantity</td><td>
-@if (d.CanContribute && (part.ReservedQuantity > 0 || part.IssuedQuantity > 0)) {
-<form class="work-order-form work-order-command" data-destination="Operations" method="post" asp-action="MovePart">@Html.AntiForgeryToken()<input type="hidden" name="id" value="@id"/><input type="hidden" name="partId" value="@part.Id"/><input type="hidden" name="Revision" value="@d.Order.Revision"/><input type="hidden" name="RequestId" value="@Guid.NewGuid().ToString("D")"/>
-<label>@localizer["Actions"]<select class="form-control" name="Kind">@foreach (var kind in Enum.GetValues<WorkOrderPartMovementKind>().Where(k => k != WorkOrderPartMovementKind.Reserve)) { <option value="@((int)kind)">@localizer["PartMovement" + kind]</option> }</select></label><label>@localizer["Quantity"]<input name="Quantity" class="form-control" type="number" min="0.000001" max="100000" step="0.000001" required/></label>
-<fieldset class="work-order-inventory" data-url="@Url.Action("PartChoices")"><label>@localizer["IssueLocation"]<select name="LocationId" class="form-control inventory-part-choice" data-kind="location"><option value="">@localizer["None"]</option></select></label><button type="button" class="btn btn-default inventory-part-load" data-kind="location" data-page="0">@localizer["LoadChoices"]</button></fieldset>
-<label>@localizer["Reason"]<input name="Reason" class="form-control" maxlength="4000" required/></label><button type="submit" class="btn btn-default">@localizer["Save"]</button></form>
-}
-</td></tr> }
-</tbody></table>
-@if (d.CanContribute) {
-<form class="work-order-form work-order-command" data-destination="Operations" method="post" asp-action="ReservePart">@Html.AntiForgeryToken()<input type="hidden" name="id" value="@id"/><input type="hidden" name="Revision" value="@d.Order.Revision"/>
-@await Html.PartialAsync("_PartInventory")
-<label>@localizer["Description"]<input name="Content.Description" class="form-control" maxlength="2000" required/></label><label>@localizer["Quantity"]<input name="Content.Quantity" class="form-control" type="number" min="0.000001" max="100000" step="0.000001" required/></label><button type="submit" class="btn btn-primary">@localizer["PartMovementReserve"]</button></form>
-}
-<h3>@localizer["PartMovements"]</h3><table class="table"><thead><tr><th>@localizer["Parts"]</th><th>@localizer["Actions"]</th><th>@localizer["Quantity"]</th><th>@localizer["CreatedOn"]</th><th>@localizer["Status"]</th></tr></thead><tbody>
-@foreach (var movement in Model.Movements) { <tr><td>@movement.PartId</td><td>@localizer["PartMovement" + (WorkOrderPartMovementKind)movement.Kind]</td><td>@movement.Quantity</td><td>@movement.CreatedOn.ToString("u")</td><td>@localizer[movement.Cancelled ? "StatusCancelled" : movement.InventoryOperationId != null && movement.InventoryTransactionId == null ? "InventoryWitnessPending" : "Done"]
-@if (!movement.Cancelled && movement.InventoryOperationId != null && movement.InventoryTransactionId == null) { <code>@movement.RequestId</code><a asp-controller="Inventory" asp-action="Index" asp-route-tab="History">@localizer["InventoryParts"]</a> }
-@if (d.CanContribute && !movement.Cancelled && movement.InventoryOperationId != null && movement.InventoryTransactionId == null) { <form class="work-order-form work-order-command" data-destination="Operations" method="post" asp-action="CancelPartMovement">@Html.AntiForgeryToken()<input type="hidden" name="id" value="@id"/><input type="hidden" name="movementId" value="@movement.Id"/><input type="hidden" name="revision" value="@d.Order.Revision"/><input class="form-control" name="reason" aria-label="@localizer["Reason"]" maxlength="4000" required/><button type="submit" class="btn btn-warning">@localizer["Cancel"]</button></form> }
-</td></tr> }
-</tbody></table>@if (Model.Movements.Count == 50) { <a asp-action="Operations" asp-route-id="@id" asp-route-movementAfterId="@Model.Movements.Last().Id">@localizer["Next"]</a> }
-</div></div></div></div>
 @section Scripts { @await Html.PartialAsync("_Scripts") }

--- a/Web/Resgrid.Web/Areas/User/Views/WorkOrders/Policy.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/WorkOrders/Policy.cshtml
@@ -1,25 +1,128 @@
 @model Resgrid.Web.Areas.User.Models.WorkOrders.WorkOrderPolicyView
 @using Resgrid.Model.WorkOrders
 @inject IStringLocalizer<Resgrid.Localization.Areas.User.WorkOrders.WorkOrders> localizer
-@{ ViewBag.Title = "Resgrid | " + localizer["OperationsPolicy"]; var p = Model.Input; }
-<div class="wrapper wrapper-content"><div class="ibox"><div class="ibox-content">
-<h2>@localizer["OperationsPolicy"]</h2><a asp-action="Index">@localizer["WorkOrders"]</a>
-@await Html.PartialAsync("_Protection")
-<div class="work-order-protected"><p>@localizer["PolicyHelp"]</p><div class="alert alert-danger work-order-error" hidden role="alert"></div>
-<form method="post" asp-action="SavePolicy" class="work-order-form work-order-command" data-destination="Policy">@Html.AntiForgeryToken()
-<input type="hidden" name="Revision" value="@p.Revision"/><fieldset disabled="@(!Model.CanWrite)">
-<legend>@localizer["SpendingApprovals"]</legend><label><input type="checkbox" name="ApprovalsEnabled" value="true" checked="@p.ApprovalsEnabled"/> @localizer["RequireSpendingApproval"]</label>
-<table class="table"><thead><tr><th>@localizer["Currency"]</th><th>@localizer["SpendingThreshold"]</th></tr></thead><tbody>
-@for (var i = 0; i < Math.Max(4, p.SpendingRules.Count + 1); i++) { var r = p.SpendingRules.ElementAtOrDefault(i); <tr><td><input name="SpendingRules[@i].Currency" value="@r?.Currency" class="form-control" maxlength="3" pattern="[A-Z]{3}" aria-label="@localizer["Currency"]"/></td><td><input name="SpendingRules[@i].Threshold" value="@((r?.Threshold ?? 0).ToString(System.Globalization.CultureInfo.InvariantCulture))" class="form-control" type="number" min="0" max="100000000" step="0.01" aria-label="@localizer["SpendingThreshold"]"/></td></tr> }
-</tbody></table>
-<h3>@localizer["BusinessCalendar"]</h3><p>@localizer["BusinessCalendarHelp"]</p>
-<label>@localizer["TimeZone"]<input name="Calendar.TimeZoneId" value="@p.Calendar.TimeZoneId" class="form-control" maxlength="100" required/></label>
-<fieldset><legend>@localizer["ServiceWeekdays"]</legend>@for (var d = 0; d < 7; d++) { var mask = 1 << d; <label><input type="checkbox" name="weekdays" value="@mask" checked="@((p.Calendar.Weekdays & mask) != 0)"/> @System.Globalization.CultureInfo.CurrentUICulture.DateTimeFormat.DayNames[d]</label> }</fieldset>
-<label>@localizer["ServiceStart"]<input name="businessStart" class="form-control" type="time" value="@(TimeOnly.FromTimeSpan(TimeSpan.FromMinutes(p.Calendar.StartMinute)).ToString("HH:mm"))" required/></label>
-<label>@localizer["ServiceEnd"]<input name="businessEnd" class="form-control" type="time" value="@(TimeOnly.FromTimeSpan(TimeSpan.FromMinutes(p.Calendar.EndMinute % 1440)).ToString("HH:mm"))" required/></label>
-<label for="holidays">@localizer["Holidays"]</label><textarea id="holidays" class="form-control" name="holidays" rows="5">@string.Join("\n", p.Calendar.Holidays)</textarea>
-<table class="table"><thead><tr><th>@localizer["Priority"]</th><th>@localizer["ResponseMinutes"]</th><th>@localizer["RepairMinutes"]</th></tr></thead><tbody>
-@for (var i = 0; i < 4; i++) { var r = p.Calendar.Targets.SingleOrDefault(t => (int)t.Priority == i); <tr><th>@localizer["Priority" + (WorkOrderPriority)i]<input type="hidden" name="Calendar.Targets[@i].Priority" value="@i"/></th><td><input name="Calendar.Targets[@i].ResponseMinutes" class="form-control" type="number" min="0" max="525600" value="@(r?.ResponseMinutes ?? 0)" aria-label="@localizer["ResponseMinutes"]"/></td><td><input name="Calendar.Targets[@i].RepairMinutes" class="form-control" type="number" min="0" max="525600" value="@(r?.RepairMinutes ?? 0)" aria-label="@localizer["RepairMinutes"]"/></td></tr> }
-</tbody></table><button type="submit" class="btn btn-primary">@localizer["Save"]</button></fieldset></form>
-</div></div></div></div>
+@{
+    ViewBag.Title = "Resgrid | " + localizer["OperationsPolicy"];
+    var p = Model.Input;
+    ViewData["Tab"] = "Policy";
+    ViewData["Title"] = localizer["OperationsPolicy"].Value;
+    ViewData["Subtitle"] = localizer["PolicyHelp"].Value;
+    ViewData["CanWrite"] = true;
+}
+
+@await Html.PartialAsync("_Shell")
+
+<div class="wrapper wrapper-content">
+    <div class="ibox float-e-margins">
+        <div class="ibox-title"><h5>@localizer["OperationsPolicy"]</h5></div>
+        <div class="ibox-content">
+            @await Html.PartialAsync("_Tabs")
+            @await Html.PartialAsync("_Protection")
+
+            <div class="alert alert-info"><i class="fa fa-info-circle"></i> @localizer["PolicyHelp"]</div>
+
+            <div class="work-order-protected">
+                <form method="post" asp-action="SavePolicy" class="work-order-form work-order-command" data-destination="Policy">
+                    @Html.AntiForgeryToken()
+                    <input type="hidden" name="Revision" value="@p.Revision" />
+                    <fieldset disabled="@(!Model.CanWrite)">
+
+                        <div class="panel panel-default">
+                            <div class="panel-heading">@localizer["SpendingApprovals"]</div>
+                            <div class="panel-body">
+                                <div class="checkbox"><label><input type="checkbox" name="ApprovalsEnabled" value="true" checked="@p.ApprovalsEnabled" /> @localizer["RequireSpendingApproval"]</label></div>
+                                <div class="table-responsive">
+                                    <table class="table rgw-table">
+                                        <thead><tr><th>@localizer["Currency"]</th><th>@localizer["SpendingThreshold"]</th></tr></thead>
+                                        <tbody>
+                                            @for (var i = 0; i < Math.Max(4, p.SpendingRules.Count + 1); i++)
+                                            {
+                                                var r = p.SpendingRules.ElementAtOrDefault(i);
+                                                <tr>
+                                                    <td><input name="SpendingRules[@i].Currency" value="@r?.Currency" class="form-control" maxlength="3" pattern="[A-Z]{3}" aria-label="@localizer["Currency"]" /></td>
+                                                    <td><input name="SpendingRules[@i].Threshold" value="@((r?.Threshold ?? 0).ToString(System.Globalization.CultureInfo.InvariantCulture))" class="form-control" type="number" min="0" max="100000000" step="0.01" aria-label="@localizer["SpendingThreshold"]" /></td>
+                                                </tr>
+                                            }
+                                        </tbody>
+                                    </table>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="panel panel-default">
+                            <div class="panel-heading">@localizer["BusinessCalendar"]</div>
+                            <div class="panel-body">
+                                <p class="text-muted">@localizer["BusinessCalendarHelp"]</p>
+                                <div class="rgw-grid">
+                                    <div class="form-group">
+                                        <label for="policy-timezone">@localizer["TimeZone"]</label>
+                                        <input id="policy-timezone" name="Calendar.TimeZoneId" value="@p.Calendar.TimeZoneId" class="form-control" maxlength="100" required />
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="policy-start">@localizer["ServiceStart"]</label>
+                                        <input id="policy-start" name="businessStart" class="form-control" type="time" value="@(TimeOnly.FromTimeSpan(TimeSpan.FromMinutes(p.Calendar.StartMinute)).ToString("HH:mm"))" required />
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="policy-end">@localizer["ServiceEnd"]</label>
+                                        <input id="policy-end" name="businessEnd" class="form-control" type="time" value="@(TimeOnly.FromTimeSpan(TimeSpan.FromMinutes(p.Calendar.EndMinute % 1440)).ToString("HH:mm"))" required />
+                                    </div>
+                                    <div class="form-group rgw-wide">
+                                        <label>@localizer["ServiceWeekdays"]</label>
+                                        <div>
+                                            @for (var d = 0; d < 7; d++)
+                                            {
+                                                var mask = 1 << d;
+                                                <label class="checkbox-inline">
+                                                    <input type="checkbox" name="weekdays" value="@mask" checked="@((p.Calendar.Weekdays & mask) != 0)" />
+                                                    @System.Globalization.CultureInfo.CurrentUICulture.DateTimeFormat.DayNames[d]
+                                                </label>
+                                            }
+                                        </div>
+                                    </div>
+                                    <div class="form-group rgw-wide">
+                                        <label for="holidays">@localizer["Holidays"]</label>
+                                        <textarea id="holidays" class="form-control" name="holidays" rows="5">@string.Join("\n", p.Calendar.Holidays)</textarea>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="panel panel-default">
+                            <div class="panel-heading">@localizer["ResponseDue"] / @localizer["RepairDue"]</div>
+                            <div class="table-responsive">
+                                <table class="table rgw-table">
+                                    <thead><tr><th>@localizer["Priority"]</th><th>@localizer["ResponseMinutes"]</th><th>@localizer["RepairMinutes"]</th></tr></thead>
+                                    <tbody>
+                                        @for (var i = 0; i < 4; i++)
+                                        {
+                                            var r = p.Calendar.Targets.SingleOrDefault(t => (int)t.Priority == i);
+                                            <tr>
+                                                <th>
+                                                    @localizer["Priority" + (WorkOrderPriority)i]
+                                                    <input type="hidden" name="Calendar.Targets[@i].Priority" value="@i" />
+                                                </th>
+                                                <td><input name="Calendar.Targets[@i].ResponseMinutes" class="form-control" type="number" min="0" max="525600" value="@(r?.ResponseMinutes ?? 0)" aria-label="@localizer["ResponseMinutes"]" /></td>
+                                                <td><input name="Calendar.Targets[@i].RepairMinutes" class="form-control" type="number" min="0" max="525600" value="@(r?.RepairMinutes ?? 0)" aria-label="@localizer["RepairMinutes"]" /></td>
+                                            </tr>
+                                        }
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+
+                        <div class="rgw-wizard-actions">
+                            <div class="rgw-wizard-spacer"></div>
+                            <a class="btn btn-white" asp-action="Index">@localizer["Cancel"]</a>
+                            <button type="submit" class="btn btn-primary">@localizer["Save"]</button>
+                        </div>
+                    </fieldset>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Styles {
+    <link rel="stylesheet" href="~/css/workspace.css" asp-append-version="true" />
+}
 @section Scripts { @await Html.PartialAsync("_Scripts") }

--- a/Web/Resgrid.Web/Areas/User/Views/WorkOrders/Recurrence.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/WorkOrders/Recurrence.cshtml
@@ -1,30 +1,198 @@
 @model Resgrid.Web.Areas.User.Models.WorkOrders.WorkOrderRecurrenceDetailView
 @using Newtonsoft.Json.Linq
 @inject IStringLocalizer<Resgrid.Localization.Areas.User.WorkOrders.WorkOrders> localizer
-@{ var row = Model.Detail.Schedule; var settings = Model.Detail.Settings; ViewBag.Title = "Resgrid | " + localizer["PreventiveMaintenance"]; }
-<div class="wrapper wrapper-content"><div class="ibox"><div class="ibox-content">
-@await Html.PartialAsync("_Protection")
-<div class="work-order-protected"><h2>@settings.Template.Content.Title</h2><p style="white-space:pre-wrap">@settings.Template.Content.Description</p>
-<p>@localizer["NextDue"]: @row.NextDueOn?.ToString("u") · @localizer[row.IsActive ? "Active" : "Paused"]</p>
-<p>@localizer["MeterBaseline"]: @row.MeterBaseline · @localizer["MeterValue"]: @row.LastMeterValue · @localizer["MeterEpoch"]: @row.MeterEpoch</p>
-<a class="btn btn-default" asp-action="Recurrences">@localizer["PreventiveMaintenance"]</a>
-@if (Model.CanWrite) { <a class="btn btn-default" asp-action="EditRecurrence" asp-route-id="@row.Id">@localizer["Edit"]</a> }
-@if (row.PendingWorkOrderId.HasValue) { <a class="btn btn-primary" asp-action="Detail" asp-route-id="@row.PendingWorkOrderId">@localizer["WorkOrders"]</a> }
-@if (Model.CanWrite && (row.MeterUnit != 0 || row.Condition != 0)) {
-<h3>@localizer["RecordReading"]</h3>
-<form class="work-order-form work-order-command" asp-action="Reading" method="post" data-destination="Recurrence">
-@Html.AntiForgeryToken()<input type="hidden" name="id" value="@row.Id"/><input type="hidden" name="Revision" value="@row.Revision"/><input type="hidden" name="RequestId" value="@Guid.NewGuid().ToString("D")"/>
-<label>@localizer["ObservedOn"] (UTC)<input name="ObservedOn" type="datetime-local" class="form-control" value="@DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm")" required/></label>
-@if (row.MeterUnit != 0) { <label>@localizer["MeterValue"]<input name="MeterValue" type="number" min="0" step="0.000001" class="form-control"/></label><label><input name="ResetMeter" type="checkbox" value="true"/> @localizer["ResetMeter"]</label> }
-@if (row.Condition != 0) { <label>@localizer["ConditionValue"] (@settings.ConditionUnit)<input name="ConditionValue" type="number" step="any" class="form-control"/></label> }
-<label>@localizer["ReadingSource"]<input name="Source" class="form-control" maxlength="1000" required/></label><label>@localizer["Reason"]<textarea name="Note" class="form-control" maxlength="4000"></textarea></label>
-<button type="submit" class="btn btn-primary">@localizer["RecordReading"]</button></form>
+@{
+    var row = Model.Detail.Schedule;
+    var settings = Model.Detail.Settings;
+    ViewBag.Title = "Resgrid | " + localizer["PreventiveMaintenance"];
+    ViewData["Tab"] = "Recurrences";
+    ViewData["Title"] = settings.Template.Content.Title;
+    ViewData["ParentText"] = localizer["PreventiveMaintenance"].Value;
+    ViewData["ParentAction"] = "Recurrences";
+    ViewData["CanWrite"] = Model.CanWrite;
+    var canRecord = Model.CanWrite && (row.MeterUnit != 0 || row.Condition != 0);
 }
-<h3>@localizer["Readings"]</h3><table class="table"><thead><tr><th>@localizer["ObservedOn"]</th><th>@localizer["MeterValue"]</th><th>@localizer["ConditionValue"]</th><th>@localizer["ReadingSource"]</th><th>@localizer["Note"]</th></tr></thead><tbody>
-@foreach (var reading in Model.Detail.Readings) { var c = JObject.Parse(reading.Content ?? "{}"); <tr><td>@reading.ObservedOn.ToString("u")</td><td>@c["MeterValue"]</td><td>@c["ConditionValue"]</td><td>@c["Source"]</td><td>@c["Note"]</td></tr> }
-</tbody></table>
-<h3>@localizer["Activity"]</h3><ol>@foreach (var change in Model.Detail.Changes) { var c = JObject.Parse(change.Content ?? "{}"); <li>@change.CreatedOn.ToString("u") · @localizer["MaintenanceChange" + change.ChangeType]<p>@c["Note"]</p><p>@change.OriginalDueOn?.ToString("u") → @change.RevisedDueOn?.ToString("u")</p></li> }</ol>
-@if (Model.Detail.HistoryPage > 0) { <a asp-action="Recurrence" asp-route-id="@row.Id" asp-route-historyPage="@(Model.Detail.HistoryPage - 1)">@localizer["Previous"]</a> }
-@if (Model.Detail.HasMoreHistory) { <a asp-action="Recurrence" asp-route-id="@row.Id" asp-route-historyPage="@(Model.Detail.HistoryPage + 1)">@localizer["Next"]</a> }
-</div></div></div></div>
+
+@await Html.PartialAsync("_Shell")
+
+<div class="wrapper wrapper-content">
+    <div class="ibox float-e-margins">
+        <div class="ibox-title"><h5>@settings.Template.Content.Title</h5></div>
+        <div class="ibox-content">
+            @await Html.PartialAsync("_Tabs")
+            @await Html.PartialAsync("_Protection")
+
+            <div class="work-order-protected">
+                <div class="rgw-toolbar">
+                    <a class="btn btn-default btn-sm" asp-action="Recurrences"><i class="fa fa-arrow-left"></i> @localizer["PreventiveMaintenance"]</a>
+                    <div class="rgw-toolbar-spacer"></div>
+                    @if (canRecord)
+                    {
+                        <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#recurrence-reading"><i class="fa fa-tachometer"></i> @localizer["RecordReading"]</button>
+                    }
+                    @if (Model.CanWrite)
+                    {
+                        <a class="btn btn-default" asp-action="EditRecurrence" asp-route-id="@row.Id"><i class="fa fa-pencil"></i> @localizer["Edit"]</a>
+                    }
+                    @if (row.PendingWorkOrderId.HasValue)
+                    {
+                        <a class="btn btn-default" asp-action="Detail" asp-route-id="@row.PendingWorkOrderId"><i class="fa fa-wrench"></i> @localizer["WorkOrders"]</a>
+                    }
+                </div>
+
+                <p class="text-muted">
+                    <span class="label @(row.IsActive ? "label-success" : "label-warning")">@localizer[row.IsActive ? "Active" : "Paused"]</span>
+                    @localizer["NextDue"]: @row.NextDueOn?.ToString("u")
+                </p>
+                @if (!string.IsNullOrEmpty(settings.Template.Content.Description))
+                {
+                    <p style="white-space:pre-wrap">@settings.Template.Content.Description</p>
+                }
+
+                <div class="row">
+                    <div class="col-lg-3 col-md-6">
+                        <div class="ibox"><div class="ibox-title"><h5>@localizer["MeterValue"]</h5></div>
+                            <div class="ibox-content"><h1 class="no-margins">@row.LastMeterValue</h1><small>@localizer["MeterBaseline"]: @row.MeterBaseline</small></div></div>
+                    </div>
+                    <div class="col-lg-3 col-md-6">
+                        <div class="ibox"><div class="ibox-title"><h5>@localizer["MeterEpoch"]</h5></div>
+                            <div class="ibox-content"><h1 class="no-margins">@row.MeterEpoch</h1></div></div>
+                    </div>
+                </div>
+
+                <div class="hr-line-dashed"></div>
+
+                <h3>@localizer["Readings"]</h3>
+                @if (Model.Detail.Readings.Count == 0)
+                {
+                    <p class="text-muted">@localizer["None"]</p>
+                }
+                else
+                {
+                    <div class="table-responsive">
+                        <table class="table table-striped rgw-table">
+                            <thead><tr><th>@localizer["ObservedOn"]</th><th class="text-right">@localizer["MeterValue"]</th><th class="text-right">@localizer["ConditionValue"]</th><th>@localizer["ReadingSource"]</th><th>@localizer["Note"]</th></tr></thead>
+                            <tbody>
+                                @foreach (var reading in Model.Detail.Readings)
+                                {
+                                    var content = JObject.Parse(reading.Content ?? "{}");
+                                    <tr>
+                                        <td>@reading.ObservedOn.ToString("u")</td>
+                                        <td class="text-right">@content["MeterValue"]</td>
+                                        <td class="text-right">@content["ConditionValue"]</td>
+                                        <td>@content["Source"]</td>
+                                        <td>@content["Note"]</td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    </div>
+                }
+
+                <h3>@localizer["Activity"]</h3>
+                @if (Model.Detail.Changes.Count == 0)
+                {
+                    <p class="text-muted">@localizer["None"]</p>
+                }
+                else
+                {
+                    <div class="table-responsive">
+                        <table class="table table-striped rgw-table">
+                            <thead><tr><th>@localizer["CreatedOn"]</th><th>@localizer["Activity"]</th><th>@localizer["Note"]</th><th>@localizer["RevisedDue"]</th></tr></thead>
+                            <tbody>
+                                @foreach (var change in Model.Detail.Changes)
+                                {
+                                    var content = JObject.Parse(change.Content ?? "{}");
+                                    <tr>
+                                        <td>@change.CreatedOn.ToString("u")</td>
+                                        <td><span class="label">@localizer["MaintenanceChange" + change.ChangeType]</span></td>
+                                        <td>@content["Note"]</td>
+                                        <td>@change.OriginalDueOn?.ToString("u") → @change.RevisedDueOn?.ToString("u")</td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    </div>
+                }
+
+                @if (Model.Detail.HistoryPage > 0 || Model.Detail.HasMoreHistory)
+                {
+                    <div class="rgw-pager">
+                        @if (Model.Detail.HistoryPage > 0)
+                        {
+                            <a class="btn btn-default btn-sm" asp-action="Recurrence" asp-route-id="@row.Id" asp-route-historyPage="@(Model.Detail.HistoryPage - 1)"><i class="fa fa-chevron-left"></i> @localizer["Previous"]</a>
+                        }
+                        @if (Model.Detail.HasMoreHistory)
+                        {
+                            <a class="btn btn-default btn-sm" asp-action="Recurrence" asp-route-id="@row.Id" asp-route-historyPage="@(Model.Detail.HistoryPage + 1)">@localizer["Next"] <i class="fa fa-chevron-right"></i></a>
+                        }
+                        <span class="text-muted">@(Model.Detail.HistoryPage + 1)</span>
+                    </div>
+                }
+
+                @if (canRecord)
+                {
+                    <div class="modal fade rgw-modal" id="recurrence-reading" tabindex="-1" role="dialog" aria-labelledby="recurrence-reading-title">
+                        <div class="modal-dialog" role="document">
+                            <div class="modal-content">
+                                <div class="modal-header">
+                                    <button type="button" class="close" data-dismiss="modal" aria-label="@localizer["Close"]"><span aria-hidden="true">&times;</span></button>
+                                    <h4 class="modal-title" id="recurrence-reading-title">@localizer["RecordReading"]</h4>
+                                </div>
+                                <div class="modal-body">
+                                    <form class="work-order-form work-order-command" asp-action="Reading" method="post" data-destination="Recurrence">
+                                        @Html.AntiForgeryToken()
+                                        <input type="hidden" name="id" value="@row.Id" />
+                                        <input type="hidden" name="Revision" value="@row.Revision" />
+                                        <input type="hidden" name="RequestId" value="@Guid.NewGuid().ToString("D")" />
+                                        <div class="rgw-grid">
+                                            <div class="form-group">
+                                                <label for="reading-observed">@localizer["ObservedOn"] (UTC)</label>
+                                                <input id="reading-observed" name="ObservedOn" type="datetime-local" class="form-control" value="@DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm")" required />
+                                            </div>
+                                            @if (row.MeterUnit != 0)
+                                            {
+                                                <div class="form-group">
+                                                    <label for="reading-meter">@localizer["MeterValue"]</label>
+                                                    <input id="reading-meter" name="MeterValue" type="number" min="0" step="0.000001" class="form-control" />
+                                                </div>
+                                                <div class="form-group">
+                                                    <div class="checkbox"><label><input name="ResetMeter" type="checkbox" value="true" /> @localizer["ResetMeter"]</label></div>
+                                                </div>
+                                            }
+                                            @if (row.Condition != 0)
+                                            {
+                                                <div class="form-group">
+                                                    <label for="reading-condition">@localizer["ConditionValue"] (@settings.ConditionUnit)</label>
+                                                    <input id="reading-condition" name="ConditionValue" type="number" step="any" class="form-control" />
+                                                </div>
+                                            }
+                                            <div class="form-group">
+                                                <label for="reading-source">@localizer["ReadingSource"]</label>
+                                                <input id="reading-source" name="Source" class="form-control" maxlength="1000" required />
+                                            </div>
+                                            <div class="form-group rgw-wide">
+                                                <label for="reading-note">@localizer["Reason"]</label>
+                                                <textarea id="reading-note" name="Note" class="form-control" rows="2" maxlength="4000"></textarea>
+                                            </div>
+                                        </div>
+                                        <div class="rgw-wizard-actions">
+                                            <div class="rgw-wizard-spacer"></div>
+                                            <button type="button" class="btn btn-white" data-dismiss="modal">@localizer["Close"]</button>
+                                            <button type="submit" class="btn btn-primary">@localizer["RecordReading"]</button>
+                                        </div>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                }
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Styles {
+    <link rel="stylesheet" href="~/css/workspace.css" asp-append-version="true" />
+}
 @section Scripts { @await Html.PartialAsync("_Scripts") }

--- a/Web/Resgrid.Web/Areas/User/Views/WorkOrders/Recurrences.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/WorkOrders/Recurrences.cshtml
@@ -1,17 +1,87 @@
 @model Resgrid.Web.Areas.User.Models.WorkOrders.WorkOrderRecurrencePageView
 @using Resgrid.Model.WorkOrders
 @inject IStringLocalizer<Resgrid.Localization.Areas.User.WorkOrders.WorkOrders> localizer
-@{ ViewBag.Title = "Resgrid | " + localizer["PreventiveMaintenance"]; }
-<div class="wrapper wrapper-content"><div class="ibox"><div class="ibox-content">
-<h2>@localizer["PreventiveMaintenance"]</h2>
-@await Html.PartialAsync("_Protection")
-<div class="work-order-protected">
-<a class="btn btn-default" asp-action="Index">@localizer["WorkOrders"]</a>
-@if (Model.CanWrite) { <a class="btn btn-primary" asp-action="NewRecurrence">@localizer["NewRecurrence"]</a> }
-<table class="table"><thead><tr><th>@localizer["Title"]</th><th>@localizer["NextDue"]</th><th>@localizer["Active"]</th><th>@localizer["Actions"]</th></tr></thead><tbody>
-@foreach (var entry in Model.Rows.Take(50)) { <tr><td><a asp-action="Recurrence" asp-route-id="@entry.Schedule.Id">@entry.Settings.Template.Content.Title</a></td><td>@entry.Schedule.NextDueOn?.ToString("u")</td><td>@localizer[entry.Schedule.IsActive ? "Active" : "Paused"]</td><td>@if (entry.Schedule.PendingWorkOrderId.HasValue) { <a asp-action="Detail" asp-route-id="@entry.Schedule.PendingWorkOrderId">@localizer["WorkOrders"]</a> }</td></tr> }
-</tbody></table>
-@if (Model.Page > 0) { <a class="btn btn-default" asp-action="Recurrences" asp-route-page="@(Model.Page - 1)">@localizer["Previous"]</a> }
-@if (Model.Rows.Count > 50) { <a class="btn btn-default" asp-action="Recurrences" asp-route-page="@(Model.Page + 1)">@localizer["Next"]</a> }
-</div></div></div></div>
+@{
+    ViewBag.Title = "Resgrid | " + localizer["PreventiveMaintenance"];
+    ViewData["Tab"] = "Recurrences";
+    ViewData["Title"] = localizer["PreventiveMaintenance"].Value;
+    ViewData["Subtitle"] = localizer["RecurrenceHelp"].Value;
+    ViewData["CanWrite"] = Model.CanWrite;
+}
+
+@await Html.PartialAsync("_Shell")
+
+<div class="wrapper wrapper-content">
+    <div class="ibox float-e-margins">
+        <div class="ibox-title"><h5>@localizer["PreventiveMaintenance"]</h5></div>
+        <div class="ibox-content">
+            @await Html.PartialAsync("_Tabs")
+            @await Html.PartialAsync("_Protection")
+
+            <div class="alert alert-info"><i class="fa fa-info-circle"></i> @localizer["RecurrenceHelp"]</div>
+
+            <div class="work-order-protected">
+                @if (Model.CanWrite)
+                {
+                    <div class="rgw-toolbar">
+                        <div class="rgw-toolbar-spacer"></div>
+                        <a class="btn btn-primary" asp-action="NewRecurrence"><i class="fa fa-plus"></i> @localizer["NewRecurrence"]</a>
+                    </div>
+                }
+
+                @if (Model.Rows.Count == 0)
+                {
+                    <div class="text-center m-t-lg m-b-lg">
+                        <i class="fa fa-refresh fa-3x text-muted"></i>
+                        <h4 class="m-t-sm">@localizer["NoWorkOrders"]</h4>
+                        <p class="text-muted">@localizer["NoRowsHelp"]</p>
+                    </div>
+                }
+                else
+                {
+                    <div class="table-responsive">
+                        <table class="table table-striped rgw-table">
+                            <thead><tr><th>@localizer["Title"]</th><th>@localizer["NextDue"]</th><th>@localizer["Status"]</th><th class="rgw-row-actions">@localizer["Actions"]</th></tr></thead>
+                            <tbody>
+                                @foreach (var entry in Model.Rows.Take(50))
+                                {
+                                    <tr>
+                                        <td><a asp-action="Recurrence" asp-route-id="@entry.Schedule.Id">@entry.Settings.Template.Content.Title</a></td>
+                                        <td>@entry.Schedule.NextDueOn?.ToString("u")</td>
+                                        <td><span class="label @(entry.Schedule.IsActive ? "label-success" : "label-warning")">@localizer[entry.Schedule.IsActive ? "Active" : "Paused"]</span></td>
+                                        <td class="rgw-row-actions">
+                                            @if (entry.Schedule.PendingWorkOrderId.HasValue)
+                                            {
+                                                <a class="btn btn-xs btn-info" asp-action="Detail" asp-route-id="@entry.Schedule.PendingWorkOrderId">@localizer["WorkOrders"]</a>
+                                            }
+                                        </td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    </div>
+                }
+
+                @if (Model.Page > 0 || Model.Rows.Count > 50)
+                {
+                    <div class="rgw-pager">
+                        @if (Model.Page > 0)
+                        {
+                            <a class="btn btn-default btn-sm" asp-action="Recurrences" asp-route-page="@(Model.Page - 1)"><i class="fa fa-chevron-left"></i> @localizer["Previous"]</a>
+                        }
+                        @if (Model.Rows.Count > 50)
+                        {
+                            <a class="btn btn-default btn-sm" asp-action="Recurrences" asp-route-page="@(Model.Page + 1)">@localizer["Next"] <i class="fa fa-chevron-right"></i></a>
+                        }
+                        <span class="text-muted">@(Model.Page + 1)</span>
+                    </div>
+                }
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Styles {
+    <link rel="stylesheet" href="~/css/workspace.css" asp-append-version="true" />
+}
 @section Scripts { @await Html.PartialAsync("_Scripts") }

--- a/Web/Resgrid.Web/Areas/User/Views/WorkOrders/Reports.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/WorkOrders/Reports.cshtml
@@ -1,44 +1,236 @@
 @model Resgrid.Web.Areas.User.Models.WorkOrders.WorkOrderReportView
 @using Resgrid.Model.WorkOrders
 @inject IStringLocalizer<Resgrid.Localization.Areas.User.WorkOrders.WorkOrders> localizer
-@{ var destination = Model.Stats == null ? "History" : "Reports"; ViewBag.Title = "Resgrid | " + localizer[Model.Stats == null ? "ServiceHistory" : "MaintenanceReports"]; }
-<div class="wrapper wrapper-content"><div class="ibox"><div class="ibox-content">
-<h2>@localizer[Model.Stats == null ? "ServiceHistory" : "MaintenanceReports"]</h2>
-<a asp-action="Index">@localizer["WorkOrders"]</a> | <a asp-action="Reports">@localizer["MaintenanceReports"]</a> | <a asp-action="History" asp-route-unitId="@Model.Query.UnitId" asp-route-assetId="@Model.Query.AssetId">@localizer["ServiceHistory"]</a>
-@await Html.PartialAsync("_Protection")
-<p>@localizer[Model.Stats == null ? "HistoryMethod" : "ReportMethod"]</p>
-<form method="post" asp-action="Reopen" class="form-inline work-order-form work-order-protected">
-@Html.AntiForgeryToken()<input type="hidden" name="destination" value="@destination"/>
-<label>@localizer["ReportFrom"] <input class="form-control" type="datetime-local" name="FromUtc" value="@Model.Query.FromUtc?.ToString("yyyy-MM-ddTHH:mm:ss")" step="1"/></label>
-<label>@localizer["ReportUntil"] <input class="form-control" type="datetime-local" name="UntilUtc" value="@Model.Query.UntilUtc?.ToString("yyyy-MM-ddTHH:mm:ss")" step="1"/></label>
-<label>@localizer["Status"] <select class="form-control" name="Status"><option value="">@localizer["All"]</option>@foreach (var s in Enum.GetValues<WorkOrderStatus>()) { <option value="@((int)s)" selected="@(Model.Query.Status == s)">@localizer["Status" + s]</option> }</select></label>
-<label>@localizer["Priority"] <select class="form-control" name="Priority"><option value="">@localizer["All"]</option>@foreach (var p in Enum.GetValues<WorkOrderPriority>()) { <option value="@((int)p)" selected="@(Model.Query.Priority == p)">@localizer["Priority" + p]</option> }</select></label>
-<label>@localizer["Unit"] <select class="form-control" name="UnitId"><option value="">@localizer["All"]</option>@foreach (var u in Model.Choices.Units) { <option value="@u.Id" selected="@(Model.Query.UnitId?.ToString() == u.Id)">@u.Name</option> }</select></label>
-<label>@localizer["Group"] <select class="form-control" name="GroupId"><option value="">@localizer["All"]</option>@foreach (var g in Model.Choices.Groups) { <option value="@g.Id" selected="@(Model.Query.GroupId?.ToString() == g.Id)">@g.Name</option> }</select></label>
-<label>@localizer["Asset"] <input class="form-control" name="AssetId" value="@Model.Query.AssetId" list="report-assets"/></label>
-<datalist id="report-assets">@foreach (var a in Model.Choices.Assets) { <option value="@a.Id">@a.Name</option> }</datalist>
-<button type="submit" class="btn btn-default">@localizer["Filter"]</button>
-</form>
-<div class="work-order-protected">
-@if (Model.Stats != null) {
-var stats = Model.Stats;
-<p>@localizer["AsOfUtc"]: @stats.AsOfUtc.ToString("u")</p>
-<table class="table"><tbody>
-<tr><th>@localizer["TotalOrders"]</th><td>@stats.Total</td><th>@localizer["OpenOrders"]</th><td>@stats.Open</td><th>@localizer["OverdueOrders"]</th><td>@stats.Overdue</td></tr>
-<tr><th>@localizer["MeanRepairHours"]</th><td>@(stats.MeanTimeToRepairHours?.ToString("0.##") ?? "—")</td><th>@localizer["RepairSamples"]</th><td>@stats.RepairSamples</td><th>@localizer["MissingRepairTimes"]</th><td>@stats.MissingRepairTimes</td></tr>
-<tr><th>@localizer["ActiveRepairHours"]</th><td>@stats.ActiveRepairHours.ToString("0.##")</td><th>@localizer["WaitingHours"]</th><td>@stats.WaitingHours.ToString("0.##")</td><th>@localizer["DowntimeHours"]</th><td>@stats.DowntimeHours.ToString("0.##")</td></tr>
-<tr><th>@localizer["PreventiveCompliance"]</th><td>@(stats.PreventiveCompliancePercent?.ToString("0.##") ?? "—")%</td><th>@localizer["PreventiveOnTime"]</th><td>@stats.PreventiveOnTime / @stats.PreventiveDue</td><th>@localizer["RepeatedFailures"]</th><td>@stats.RepeatedFailures</td></tr>
-<tr><th>@localizer["MissingTimeHistory"]</th><td>@stats.MissingTimeHistory</td><th>@localizer["ResponseSlaBreaches"]</th><td>@stats.ResponseSlaBreaches</td><th>@localizer["RepairSlaBreaches"]</th><td>@stats.RepairSlaBreaches</td></tr>
-</tbody></table><p>@localizer["OperationsAnalyticsHelp"]</p>
-<table class="table"><caption>@localizer["OpenByPriority"]</caption><tbody>@foreach (var p in Enum.GetValues<WorkOrderPriority>()) { <tr><th>@localizer["Priority" + p]</th><td>@stats.OpenByPriority[(int)p]</td></tr> }</tbody></table>
-<table class="table"><caption>@localizer["OpenByAge"]</caption><tbody>@for (var i = 0; i < 4; i++) { <tr><th>@localizer["AgeBucket" + i]</th><td>@stats.OpenByAge[i]</td></tr> }</tbody></table>
-@await Html.PartialAsync("_ReportCosts", stats.Costs)
+@{
+    var isHistory = Model.Stats == null;
+    var destination = isHistory ? "History" : "Reports";
+    var heading = localizer[isHistory ? "ServiceHistory" : "MaintenanceReports"].Value;
+    ViewBag.Title = "Resgrid | " + heading;
+    ViewData["Tab"] = destination;
+    ViewData["Title"] = heading;
+    ViewData["Subtitle"] = localizer[isHistory ? "HistoryMethod" : "ReportMethod"].Value;
 }
-<form class="work-order-form" method="post" asp-action="ExportCsv">@Html.AntiForgeryToken()@await Html.PartialAsync("_ReportFields", Model.Query)<button class="btn btn-default" type="submit">@localizer["ExportCsv"]</button></form>
-<table class="table table-striped"><caption>@localizer["ServiceHistory"]</caption><thead><tr><th>@localizer["Number"]</th><th>@localizer["Title"]</th><th>@localizer["Status"]</th><th>@localizer["Priority"]</th><th>@localizer["CreatedOn"]</th><th>@localizer["RepairHours"]</th><th>@localizer["ActiveRepairHours"]</th><th>@localizer["WaitingHours"]</th><th>@localizer["DowntimeHours"]</th><th>@localizer["Costs"]</th></tr></thead><tbody>
-@foreach (var entry in Model.History.Items) { <tr><td>@entry.Order.Number</td><td><a asp-action="Detail" asp-route-id="@entry.Order.Id">@entry.Order.Title</a></td><td>@localizer["Status" + entry.Order.Status]</td><td>@localizer["Priority" + entry.Order.Priority]</td><td>@entry.Order.CreatedOn.ToString("u")</td><td>@(entry.RepairHours?.ToString("0.##") ?? "—")</td><td>@(entry.ActiveRepairHours?.ToString("0.##") ?? "—")</td><td>@(entry.WaitingHours?.ToString("0.##") ?? "—")</td><td>@entry.DowntimeHours.ToString("0.##")</td><td>@await Html.PartialAsync("_ReportCosts", entry.Costs)</td></tr> }
-</tbody></table>
-@if (Model.History.Items.Count == 0) { <p>@localizer["NoWorkOrders"]</p> }
-@if (Model.History.NextAfterId.HasValue) { <a asp-action="@destination" asp-route-afterId="@Model.History.NextAfterId" asp-route-fromUtc="@Model.Query.FromUtc?.ToString("O")" asp-route-untilUtc="@Model.Query.UntilUtc?.ToString("O")" asp-route-status="@Model.Query.Status" asp-route-priority="@Model.Query.Priority" asp-route-unitId="@Model.Query.UnitId" asp-route-groupId="@Model.Query.GroupId" asp-route-assetId="@Model.Query.AssetId">@localizer["Next"]</a> }
-</div></div></div></div>
+
+@await Html.PartialAsync("_Shell")
+
+<div class="wrapper wrapper-content">
+    <div class="ibox float-e-margins">
+        <div class="ibox-title"><h5>@heading</h5></div>
+        <div class="ibox-content">
+            @await Html.PartialAsync("_Tabs")
+            @await Html.PartialAsync("_Protection")
+
+            <div class="alert alert-info"><i class="fa fa-info-circle"></i> @localizer[isHistory ? "HistoryMethod" : "ReportMethod"]</div>
+
+            <div class="rgw-filter">
+                <form method="post" asp-action="Reopen" class="work-order-form work-order-protected">
+                    @Html.AntiForgeryToken()
+                    <input type="hidden" name="destination" value="@destination" />
+                    <div class="rgw-grid">
+                        <div class="form-group">
+                            <label for="report-from">@localizer["ReportFrom"]</label>
+                            <input class="form-control" id="report-from" type="datetime-local" name="FromUtc" value="@Model.Query.FromUtc?.ToString("yyyy-MM-ddTHH:mm:ss")" step="1" />
+                        </div>
+                        <div class="form-group">
+                            <label for="report-until">@localizer["ReportUntil"]</label>
+                            <input class="form-control" id="report-until" type="datetime-local" name="UntilUtc" value="@Model.Query.UntilUtc?.ToString("yyyy-MM-ddTHH:mm:ss")" step="1" />
+                        </div>
+                        <div class="form-group">
+                            <label for="report-status">@localizer["Status"]</label>
+                            <select class="form-control" id="report-status" name="Status">
+                                <option value="">@localizer["All"]</option>
+                                @foreach (var s in Enum.GetValues<WorkOrderStatus>())
+                                {
+                                    <option value="@((int)s)" selected="@(Model.Query.Status == s)">@localizer["Status" + s]</option>
+                                }
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label for="report-priority">@localizer["Priority"]</label>
+                            <select class="form-control" id="report-priority" name="Priority">
+                                <option value="">@localizer["All"]</option>
+                                @foreach (var p in Enum.GetValues<WorkOrderPriority>())
+                                {
+                                    <option value="@((int)p)" selected="@(Model.Query.Priority == p)">@localizer["Priority" + p]</option>
+                                }
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label for="report-unit">@localizer["Unit"]</label>
+                            <select class="form-control" id="report-unit" name="UnitId">
+                                <option value="">@localizer["All"]</option>
+                                @foreach (var u in Model.Choices.Units)
+                                {
+                                    <option value="@u.Id" selected="@(Model.Query.UnitId?.ToString() == u.Id)">@u.Name</option>
+                                }
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label for="report-group">@localizer["Group"]</label>
+                            <select class="form-control" id="report-group" name="GroupId">
+                                <option value="">@localizer["All"]</option>
+                                @foreach (var g in Model.Choices.Groups)
+                                {
+                                    <option value="@g.Id" selected="@(Model.Query.GroupId?.ToString() == g.Id)">@g.Name</option>
+                                }
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label for="report-asset">@localizer["Asset"]</label>
+                            <input class="form-control" id="report-asset" name="AssetId" value="@Model.Query.AssetId" list="report-assets" />
+                            <datalist id="report-assets">
+                                @foreach (var a in Model.Choices.Assets)
+                                {
+                                    <option value="@a.Id">@a.Name</option>
+                                }
+                            </datalist>
+                        </div>
+                    </div>
+                    <div class="rgw-filter-actions">
+                        <button type="submit" class="btn btn-primary"><i class="fa fa-filter"></i> @localizer["Filter"]</button>
+                    </div>
+                </form>
+            </div>
+
+            <div class="work-order-protected">
+                @if (Model.Stats != null)
+                {
+                    var stats = Model.Stats;
+                    <div class="row">
+                        <div class="col-lg-3 col-md-6">
+                            <div class="ibox"><div class="ibox-title"><h5>@localizer["TotalOrders"]</h5></div>
+                                <div class="ibox-content"><h1 class="no-margins">@stats.Total</h1><small>@localizer["AsOfUtc"]: @stats.AsOfUtc.ToString("u")</small></div></div>
+                        </div>
+                        <div class="col-lg-3 col-md-6">
+                            <div class="ibox"><div class="ibox-title"><h5>@localizer["OpenOrders"]</h5></div>
+                                <div class="ibox-content"><h1 class="no-margins">@stats.Open</h1></div></div>
+                        </div>
+                        <div class="col-lg-3 col-md-6">
+                            <div class="ibox"><div class="ibox-title"><h5>@localizer["OverdueOrders"]</h5></div>
+                                <div class="ibox-content"><h1 class="no-margins @(stats.Overdue > 0 ? "text-danger" : string.Empty)">@stats.Overdue</h1></div></div>
+                        </div>
+                        <div class="col-lg-3 col-md-6">
+                            <div class="ibox"><div class="ibox-title"><h5>@localizer["PreventiveCompliance"]</h5></div>
+                                <div class="ibox-content"><h1 class="no-margins">@(stats.PreventiveCompliancePercent?.ToString("0.##") ?? "—")%</h1><small>@localizer["PreventiveOnTime"]: @stats.PreventiveOnTime / @stats.PreventiveDue</small></div></div>
+                        </div>
+                    </div>
+
+                    <div class="alert alert-info"><i class="fa fa-info-circle"></i> @localizer["OperationsAnalyticsHelp"]</div>
+
+                    <div class="table-responsive">
+                        <table class="table table-striped rgw-table">
+                            <tbody>
+                                <tr><th>@localizer["MeanRepairHours"]</th><td class="text-right">@(stats.MeanTimeToRepairHours?.ToString("0.##") ?? "—")</td><th>@localizer["RepairSamples"]</th><td class="text-right">@stats.RepairSamples</td><th>@localizer["MissingRepairTimes"]</th><td class="text-right">@stats.MissingRepairTimes</td></tr>
+                                <tr><th>@localizer["ActiveRepairHours"]</th><td class="text-right">@stats.ActiveRepairHours.ToString("0.##")</td><th>@localizer["WaitingHours"]</th><td class="text-right">@stats.WaitingHours.ToString("0.##")</td><th>@localizer["DowntimeHours"]</th><td class="text-right">@stats.DowntimeHours.ToString("0.##")</td></tr>
+                                <tr><th>@localizer["RepeatedFailures"]</th><td class="text-right">@stats.RepeatedFailures</td><th>@localizer["ResponseSlaBreaches"]</th><td class="text-right">@stats.ResponseSlaBreaches</td><th>@localizer["RepairSlaBreaches"]</th><td class="text-right">@stats.RepairSlaBreaches</td></tr>
+                                <tr><th>@localizer["MissingTimeHistory"]</th><td class="text-right">@stats.MissingTimeHistory</td><th></th><td></td><th></th><td></td></tr>
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <div class="row">
+                        <div class="col-md-6">
+                            <div class="panel panel-default">
+                                <div class="panel-heading">@localizer["OpenByPriority"]</div>
+                                <table class="table rgw-table">
+                                    <tbody>
+                                        @foreach (var p in Enum.GetValues<WorkOrderPriority>())
+                                        {
+                                            <tr><th>@localizer["Priority" + p]</th><td class="text-right">@stats.OpenByPriority[(int)p]</td></tr>
+                                        }
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                        <div class="col-md-6">
+                            <div class="panel panel-default">
+                                <div class="panel-heading">@localizer["OpenByAge"]</div>
+                                <table class="table rgw-table">
+                                    <tbody>
+                                        @for (var i = 0; i < 4; i++)
+                                        {
+                                            <tr><th>@localizer["AgeBucket" + i]</th><td class="text-right">@stats.OpenByAge[i]</td></tr>
+                                        }
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="panel panel-default">
+                        <div class="panel-heading">@localizer["Costs"]</div>
+                        @await Html.PartialAsync("_ReportCosts", stats.Costs)
+                    </div>
+                }
+
+                <div class="rgw-toolbar">
+                    <h3 class="m-t-none m-b-none">@localizer["ServiceHistory"]</h3>
+                    <div class="rgw-toolbar-spacer"></div>
+                    <form class="work-order-form" method="post" asp-action="ExportCsv">
+                        @Html.AntiForgeryToken()
+                        @await Html.PartialAsync("_ReportFields", Model.Query)
+                        <button class="btn btn-default btn-sm" type="submit"><i class="fa fa-download"></i> @localizer["ExportCsv"]</button>
+                    </form>
+                </div>
+
+                @if (Model.History.Items.Count == 0)
+                {
+                    <div class="text-center m-t-lg m-b-lg">
+                        <i class="fa fa-history fa-3x text-muted"></i>
+                        <h4 class="m-t-sm">@localizer["NoWorkOrders"]</h4>
+                    </div>
+                }
+                else
+                {
+                    <div class="table-responsive">
+                        <table class="table table-striped rgw-table">
+                            <thead>
+                                <tr>
+                                    <th>@localizer["Number"]</th>
+                                    <th>@localizer["Title"]</th>
+                                    <th>@localizer["Status"]</th>
+                                    <th>@localizer["Priority"]</th>
+                                    <th>@localizer["CreatedOn"]</th>
+                                    <th class="text-right">@localizer["RepairHours"]</th>
+                                    <th class="text-right">@localizer["ActiveRepairHours"]</th>
+                                    <th class="text-right">@localizer["WaitingHours"]</th>
+                                    <th class="text-right">@localizer["DowntimeHours"]</th>
+                                    <th>@localizer["Costs"]</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach (var entry in Model.History.Items)
+                                {
+                                    <tr>
+                                        <td>@entry.Order.Number</td>
+                                        <td><a asp-action="Detail" asp-route-id="@entry.Order.Id">@entry.Order.Title</a></td>
+                                        <td><span class="label">@localizer["Status" + entry.Order.Status]</span></td>
+                                        <td><span class="label">@localizer["Priority" + entry.Order.Priority]</span></td>
+                                        <td>@entry.Order.CreatedOn.ToString("u")</td>
+                                        <td class="text-right">@(entry.RepairHours?.ToString("0.##") ?? "—")</td>
+                                        <td class="text-right">@(entry.ActiveRepairHours?.ToString("0.##") ?? "—")</td>
+                                        <td class="text-right">@(entry.WaitingHours?.ToString("0.##") ?? "—")</td>
+                                        <td class="text-right">@entry.DowntimeHours.ToString("0.##")</td>
+                                        <td>@await Html.PartialAsync("_ReportCosts", entry.Costs)</td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    </div>
+                }
+
+                @if (Model.History.NextAfterId.HasValue)
+                {
+                    <div class="rgw-pager">
+                        <a class="btn btn-default btn-sm" asp-action="@destination" asp-route-afterId="@Model.History.NextAfterId" asp-route-fromUtc="@Model.Query.FromUtc?.ToString("O")" asp-route-untilUtc="@Model.Query.UntilUtc?.ToString("O")" asp-route-status="@Model.Query.Status" asp-route-priority="@Model.Query.Priority" asp-route-unitId="@Model.Query.UnitId" asp-route-groupId="@Model.Query.GroupId" asp-route-assetId="@Model.Query.AssetId">@localizer["Next"] <i class="fa fa-chevron-right"></i></a>
+                    </div>
+                }
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Styles {
+    <link rel="stylesheet" href="~/css/workspace.css" asp-append-version="true" />
+}
 @section Scripts { @await Html.PartialAsync("_Scripts") }

--- a/Web/Resgrid.Web/Areas/User/Views/WorkOrders/_Maintenance.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/WorkOrders/_Maintenance.cshtml
@@ -1,35 +1,210 @@
 @model Resgrid.Web.Areas.User.Models.WorkOrders.WorkOrderDetailView
 @using Resgrid.Model.WorkOrders
 @inject IStringLocalizer<Resgrid.Localization.Areas.User.WorkOrders.WorkOrders> localizer
-@{ var d = Model.Detail; var id = d.Order.Id; }
-@if (d.SourceChecklistCompletionId != null) { <p><a asp-controller="Checklists" asp-action="Run" asp-route-id="@d.SourceChecklistCompletionId">@localizer["SourceChecklist"]</a></p> }
-@if (d.RecurrenceId != null) { <p><a asp-action="Recurrence" asp-route-id="@d.RecurrenceId">@localizer["PreventiveMaintenance"]</a></p> }
-@if (d.OriginalDueOn.HasValue) { <p>@localizer["OriginalDue"]: @d.OriginalDueOn.Value.ToString("u")</p> }
-<h3>@localizer["SafetyHolds"]</h3><p>@localizer["HoldReleaseHelp"]</p>
-<table class="table"><thead><tr><th>@localizer["Target"]</th><th>@localizer["Reason"]</th><th>@localizer["Status"]</th><th>@localizer["Actions"]</th></tr></thead><tbody>
-@foreach (var entry in Model.Holds) {
-    var h = entry.Hold;
-    <tr><td>@localizer[h.UnitId.HasValue ? "Unit" : "Asset"]: @(h.UnitId?.ToString() ?? h.AssetId)</td><td>@entry.Content.Reason</td>
-    <td>@localizer[h.ReleasedOn.HasValue ? "ActivitySafetyReleased" : "ActivitySafetyHold"] @if (h.ReleasedOn.HasValue) { <span>· @localizer[h.StateRestored ? "StateRestored" : "StatePreserved"]</span><p>@entry.Content.ReleaseEvidence</p><p>@entry.Content.Qualification</p> }</td>
-    <td>@if (!h.ReleasedOn.HasValue && Model.CanRelease) {
-        <form class="work-order-form work-order-command" asp-action="ReleaseHold" method="post">@Html.AntiForgeryToken()
-        <input type="hidden" name="id" value="@id"/><input type="hidden" name="holdId" value="@h.Id"/><input type="hidden" name="Revision" value="@h.Revision"/>
-        <label>@localizer["ReleaseEvidence"]<textarea name="Evidence" class="form-control" maxlength="4000" required></textarea></label>
-        <label>@localizer["ReleaseQualification"]<input name="Qualification" class="form-control" maxlength="2000" required/></label>
-        <label><input type="checkbox" name="RestoreState" value="true"/> @localizer["RestoreIfUnchanged"]</label>
-        <button type="submit" class="btn btn-warning">@localizer["ReleaseHold"]</button></form>
-    }</td></tr>
+@*
+    Safety holds, plus the two commands that change what a work order is holding: placing a
+    hold and deferring the due date. Both ask for a reason, so both open in a dialog.
+*@
+@{
+    var d = Model.Detail;
+    var id = d.Order.Id;
+    var isOpen = d.Order.Status is not (WorkOrderStatus.Closed or WorkOrderStatus.Cancelled or WorkOrderStatus.Rejected or WorkOrderStatus.Duplicate);
+    var canHold = d.CanManage && isOpen && (d.Order.UnitId.HasValue || d.Order.AssetId != null);
+    var canDefer = d.CanManage && isOpen && d.Order.Status != WorkOrderStatus.Completed;
 }
-</tbody></table>
-@if (d.CanManage && d.Order.Status is not (WorkOrderStatus.Closed or WorkOrderStatus.Cancelled or WorkOrderStatus.Rejected or WorkOrderStatus.Duplicate)) {
-@if (d.Order.UnitId.HasValue || d.Order.AssetId != null) {
-<form class="work-order-form work-order-command" asp-action="Hold" method="post">@Html.AntiForgeryToken()<input type="hidden" name="id" value="@id"/><input type="hidden" name="Revision" value="@d.Order.Revision"/>
-@if (d.Order.UnitId.HasValue) { <label><input type="checkbox" name="Unit" value="true"/> @localizer["HoldUnit"]</label> }
-@if (d.Order.AssetId != null) { <label><input type="checkbox" name="Asset" value="true"/> @localizer["HoldAsset"]</label> }
-<label>@localizer["Reason"]<textarea name="Reason" class="form-control" maxlength="4000" required></textarea></label><button type="submit" class="btn btn-warning">@localizer["AddHold"]</button></form>
+
+@if (d.SourceChecklistCompletionId != null || d.RecurrenceId != null || d.OriginalDueOn.HasValue)
+{
+    <p class="text-muted">
+        @if (d.SourceChecklistCompletionId != null)
+        {
+            <a asp-controller="Checklists" asp-action="Run" asp-route-id="@d.SourceChecklistCompletionId">@localizer["SourceChecklist"]</a>
+        }
+        @if (d.RecurrenceId != null)
+        {
+            <a asp-action="Recurrence" asp-route-id="@d.RecurrenceId">@localizer["PreventiveMaintenance"]</a>
+        }
+        @if (d.OriginalDueOn.HasValue)
+        {
+            <span>@localizer["OriginalDue"]: @d.OriginalDueOn.Value.ToString("u")</span>
+        }
+    </p>
 }
-@if (d.Order.Status != WorkOrderStatus.Completed) {
-<form class="work-order-form work-order-command" asp-action="Defer" method="post">@Html.AntiForgeryToken()<input type="hidden" name="id" value="@id"/><input type="hidden" name="Revision" value="@d.Order.Revision"/>
-<label>@localizer["RevisedDue"] (UTC)<input type="datetime-local" name="DueOn" class="form-control" required/></label><label>@localizer["DeferralReason"]<textarea name="Reason" class="form-control" maxlength="4000" required></textarea></label><button type="submit" class="btn btn-default">@localizer["ApproveDeferral"]</button></form>
+
+<div class="rgw-toolbar">
+    <h3 class="m-t-none m-b-none">@localizer["SafetyHolds"]</h3>
+    <div class="rgw-toolbar-spacer"></div>
+    @if (canHold)
+    {
+        <button type="button" class="btn btn-warning btn-sm" data-toggle="modal" data-target="#work-order-hold"><i class="fa fa-hand-paper-o"></i> @localizer["AddHold"]</button>
+    }
+    @if (canDefer)
+    {
+        <button type="button" class="btn btn-default btn-sm" data-toggle="modal" data-target="#work-order-defer"><i class="fa fa-clock-o"></i> @localizer["ApproveDeferral"]</button>
+    }
+</div>
+
+<div class="alert alert-info"><i class="fa fa-info-circle"></i> @localizer["HoldReleaseHelp"]</div>
+
+@if (Model.Holds.Count == 0)
+{
+    <p class="text-muted">@localizer["None"]</p>
 }
+else
+{
+    <div class="table-responsive">
+        <table class="table table-striped rgw-table">
+            <thead><tr><th>@localizer["Target"]</th><th>@localizer["Reason"]</th><th>@localizer["Status"]</th><th class="rgw-row-actions">@localizer["Actions"]</th></tr></thead>
+            <tbody>
+                @foreach (var entry in Model.Holds)
+                {
+                    var h = entry.Hold;
+                    <tr>
+                        <td>@localizer[h.UnitId.HasValue ? "Unit" : "Asset"]: @(h.UnitId?.ToString() ?? h.AssetId)</td>
+                        <td>@entry.Content.Reason</td>
+                        <td>
+                            <span class="label @(h.ReleasedOn.HasValue ? "label-success" : "label-danger")">@localizer[h.ReleasedOn.HasValue ? "ActivitySafetyReleased" : "ActivitySafetyHold"]</span>
+                            @if (h.ReleasedOn.HasValue)
+                            {
+                                <span class="label">@localizer[h.StateRestored ? "StateRestored" : "StatePreserved"]</span>
+                                <small class="text-muted rgw-sub">@entry.Content.ReleaseEvidence</small>
+                                <small class="text-muted rgw-sub">@entry.Content.Qualification</small>
+                            }
+                        </td>
+                        <td class="rgw-row-actions">
+                            @if (!h.ReleasedOn.HasValue && Model.CanRelease)
+                            {
+                                <button type="button" class="btn btn-xs btn-warning" data-toggle="modal" data-target="#hold-release-@h.Id">@localizer["ReleaseHold"]</button>
+                            }
+                        </td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </div>
+}
+
+@if (Model.CanRelease)
+{
+    foreach (var entry in Model.Holds.Where(x => !x.Hold.ReleasedOn.HasValue))
+    {
+        var h = entry.Hold;
+        <div class="modal fade rgw-modal" id="hold-release-@h.Id" tabindex="-1" role="dialog" aria-labelledby="hold-release-@(h.Id)-title">
+            <div class="modal-dialog" role="document">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <button type="button" class="close" data-dismiss="modal" aria-label="@localizer["Cancel"]"><span aria-hidden="true">&times;</span></button>
+                        <h4 class="modal-title" id="hold-release-@(h.Id)-title">@localizer["ReleaseHold"]</h4>
+                    </div>
+                    <div class="modal-body">
+                        <p class="text-muted">@localizer["IndependentReleaseRequired"]</p>
+                        <form class="work-order-form work-order-command" asp-action="ReleaseHold" method="post">
+                            @Html.AntiForgeryToken()
+                            <input type="hidden" name="id" value="@id" />
+                            <input type="hidden" name="holdId" value="@h.Id" />
+                            <input type="hidden" name="Revision" value="@h.Revision" />
+                            <div class="rgw-grid">
+                                <div class="form-group rgw-wide">
+                                    <label for="hold-evidence-@h.Id">@localizer["ReleaseEvidence"]</label>
+                                    <textarea id="hold-evidence-@h.Id" name="Evidence" class="form-control" rows="3" maxlength="4000" required></textarea>
+                                </div>
+                                <div class="form-group rgw-wide">
+                                    <label for="hold-qualification-@h.Id">@localizer["ReleaseQualification"]</label>
+                                    <input id="hold-qualification-@h.Id" name="Qualification" class="form-control" maxlength="2000" required />
+                                </div>
+                                <div class="form-group rgw-wide">
+                                    <div class="checkbox"><label><input type="checkbox" name="RestoreState" value="true" /> @localizer["RestoreIfUnchanged"]</label></div>
+                                </div>
+                            </div>
+                            <div class="rgw-wizard-actions">
+                                <div class="rgw-wizard-spacer"></div>
+                                <button type="button" class="btn btn-white" data-dismiss="modal">@localizer["Cancel"]</button>
+                                <button type="submit" class="btn btn-warning">@localizer["ReleaseHold"]</button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    }
+}
+
+@if (canHold)
+{
+    <div class="modal fade rgw-modal" id="work-order-hold" tabindex="-1" role="dialog" aria-labelledby="work-order-hold-title">
+        <div class="modal-dialog" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-label="@localizer["Cancel"]"><span aria-hidden="true">&times;</span></button>
+                    <h4 class="modal-title" id="work-order-hold-title">@localizer["AddHold"]</h4>
+                </div>
+                <div class="modal-body">
+                    <form class="work-order-form work-order-command" asp-action="Hold" method="post">
+                        @Html.AntiForgeryToken()
+                        <input type="hidden" name="id" value="@id" />
+                        <input type="hidden" name="Revision" value="@d.Order.Revision" />
+                        <div class="rgw-grid">
+                            @if (d.Order.UnitId.HasValue)
+                            {
+                                <div class="form-group">
+                                    <div class="checkbox"><label><input type="checkbox" name="Unit" value="true" /> @localizer["HoldUnit"]</label></div>
+                                </div>
+                            }
+                            @if (d.Order.AssetId != null)
+                            {
+                                <div class="form-group">
+                                    <div class="checkbox"><label><input type="checkbox" name="Asset" value="true" /> @localizer["HoldAsset"]</label></div>
+                                </div>
+                            }
+                            <div class="form-group rgw-wide">
+                                <label for="hold-reason">@localizer["Reason"]</label>
+                                <textarea id="hold-reason" name="Reason" class="form-control" rows="3" maxlength="4000" required></textarea>
+                            </div>
+                        </div>
+                        <div class="rgw-wizard-actions">
+                            <div class="rgw-wizard-spacer"></div>
+                            <button type="button" class="btn btn-white" data-dismiss="modal">@localizer["Cancel"]</button>
+                            <button type="submit" class="btn btn-warning">@localizer["AddHold"]</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+}
+
+@if (canDefer)
+{
+    <div class="modal fade rgw-modal" id="work-order-defer" tabindex="-1" role="dialog" aria-labelledby="work-order-defer-title">
+        <div class="modal-dialog" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-label="@localizer["Cancel"]"><span aria-hidden="true">&times;</span></button>
+                    <h4 class="modal-title" id="work-order-defer-title">@localizer["ApproveDeferral"]</h4>
+                </div>
+                <div class="modal-body">
+                    <form class="work-order-form work-order-command" asp-action="Defer" method="post">
+                        @Html.AntiForgeryToken()
+                        <input type="hidden" name="id" value="@id" />
+                        <input type="hidden" name="Revision" value="@d.Order.Revision" />
+                        <div class="rgw-grid">
+                            <div class="form-group">
+                                <label for="defer-due">@localizer["RevisedDue"] (UTC)</label>
+                                <input id="defer-due" type="datetime-local" name="DueOn" class="form-control" required />
+                            </div>
+                            <div class="form-group rgw-wide">
+                                <label for="defer-reason">@localizer["DeferralReason"]</label>
+                                <textarea id="defer-reason" name="Reason" class="form-control" rows="3" maxlength="4000" required></textarea>
+                            </div>
+                        </div>
+                        <div class="rgw-wizard-actions">
+                            <div class="rgw-wizard-spacer"></div>
+                            <button type="button" class="btn btn-white" data-dismiss="modal">@localizer["Cancel"]</button>
+                            <button type="submit" class="btn btn-primary">@localizer["ApproveDeferral"]</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
 }

--- a/Web/Resgrid.Web/Areas/User/Views/WorkOrders/_OrderFields.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/WorkOrders/_OrderFields.cshtml
@@ -48,7 +48,7 @@
         {
             <div class="form-group">
                 <label asp-for="DueOn">@localizer["DueOn"] (UTC)</label>
-                <input asp-for="DueOn" class="form-control" type="datetime-local" asp-format="{0:yyyy-MM-ddTHH:mm:ss.fffffff}" step="any" readonly="@(Model.Revision > 0)" />
+                <input asp-for="DueOn" class="form-control" type="datetime-local" asp-format="{0:yyyy-MM-ddTHH:mm:ss.fffffff}" readonly="@(Model.Revision > 0)" />
                 <span class="help-block">@localizer["HelpFieldDueOn"]</span>
             </div>
         }

--- a/Web/Resgrid.Web/Areas/User/Views/WorkOrders/_OrderFields.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/WorkOrders/_OrderFields.cshtml
@@ -1,32 +1,185 @@
 @model Resgrid.Model.WorkOrders.WorkOrderInput
 @using Resgrid.Model.WorkOrders
 @inject IStringLocalizer<Resgrid.Localization.Areas.User.WorkOrders.WorkOrders> localizer
-@{ var choices = (WorkOrderChoices)ViewData["Choices"]; var canManage = (bool)ViewData["CanManage"]; }
-<div class="form-group"><label asp-for="Content.Title">@localizer["Title"]</label><input asp-for="Content.Title" class="form-control" required maxlength="200"/></div>
-<div class="form-group"><label asp-for="Content.Description">@localizer["Description"]</label><textarea asp-for="Content.Description" class="form-control" rows="5" maxlength="20000"></textarea></div>
-<div class="row">
-@if (ViewData["Recurrence"] as bool? != true) { <div class="col-sm-4 form-group"><label asp-for="Type">@localizer["Type"]</label><select asp-for="Type" class="form-control">@foreach (var t in Enum.GetValues<WorkOrderType>()) { <option value="@((int)t)">@localizer["Type" + t]</option> }</select></div> }
-<div class="col-sm-4 form-group"><label asp-for="Priority">@localizer["Priority"]</label><select asp-for="Priority" class="form-control">@foreach (var p in Enum.GetValues<WorkOrderPriority>()) { <option value="@((int)p)">@localizer["Priority" + p]</option> }</select></div>
-@if (ViewData["Recurrence"] as bool? != true) { <div class="col-sm-4 form-group"><label asp-for="DueOn">@localizer["DueOn"] (UTC)</label><input asp-for="DueOn" class="form-control" type="datetime-local" asp-format="{0:yyyy-MM-ddTHH:mm:ss.fffffff}" step="any" readonly="@(Model.Revision > 0)"/></div> }</div>
-<div class="row"><div class="col-sm-4 form-group"><label asp-for="TargetUnitId">@localizer["Unit"]</label><select asp-for="TargetUnitId" class="form-control"><option value="">@localizer["None"]</option>@foreach (var x in choices.Units) { <option value="@x.Id">@x.Name</option> }</select></div>
-<div class="col-sm-4 form-group"><label asp-for="TargetGroupId">@localizer["Group"]</label><select asp-for="TargetGroupId" class="form-control"><option value="">@localizer["None"]</option>@foreach (var x in choices.Groups) { <option value="@x.Id">@x.Name</option> }</select></div>
-@if (choices.Assets.Count > 0) { <div class="col-sm-4 form-group"><label asp-for="InventoryAssetId">@localizer["Asset"]</label><select asp-for="InventoryAssetId" class="form-control"><option value="">@localizer["None"]</option>@foreach (var x in choices.Assets) { <option value="@x.Id">@x.Name</option> }</select></div> }
-else { <input asp-for="InventoryAssetId" type="hidden"/> }</div>
-<div class="form-group"><label asp-for="Content.LocationText">@localizer["LocationText"]</label><input asp-for="Content.LocationText" class="form-control" maxlength="1000"/></div>
-<div class="row"><div class="col-sm-4 form-group"><label asp-for="Content.Currency">@localizer["Currency"]</label><input asp-for="Content.Currency" class="form-control" maxlength="3" pattern="[A-Z]{3}" required/></div>
-<div class="col-sm-4 form-group"><label asp-for="Content.EstimatedCost">@localizer["EstimatedCost"]</label><input asp-for="Content.EstimatedCost" type="number" min="0" step="0.01" class="form-control"/></div>
-@if (canManage) { <div class="col-sm-4 form-group"><label asp-for="Content.ApprovedCost">@localizer["ApprovedCost"]</label><input asp-for="Content.ApprovedCost" type="number" min="0" step="0.01" class="form-control"/></div> }</div>
-<div class="form-group"><label asp-for="Content.CostCenter">@localizer["CostCenter"]</label><input asp-for="Content.CostCenter" class="form-control" maxlength="200"/></div>
-<div class="form-group"><label asp-for="Content.VendorDetails">@localizer["VendorDetails"]</label><textarea asp-for="Content.VendorDetails" class="form-control" maxlength="4000"></textarea></div>
-<div class="form-group"><label asp-for="Content.WarrantyReference">@localizer["WarrantyReference"]</label><input asp-for="Content.WarrantyReference" class="form-control" maxlength="4000"/></div>
-<label><input asp-for="Content.SafetyCritical"/> @localizer["SafetyCritical"]</label>
-<label><input asp-for="Content.HazardousWork"/> @localizer["HazardousWork"]</label>
-<p>@localizer["SafetyNotice"]</p>
-<div class="form-group"><label asp-for="Content.ProcedureReference">@localizer["ProcedureReference"]</label><input asp-for="Content.ProcedureReference" class="form-control" maxlength="4000"/></div>
-<div class="form-group"><label asp-for="Content.ProcedureVersion">@localizer["ProcedureVersion"]</label><input asp-for="Content.ProcedureVersion" class="form-control" maxlength="4000"/></div>
-<div class="form-group"><label asp-for="Content.PermitReference">@localizer["PermitReference"]</label><input asp-for="Content.PermitReference" class="form-control" maxlength="4000"/></div>
-<div class="form-group"><label asp-for="Content.IsolationReference">@localizer["IsolationReference"]</label><input asp-for="Content.IsolationReference" class="form-control" maxlength="4000"/></div>
-<div class="form-group"><label asp-for="Content.QualifiedPersonnel">@localizer["QualifiedPersonnel"]</label><input asp-for="Content.QualifiedPersonnel" class="form-control" maxlength="4000"/></div>
-<h3>@localizer["TaskSteps"]</h3><div id="work-order-steps">
-@for (var i = 0; i < Model.Content.Steps.Count; i++) { <div class="form-group"><input asp-for="Content.Steps[i].Text" class="form-control" maxlength="1000" required/><input asp-for="Content.Steps[i].Completed" type="hidden"/></div> }
-</div><button type="button" class="btn btn-default" id="work-order-add-step">@localizer["AddStep"]</button>
+@*
+    The order fields, emitted as wizard steps. Both hosts (a work order and a preventive
+    maintenance template) are rgw-wizard forms, so these steps come first and the host adds
+    its own steps and the review after them. Field names are unchanged.
+*@
+@{
+    var choices = (WorkOrderChoices)ViewData["Choices"];
+    var canManage = (bool)ViewData["CanManage"];
+    var isRecurrence = ViewData["Recurrence"] as bool? == true;
+}
+<div class="rgw-step" data-title="@localizer["StepOrderDescribe"]">
+    <h4>@localizer["StepOrderDescribe"]</h4>
+    <p class="text-muted">@localizer["StepOrderDescribeHint"]</p>
+    <div class="rgw-grid">
+        <div class="form-group rgw-wide">
+            <label asp-for="Content.Title">@localizer["Title"]</label>
+            <input asp-for="Content.Title" class="form-control" required maxlength="200" />
+        </div>
+        <div class="form-group rgw-wide">
+            <label asp-for="Content.Description">@localizer["Description"]</label>
+            <textarea asp-for="Content.Description" class="form-control" rows="5" maxlength="20000"></textarea>
+        </div>
+        @if (!isRecurrence)
+        {
+            <div class="form-group">
+                <label asp-for="Type">@localizer["Type"]</label>
+                <select asp-for="Type" class="form-control">
+                    @foreach (var t in Enum.GetValues<WorkOrderType>())
+                    {
+                        <option value="@((int)t)">@localizer["Type" + t]</option>
+                    }
+                </select>
+            </div>
+        }
+        <div class="form-group">
+            <label asp-for="Priority">@localizer["Priority"]</label>
+            <select asp-for="Priority" class="form-control">
+                @foreach (var p in Enum.GetValues<WorkOrderPriority>())
+                {
+                    <option value="@((int)p)">@localizer["Priority" + p]</option>
+                }
+            </select>
+        </div>
+        @if (!isRecurrence)
+        {
+            <div class="form-group">
+                <label asp-for="DueOn">@localizer["DueOn"] (UTC)</label>
+                <input asp-for="DueOn" class="form-control" type="datetime-local" asp-format="{0:yyyy-MM-ddTHH:mm:ss.fffffff}" step="any" readonly="@(Model.Revision > 0)" />
+                <span class="help-block">@localizer["HelpFieldDueOn"]</span>
+            </div>
+        }
+    </div>
+</div>
+
+<div class="rgw-step" data-title="@localizer["StepOrderTarget"]">
+    <h4>@localizer["StepOrderTarget"]</h4>
+    <p class="text-muted">@localizer["StepOrderTargetHint"]</p>
+    <div class="rgw-grid">
+        <div class="form-group">
+            <label asp-for="TargetUnitId">@localizer["Unit"]</label>
+            <select asp-for="TargetUnitId" class="form-control">
+                <option value="">@localizer["None"]</option>
+                @foreach (var x in choices.Units)
+                {
+                    <option value="@x.Id">@x.Name</option>
+                }
+            </select>
+        </div>
+        <div class="form-group">
+            <label asp-for="TargetGroupId">@localizer["Group"]</label>
+            <select asp-for="TargetGroupId" class="form-control">
+                <option value="">@localizer["None"]</option>
+                @foreach (var x in choices.Groups)
+                {
+                    <option value="@x.Id">@x.Name</option>
+                }
+            </select>
+        </div>
+        @if (choices.Assets.Count > 0)
+        {
+            <div class="form-group">
+                <label asp-for="InventoryAssetId">@localizer["Asset"]</label>
+                <select asp-for="InventoryAssetId" class="form-control">
+                    <option value="">@localizer["None"]</option>
+                    @foreach (var x in choices.Assets)
+                    {
+                        <option value="@x.Id">@x.Name</option>
+                    }
+                </select>
+            </div>
+        }
+        else
+        {
+            <input asp-for="InventoryAssetId" type="hidden" />
+        }
+        <div class="form-group rgw-wide">
+            <label asp-for="Content.LocationText">@localizer["LocationText"]</label>
+            <input asp-for="Content.LocationText" class="form-control" maxlength="1000" />
+        </div>
+    </div>
+</div>
+
+<div class="rgw-step" data-title="@localizer["StepOrderCost"]">
+    <h4>@localizer["StepOrderCost"]</h4>
+    <p class="text-muted">@localizer["StepOrderCostHint"]</p>
+    <div class="rgw-grid">
+        <div class="form-group">
+            <label asp-for="Content.Currency">@localizer["Currency"]</label>
+            <input asp-for="Content.Currency" class="form-control" maxlength="3" pattern="[A-Z]{3}" required />
+        </div>
+        <div class="form-group">
+            <label asp-for="Content.EstimatedCost">@localizer["EstimatedCost"]</label>
+            <input asp-for="Content.EstimatedCost" type="number" min="0" step="0.01" class="form-control" />
+        </div>
+        @if (canManage)
+        {
+            <div class="form-group">
+                <label asp-for="Content.ApprovedCost">@localizer["ApprovedCost"]</label>
+                <input asp-for="Content.ApprovedCost" type="number" min="0" step="0.01" class="form-control" />
+            </div>
+        }
+        <div class="form-group">
+            <label asp-for="Content.CostCenter">@localizer["CostCenter"]</label>
+            <input asp-for="Content.CostCenter" class="form-control" maxlength="200" />
+        </div>
+        <div class="form-group rgw-wide">
+            <label asp-for="Content.VendorDetails">@localizer["VendorDetails"]</label>
+            <textarea asp-for="Content.VendorDetails" class="form-control" rows="3" maxlength="4000"></textarea>
+        </div>
+        <div class="form-group rgw-wide">
+            <label asp-for="Content.WarrantyReference">@localizer["WarrantyReference"]</label>
+            <input asp-for="Content.WarrantyReference" class="form-control" maxlength="4000" />
+        </div>
+    </div>
+</div>
+
+<div class="rgw-step" data-title="@localizer["StepOrderSafety"]">
+    <h4>@localizer["StepOrderSafety"]</h4>
+    <p class="text-muted">@localizer["StepOrderSafetyHint"]</p>
+    <div class="alert alert-warning"><i class="fa fa-exclamation-triangle"></i> @localizer["SafetyNotice"]</div>
+    <div class="rgw-grid">
+        <div class="form-group">
+            <div class="checkbox"><label><input asp-for="Content.SafetyCritical" /> @localizer["SafetyCritical"]</label></div>
+        </div>
+        <div class="form-group">
+            <div class="checkbox"><label><input asp-for="Content.HazardousWork" /> @localizer["HazardousWork"]</label></div>
+        </div>
+        <div class="form-group">
+            <label asp-for="Content.ProcedureReference">@localizer["ProcedureReference"]</label>
+            <input asp-for="Content.ProcedureReference" class="form-control" maxlength="4000" />
+        </div>
+        <div class="form-group">
+            <label asp-for="Content.ProcedureVersion">@localizer["ProcedureVersion"]</label>
+            <input asp-for="Content.ProcedureVersion" class="form-control" maxlength="4000" />
+        </div>
+        <div class="form-group">
+            <label asp-for="Content.PermitReference">@localizer["PermitReference"]</label>
+            <input asp-for="Content.PermitReference" class="form-control" maxlength="4000" />
+        </div>
+        <div class="form-group">
+            <label asp-for="Content.IsolationReference">@localizer["IsolationReference"]</label>
+            <input asp-for="Content.IsolationReference" class="form-control" maxlength="4000" />
+        </div>
+        <div class="form-group rgw-wide">
+            <label asp-for="Content.QualifiedPersonnel">@localizer["QualifiedPersonnel"]</label>
+            <input asp-for="Content.QualifiedPersonnel" class="form-control" maxlength="4000" />
+        </div>
+    </div>
+
+    <h4>@localizer["TaskSteps"]</h4>
+    <p class="text-muted">@localizer["HelpFieldSteps"]</p>
+    <div id="work-order-steps">
+        @for (var i = 0; i < Model.Content.Steps.Count; i++)
+        {
+            <div class="form-group">
+                <input asp-for="Content.Steps[i].Text" class="form-control" maxlength="1000" required />
+                <input asp-for="Content.Steps[i].Completed" type="hidden" />
+            </div>
+        }
+    </div>
+    <button type="button" class="btn btn-default" id="work-order-add-step"><i class="fa fa-plus"></i> @localizer["AddStep"]</button>
+</div>

--- a/Web/Resgrid.Web/Areas/User/Views/WorkOrders/_PartInventory.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/WorkOrders/_PartInventory.cshtml
@@ -1,9 +1,23 @@
 @inject IStringLocalizer<Resgrid.Localization.Areas.User.WorkOrders.WorkOrders> localizer
+@*
+    Inventory-backed part picker. The classes and data attributes are the contract
+    work-orders.js loads the choices with; only the layout around them changed.
+*@
 <fieldset class="work-order-inventory" data-url="@Url.Action("PartChoices")">
-<legend>@localizer["InventoryParts"]</legend><p>@localizer["InventoryPartsHelp"]</p>
-<input type="hidden" name="RequestId" value="@Guid.NewGuid().ToString("D")"/>
-@foreach (var choice in new[] { ("item", "InventoryItemId", "InventoryItem"), ("location", "InventoryLocationId", "InventoryLocation"), ("lot", "InventoryLotId", "InventoryLot"), ("asset", "InventoryAssetId", "Asset") }) {
-<label>@localizer[choice.Item3]<select class="form-control inventory-part-choice" name="@choice.Item2" data-kind="@choice.Item1"><option value="">@localizer["None"]</option></select></label>
-<button type="button" class="btn btn-default inventory-part-load" data-kind="@choice.Item1" data-page="0">@localizer["LoadChoices"]</button>
-}
+    <legend>@localizer["InventoryParts"]</legend>
+    <p class="text-muted">@localizer["InventoryPartsHelp"]</p>
+    <input type="hidden" name="RequestId" value="@Guid.NewGuid().ToString("D")" />
+    <div class="rgw-grid">
+        @foreach (var choice in new[] { ("item", "InventoryItemId", "InventoryItem"), ("location", "InventoryLocationId", "InventoryLocation"), ("lot", "InventoryLotId", "InventoryLot"), ("asset", "InventoryAssetId", "Asset") })
+        {
+            var identity = "part-choice-" + choice.Item1;
+            <div class="form-group">
+                <label for="@identity">@localizer[choice.Item3]</label>
+                <select class="form-control inventory-part-choice" id="@identity" name="@choice.Item2" data-kind="@choice.Item1">
+                    <option value="">@localizer["None"]</option>
+                </select>
+                <button type="button" class="btn btn-default btn-xs m-t-xs inventory-part-load" data-kind="@choice.Item1" data-page="0">@localizer["LoadChoices"]</button>
+            </div>
+        }
+    </div>
 </fieldset>

--- a/Web/Resgrid.Web/Areas/User/Views/WorkOrders/_Shell.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/WorkOrders/_Shell.cshtml
@@ -1,0 +1,42 @@
+@inject IStringLocalizer<Resgrid.Localization.Areas.User.WorkOrders.WorkOrders> localizer
+@*
+    Page heading shared by every work order screen, laid out the same way as the rest of the
+    application: title and breadcrumb on the left.
+
+    ViewData["Title"]      heading and last breadcrumb crumb (defaults to the module name)
+    ViewData["Subtitle"]   optional one line description under the breadcrumb
+    ViewData["ParentText"] optional intermediate crumb, with ParentAction and ParentId
+*@
+@{
+    var title = (string)ViewData["Title"] ?? localizer["WorkOrders"].Value;
+    var subtitle = (string)ViewData["Subtitle"];
+    var parentText = (string)ViewData["ParentText"];
+    var parentAction = (string)ViewData["ParentAction"];
+    var parentId = (string)ViewData["ParentId"];
+    var isRoot = string.Equals(title, localizer["WorkOrders"].Value, StringComparison.Ordinal);
+}
+<div class="row wrapper border-bottom white-bg page-heading">
+    <div class="col-sm-12">
+        <h2>@title</h2>
+        <ol class="breadcrumb">
+            <li><a asp-controller="Home" asp-action="Dashboard" asp-route-area="User">@commonLocalizer["HomeModule"]</a></li>
+            @if (isRoot)
+            {
+                <li class="active"><strong>@localizer["WorkOrders"]</strong></li>
+            }
+            else
+            {
+                <li><a asp-controller="WorkOrders" asp-action="Index" asp-route-area="User">@localizer["WorkOrders"]</a></li>
+                @if (!string.IsNullOrEmpty(parentText))
+                {
+                    <li><a asp-controller="WorkOrders" asp-action="@parentAction" asp-route-id="@parentId" asp-route-area="User">@parentText</a></li>
+                }
+                <li class="active"><strong>@title</strong></li>
+            }
+        </ol>
+        @if (!string.IsNullOrEmpty(subtitle))
+        {
+            <small class="text-muted">@subtitle</small>
+        }
+    </div>
+</div>

--- a/Web/Resgrid.Web/Areas/User/Views/WorkOrders/_Tabs.cshtml
+++ b/Web/Resgrid.Web/Areas/User/Views/WorkOrders/_Tabs.cshtml
@@ -1,0 +1,34 @@
+@inject IStringLocalizer<Resgrid.Localization.Areas.User.WorkOrders.WorkOrders> localizer
+@*
+    The module's tab strip. ViewData["Tab"] names the tab that owns the current screen, so a
+    sub page (an order, a recurrence, the operations desk) still shows where in the module it
+    sits. ViewData["CanWrite"] hides the two tabs a read only member cannot use.
+*@
+@{
+    var current = (string)ViewData["Tab"] ?? "Index";
+    var canWrite = ViewData["CanWrite"] as bool? ?? false;
+    var tabs = new List<(string Action, string Icon, string Label)>
+    {
+        ("Index", "fa-wrench", localizer["WorkOrders"].Value),
+        ("Recurrences", "fa-refresh", localizer["PreventiveMaintenance"].Value),
+        ("Reports", "fa-bar-chart", localizer["MaintenanceReports"].Value),
+        ("History", "fa-history", localizer["ServiceHistory"].Value)
+    };
+
+    if (canWrite)
+    {
+        tabs.Add(("Bulk", "fa-list-ol", localizer["BulkOperations"].Value));
+        tabs.Add(("Policy", "fa-sliders", localizer["OperationsPolicy"].Value));
+    }
+}
+<ul class="nav nav-tabs" role="tablist">
+    @foreach (var tab in tabs)
+    {
+        <li class="nav-item @(current == tab.Action ? "active" : null)">
+            <a asp-controller="WorkOrders" asp-action="@tab.Action" asp-route-area="User"
+               aria-current="@(current == tab.Action ? "page" : "false")">
+                <i class="fa @tab.Icon"></i> @tab.Label
+            </a>
+        </li>
+    }
+</ul>

--- a/Web/Resgrid.Web/Helpers/HtmlHelpers.cs
+++ b/Web/Resgrid.Web/Helpers/HtmlHelpers.cs
@@ -24,6 +24,22 @@ namespace Resgrid.Web
 					cssClass : String.Empty;
 		}
 
+		/// <summary>
+		/// True when the request is being handled by any of the named controllers. Used by the
+		/// sidebar to light up and expand a group when the user is on one of its pages, including
+		/// the pages inside the group that have no link of their own.
+		/// </summary>
+		public static bool IsController(this IHtmlHelper html, params string[] controllers)
+		{
+			string currentController = (string)html.ViewContext.RouteData.Values["controller"];
+
+			foreach (var controller in controllers)
+				if (String.Equals(controller, currentController, StringComparison.OrdinalIgnoreCase))
+					return true;
+
+			return false;
+		}
+
 		public static string PageClass(this IHtmlHelper htmlHelper)
 		{
 			string currentAction = (string) htmlHelper.ViewContext.RouteData.Values["action"];

--- a/Web/Resgrid.Web/Helpers/WorkspaceFormHelper.cs
+++ b/Web/Resgrid.Web/Helpers/WorkspaceFormHelper.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.Extensions.Localization;
+
+namespace Resgrid.Web.Helpers
+{
+	/// <summary>
+	/// Field builders for the module workspace screens (inventory, checklists). Every control
+	/// comes out as a labelled Bootstrap form group with optional help text underneath, so the
+	/// screens stay consistent with each other and the views stay readable.
+	/// </summary>
+	public static class WorkspaceFormHelper
+	{
+		private const string EmptyChoice = "—";
+
+		/// <summary>Renders one labelled field: input, select, textarea or checkbox.</summary>
+		/// <param name="localizer">Inventory string localizer; <paramref name="label"/> and <paramref name="help"/> are resource keys.</param>
+		/// <param name="wide">Span the full width of an <c>.rgw-grid</c> rather than one column.</param>
+		public static IHtmlContent Field(IStringLocalizer localizer, string name, string label, object value = null,
+			string type = "text", IEnumerable<SelectListItem> options = null, string help = null,
+			bool required = false, bool readOnly = false, bool wide = false, int maxLength = 16000,
+			string step = null, string min = null, string max = null, string ariaLabel = null)
+		{
+			var identity = "rgw-" + Guid.NewGuid().ToString("N");
+			var caption = localizer[label].Value;
+			var text = value is DateTime date
+				? date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)
+				: Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty;
+
+			var group = new TagBuilder("div");
+			group.AddCssClass("form-group");
+			if (wide)
+				group.AddCssClass("rgw-wide");
+
+			if (type == "checkbox")
+			{
+				var box = new TagBuilder("input") { TagRenderMode = TagRenderMode.SelfClosing };
+				box.Attributes["type"] = "checkbox";
+				box.Attributes["name"] = name;
+				box.Attributes["id"] = identity;
+				box.Attributes["value"] = "true";
+				if (string.Equals(text, "true", StringComparison.OrdinalIgnoreCase))
+					box.Attributes["checked"] = "checked";
+
+				var boxLabel = new TagBuilder("label");
+				boxLabel.Attributes["for"] = identity;
+				boxLabel.InnerHtml.AppendHtml(box);
+				boxLabel.InnerHtml.Append(" " + caption);
+
+				var wrap = new TagBuilder("div");
+				wrap.AddCssClass("checkbox");
+				wrap.InnerHtml.AppendHtml(boxLabel);
+				group.InnerHtml.AppendHtml(wrap);
+
+				// Paired hidden field so clearing the box posts an explicit false; without it
+				// the model binder leaves the property at whatever the input class defaults to.
+				group.InnerHtml.AppendHtml(Hidden(name, "false"));
+
+				AppendHelp(group, localizer, help);
+				return group;
+			}
+
+			var title = new TagBuilder("label");
+			title.Attributes["for"] = identity;
+			title.InnerHtml.Append(caption);
+			group.InnerHtml.AppendHtml(title);
+
+			TagBuilder element;
+			if (options != null)
+			{
+				element = new TagBuilder("select");
+				foreach (var option in options)
+				{
+					var item = new TagBuilder("option");
+					item.Attributes["value"] = option.Value ?? string.Empty;
+					if ((option.Value ?? string.Empty) == text)
+						item.Attributes["selected"] = "selected";
+					item.InnerHtml.Append(option.Text);
+					element.InnerHtml.AppendHtml(item);
+				}
+			}
+			else if (type == "textarea")
+			{
+				element = new TagBuilder("textarea");
+				element.Attributes["rows"] = "3";
+				element.Attributes["maxlength"] = maxLength.ToString(CultureInfo.InvariantCulture);
+				element.InnerHtml.Append(text);
+			}
+			else
+			{
+				element = new TagBuilder("input") { TagRenderMode = TagRenderMode.SelfClosing };
+				element.Attributes["type"] = type;
+				element.Attributes["value"] = text;
+				element.Attributes["maxlength"] = maxLength.ToString(CultureInfo.InvariantCulture);
+				if (type == "number")
+					element.Attributes["step"] = step ?? "0.000001";
+				if (min != null)
+					element.Attributes["min"] = min;
+				if (max != null)
+					element.Attributes["max"] = max;
+			}
+
+			element.AddCssClass("form-control");
+			element.Attributes["name"] = name;
+			element.Attributes["id"] = identity;
+			if (required)
+				element.Attributes["required"] = "required";
+			if (readOnly)
+				element.Attributes["readonly"] = "readonly";
+			if (!string.IsNullOrEmpty(ariaLabel))
+				element.Attributes["aria-label"] = ariaLabel;
+			group.InnerHtml.AppendHtml(element);
+
+			AppendHelp(group, localizer, help);
+			return group;
+		}
+
+		/// <summary>
+		/// A hidden field, for values the screen carries but never asks about. Written by hand
+		/// rather than with a TagBuilder because TagBuilder sorts attributes alphabetically, and
+		/// the page state these fields carry is asserted on by name/value pairs in the tests.
+		/// </summary>
+		public static IHtmlContent Hidden(string name, object value)
+		{
+			var text = value is DateTime date
+				? date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)
+				: Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty;
+			return new HtmlString("<input type=\"hidden\" name=\"" + HtmlEncoder.Default.Encode(name) +
+				"\" value=\"" + HtmlEncoder.Default.Encode(text) + "\" />");
+		}
+
+		/// <summary>Choice list with a leading blank entry, for optional selects.</summary>
+		public static IEnumerable<SelectListItem> Choices(IEnumerable<(string Id, string Name)> choices) =>
+			new[] { new SelectListItem { Value = string.Empty, Text = EmptyChoice } }
+				.Concat(choices.Select(x => new SelectListItem { Value = x.Id, Text = x.Name }));
+
+		/// <summary>Choice list without a blank entry, for selects that must hold a value.</summary>
+		public static IEnumerable<SelectListItem> Required(IEnumerable<(string Id, string Name)> choices) =>
+			choices.Select(x => new SelectListItem { Value = x.Id, Text = x.Name });
+
+		/// <summary>Enum codes rendered from "{prefix}{value}" resource keys, such as Movement3.</summary>
+		public static IEnumerable<SelectListItem> Codes(IStringLocalizer localizer, string prefix, params int[] values) =>
+			values.Select(x => new SelectListItem { Value = x.ToString(CultureInfo.InvariantCulture), Text = localizer[prefix + x].Value });
+
+		/// <summary>Yes/No pair for the few flags that stay a dropdown rather than a checkbox.</summary>
+		public static IEnumerable<SelectListItem> YesNo(IStringLocalizer localizer) => new[]
+		{
+			new SelectListItem { Value = "false", Text = localizer["No"].Value },
+			new SelectListItem { Value = "true", Text = localizer["Yes"].Value }
+		};
+
+		private static void AppendHelp(TagBuilder group, IStringLocalizer localizer, string help)
+		{
+			if (string.IsNullOrEmpty(help))
+				return;
+
+			var resolved = localizer[help];
+			if (resolved.ResourceNotFound)
+				return;
+
+			var block = new TagBuilder("span");
+			block.AddCssClass("help-block");
+			block.InnerHtml.Append(resolved.Value);
+			group.InnerHtml.AppendHtml(block);
+		}
+	}
+}

--- a/Web/Resgrid.Web/wwwroot/css/workspace.css
+++ b/Web/Resgrid.Web/wwwroot/css/workspace.css
@@ -44,6 +44,12 @@
 /* Each module button in the page heading is its own POST form, which is block level. */
 .rgw-modules form { display: inline-block; margin-left: 5px; }
 
+/* The theme restates `.dropdown-menu { left: 0 }` after Bootstrap, which undoes
+   `.dropdown-menu-right`; a menu opened from the right edge of the heading would hang
+   off the page. Restated here at higher specificity for the heading only. */
+.top-page-buttons .dropdown-menu-right { left: auto; right: 0; }
+.top-page-buttons .dropdown-menu > li > a { white-space: nowrap; }
+
 /* -- Toolbar above a list ------------------------------------------------
    A row of actions, some of which are POST forms and so cannot sit in a btn-group. */
 .rgw-toolbar { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin: 0 0 15px 0; }
@@ -136,6 +142,45 @@
 /* -- Modals --------------------------------------------------------------- */
 .rgw-modal .rgw-modal-message { display: none; }
 .rgw-modal .rgw-modal-message.rgw-visible { display: block; }
+
+/* -- Checklist builder ----------------------------------------------------
+   Sections and items are panels so the "Section 1" / "Item 1" caption sits inside
+   the block's own header bar rather than straddling a fieldset border. */
+.rgw-builder-heading { display: flex; flex-wrap: wrap; align-items: center; gap: 6px; }
+.rgw-builder-heading .rgw-builder-title { flex: 1 1 auto; font-weight: 600; }
+.rgw-builder-heading .rgw-builder-actions { flex: 0 0 auto; white-space: nowrap; }
+.rgw-builder-heading .rgw-builder-actions .btn + .btn { margin-left: 4px; }
+
+.rgw-builder-section > .panel-heading { background: #f3f3f4; }
+.rgw-builder-item { background: #fcfcfd; }
+.rgw-builder-item > .panel-heading { background: #ffffff; }
+
+/* Builder labels are long enough to wrap, which would otherwise leave the controls in a
+   row sitting at different heights. Bottom aligning the cells lines the controls up. */
+.rgw-builder-item > .panel-body > .rgw-grid { align-items: end; }
+
+/* Toggles read as one block of choices rather than a column of lone checkboxes. */
+.rgw-builder-toggles { display: flex; flex-wrap: wrap; gap: 2px 24px; margin-bottom: 15px; }
+.rgw-builder-toggles .form-group { margin-bottom: 0; }
+.rgw-builder-toggles .checkbox { margin-top: 4px; margin-bottom: 4px; }
+
+/* -- Records analytics ----------------------------------------------------
+   The KPI tile, weekday/hour heat map and fixed height chart box used by the
+   records analytics screens. The heat-N class is chosen server side by
+   RmsAnalyticsDisplay.Heat, so these names are a contract with that helper. */
+.rms-kpi { text-align: center; padding: 10px 4px; }
+.rms-kpi .value { font-size: 26px; font-weight: 600; }
+.rms-kpi .label { color: #888; font-size: 12px; text-transform: uppercase; }
+
+.rms-heat { border-collapse: collapse; width: 100%; font-size: 10px; }
+.rms-heat td, .rms-heat th { border: 1px solid #eee; padding: 2px; text-align: center; width: 3.7%; }
+.rms-heat .heat-0 { background: #ffffff; color: #cccccc; }
+.rms-heat .heat-1 { background: #d9f3ee; }
+.rms-heat .heat-2 { background: #a7e2d5; }
+.rms-heat .heat-3 { background: #5fc9b2; }
+.rms-heat .heat-4 { background: #1ab394; color: #ffffff; }
+
+.rms-chart { position: relative; height: 240px; }
 
 /* -- Pager ---------------------------------------------------------------- */
 .rgw-pager { margin-top: 15px; display: flex; gap: 8px; align-items: center; }

--- a/Web/Resgrid.Web/wwwroot/css/workspace.css
+++ b/Web/Resgrid.Web/wwwroot/css/workspace.css
@@ -1,0 +1,146 @@
+/* Shared workspace chrome for the module screens that use it (inventory, checklists).
+   Everything the INSPINIA theme already provides is used as-is: ibox, nav-tabs, label,
+   alert, panel, btn and the text/spacing helpers. This file only adds the handful of
+   things the theme has no component for -- the step wizard, the field grid, and the
+   rules that make a POST form behave like a tab or an inline table action. */
+
+/* -- Tabs -----------------------------------------------------------------
+   Tab navigation has to POST, because under Advanced Data Protection the reveal grant
+   rides on the form (see inventory-modern.js). These rules give the submit button the
+   same box the theme gives `.nav-tabs > li > a`, so the strip is indistinguishable from
+   every other tab strip in the application. */
+.nav-tabs > li > form { margin: 0; }
+.nav-tabs > li > form > button {
+    position: relative;
+    display: block;
+    padding: 14px 20px;
+    margin-right: 2px;
+    line-height: 1.42857143;
+    background: none;
+    border: 1px solid transparent;
+    border-radius: 4px 4px 0 0;
+    color: #a7b1c2;
+    font-weight: 600;
+}
+.nav-tabs > li > form > button:hover,
+.nav-tabs > li > form > button:focus { border-color: #eee #eee #ddd; background-color: #eee; color: #a7b1c2; }
+.nav-tabs > li.active > form > button,
+.nav-tabs > li.active > form > button:hover,
+.nav-tabs > li.active > form > button:focus {
+    background: none;
+    border-color: #dddddd #dddddd transparent;
+    border-bottom: #f3f3f4;
+    border-style: solid;
+    border-width: 1px;
+    color: #555555;
+    cursor: default;
+}
+.nav-tabs > li > form > button i { margin-right: 6px; }
+
+/* The theme spaces tab content through .tabs-container; these screens put the panel
+   straight into the ibox, so the strip needs the gap itself. */
+.ibox-content > .nav-tabs { margin-bottom: 20px; }
+
+/* Each module button in the page heading is its own POST form, which is block level. */
+.rgw-modules form { display: inline-block; margin-left: 5px; }
+
+/* -- Toolbar above a list ------------------------------------------------
+   A row of actions, some of which are POST forms and so cannot sit in a btn-group. */
+.rgw-toolbar { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin: 0 0 15px 0; }
+.rgw-toolbar .rgw-toolbar-spacer { flex: 1 1 auto; }
+.rgw-toolbar form { margin: 0; }
+
+/* -- Filter block --------------------------------------------------------- */
+.rgw-filter { border: 1px solid #e7eaec; border-radius: 3px; padding: 15px 20px 5px 20px; margin: 0 0 20px 0; background: #f3f3f4; }
+.rgw-filter .rgw-filter-actions { padding-bottom: 15px; }
+.rgw-filter .rgw-filter-split { border-top: 1px solid #e7eaec; padding-top: 15px; }
+
+/* A filter has only two or three fields; without a cap they stretch the whole page. */
+.rgw-filter .rgw-grid { grid-template-columns: repeat(auto-fit, minmax(240px, 340px)); }
+.rgw-lookup { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 340px)); gap: 0 20px; }
+.rgw-lookup > form { min-width: 0; }
+
+/* -- Field grid -----------------------------------------------------------
+   Bootstrap's row/col grid cannot flow an unknown number of form groups into as many
+   columns as will fit, so the form groups themselves are laid out here. */
+.rgw-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 0 20px; }
+.rgw-grid > .form-group { min-width: 0; margin-bottom: 15px; }
+.rgw-grid > .form-group.rgw-wide { grid-column: 1 / -1; }
+.rgw-grid .checkbox { margin-top: 0; }
+
+/* -- Step wizard ---------------------------------------------------------- */
+.rgw-wizard .rgw-steps {
+    list-style: none;
+    display: flex;
+    flex-wrap: wrap;
+    margin: 0 0 20px 0;
+    padding: 0 0 15px 0;
+    border-bottom: 1px solid #e7eaec;
+    gap: 6px 22px;
+}
+.rgw-wizard .rgw-steps li { display: flex; align-items: center; color: #a7b1c2; }
+.rgw-wizard .rgw-steps .rgw-step-number {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    margin-right: 8px;
+    border-radius: 50%;
+    border: 1px solid #e7eaec;
+    background: #ffffff;
+    font-size: 11px;
+    font-weight: 600;
+}
+.rgw-wizard .rgw-steps li.done { color: #676a6c; }
+.rgw-wizard .rgw-steps li.done .rgw-step-number { border-color: #1ab394; background: #1ab394; color: #ffffff; }
+.rgw-wizard .rgw-steps li.current { color: #1ab394; font-weight: 600; }
+.rgw-wizard .rgw-steps li.current .rgw-step-number { border-color: #1ab394; color: #1ab394; }
+
+.rgw-wizard .rgw-step[hidden] { display: none !important; }
+.rgw-wizard .rgw-invalid > .form-control { border-color: #ed5565; }
+.rgw-wizard .rgw-step-error { color: #ed5565; margin: 0 0 15px 0; }
+
+.rgw-wizard-actions {
+    padding-top: 15px;
+    border-top: 1px solid #e7eaec;
+    display: flex;
+    gap: 8px;
+    align-items: center;
+}
+.rgw-wizard-actions .rgw-wizard-spacer { flex: 1 1 auto; }
+
+/* Review step: a definition list that reads as label / answer pairs. */
+.rgw-review { margin: 0; }
+.rgw-review .rgw-review-row { display: flex; padding: 7px 0; border-bottom: 1px solid #f0f2f3; }
+.rgw-review .rgw-review-row:last-child { border-bottom: 0; }
+.rgw-review dt { flex: 0 0 45%; padding-right: 12px; }
+.rgw-review dd { flex: 1 1 auto; margin: 0; word-break: break-word; }
+
+/* -- Tables ---------------------------------------------------------------
+   Row actions are POST forms, which are block level by default. */
+.rgw-table > tbody > tr > td { vertical-align: middle; }
+.rgw-table small.rgw-sub { display: block; }
+.rgw-table .rgw-row-actions { white-space: nowrap; }
+.rgw-table .rgw-row-actions form { display: inline-block; margin: 0; }
+.rgw-table .rgw-row-actions .btn + .btn,
+.rgw-table .rgw-row-actions form + form,
+.rgw-table .rgw-row-actions .btn + form,
+.rgw-table .rgw-row-actions form + .btn { margin-left: 5px; }
+.rgw-flow i { color: #a7b1c2; margin: 0 6px; }
+
+/* -- Repeating line rows (kit contents, order lines, receipts) ------------- */
+.rgw-line > .panel-body { padding-bottom: 0; }
+.rgw-line-actions { padding-bottom: 15px; }
+
+/* -- Modals --------------------------------------------------------------- */
+.rgw-modal .rgw-modal-message { display: none; }
+.rgw-modal .rgw-modal-message.rgw-visible { display: block; }
+
+/* -- Pager ---------------------------------------------------------------- */
+.rgw-pager { margin-top: 15px; display: flex; gap: 8px; align-items: center; }
+.rgw-pager form { margin: 0; }
+
+@media (max-width: 767px) {
+    .top-page-buttons { float: none; padding: 0 15px 10px 15px; }
+}

--- a/Web/Resgrid.Web/wwwroot/js/app/common/workspace/resgrid.common.workspace.js
+++ b/Web/Resgrid.Web/wwwroot/js/app/common/workspace/resgrid.common.workspace.js
@@ -1,0 +1,234 @@
+/*
+ * Shared workspace UX: step wizards, the review step and modal housekeeping.
+ *
+ * The wizards are plain markup driven. A form only needs:
+ *   <form class="inventory-command rgw-wizard">
+ *     <ol class="rgw-steps"></ol>                        <- indicator, filled in here
+ *     <div class="rgw-step" data-title="...">...</div>   <- one per step
+ *     <div class="rgw-wizard-actions">
+ *        <button class="rgw-step-prev">   <button class="rgw-step-next">
+ *        <button type="submit" class="rgw-step-submit">
+ *
+ * Native validation is turned off on wizard forms because the browser refuses to
+ * report a required field that lives on a hidden step; the step validation below
+ * replaces it and jumps the user back to the step that is actually incomplete.
+ *
+ * The submit handler is registered immediately (rather than on ready) so that it runs
+ * before any page handler that posts the form, and can cancel an incomplete submit.
+ */
+(function () {
+    'use strict';
+
+    var text = {};
+    var settings = document.getElementById('workspace-settings');
+    if (settings) {
+        try { text = JSON.parse(settings.textContent) || {}; } catch (error) { text = {}; }
+    }
+
+    function steps(form) {
+        return Array.prototype.filter.call(form.querySelectorAll('.rgw-step'), function (step) {
+            return step.closest('form') === form;
+        });
+    }
+
+    function fields(step) {
+        return Array.prototype.filter.call(step.querySelectorAll('input, select, textarea'), function (field) {
+            return !field.disabled && field.type !== 'hidden';
+        });
+    }
+
+    function group(field) {
+        return field.closest('.form-group') || field.parentElement;
+    }
+
+    function clearErrors(step) {
+        Array.prototype.forEach.call(step.querySelectorAll('.rgw-invalid'), function (node) {
+            node.classList.remove('rgw-invalid');
+        });
+        var error = step.querySelector('.rgw-step-error');
+        if (error) { error.textContent = ''; error.hidden = true; }
+    }
+
+    function validate(step) {
+        clearErrors(step);
+        var bad = fields(step).filter(function (field) { return !field.checkValidity(); });
+        if (bad.length === 0) { return true; }
+
+        bad.forEach(function (field) { group(field).classList.add('rgw-invalid'); });
+
+        var error = step.querySelector('.rgw-step-error');
+        if (!error) {
+            error = document.createElement('p');
+            error.className = 'rgw-step-error';
+            step.insertBefore(error, step.firstChild);
+        }
+        error.textContent = bad[0].validationMessage || text.required || '';
+        error.hidden = false;
+
+        bad[0].focus();
+        return false;
+    }
+
+    // Human readable value for the review step: the chosen option text for a
+    // select, the checked state for a checkbox, the raw value for anything else.
+    function display(field) {
+        if (field.tagName === 'SELECT') {
+            var option = field.options[field.selectedIndex];
+            var label = option ? option.text.trim() : '';
+            return label === '—' ? '' : label;
+        }
+        if (field.type === 'checkbox') { return field.checked ? (text.yes || 'Yes') : (text.no || 'No'); }
+        return (field.value || '').trim();
+    }
+
+    function caption(field) {
+        var owner = field.id ? field.form.querySelector('label[for="' + field.id + '"]') : null;
+        if (!owner) { owner = group(field).querySelector('label'); }
+        return owner ? owner.textContent.trim() : field.name;
+    }
+
+    function review(form) {
+        var target = form.querySelector('.rgw-review');
+        if (!target) { return; }
+        target.textContent = '';
+
+        steps(form).forEach(function (step) {
+            if (step.querySelector('.rgw-review')) { return; }
+            fields(step).forEach(function (field) {
+                if (field.type === 'checkbox' && field.dataset.reviewSkip === 'true') { return; }
+                var value = display(field);
+                if (!value) { return; }
+
+                var row = document.createElement('div');
+                row.className = 'rgw-review-row';
+                var term = document.createElement('dt');
+                term.textContent = caption(field);
+                var definition = document.createElement('dd');
+                definition.textContent = value;
+                row.appendChild(term);
+                row.appendChild(definition);
+                target.appendChild(row);
+            });
+        });
+
+        if (!target.hasChildNodes()) {
+            var empty = document.createElement('div');
+            empty.className = 'rgw-review-row';
+            empty.textContent = text.nothingEntered || '';
+            target.appendChild(empty);
+        }
+    }
+
+    function indicator(form, all, index) {
+        var list = form.querySelector('.rgw-steps');
+        if (!list) { return; }
+
+        if (!list.hasChildNodes()) {
+            all.forEach(function (step, position) {
+                var entry = document.createElement('li');
+                var number = document.createElement('span');
+                number.className = 'rgw-step-number';
+                number.textContent = String(position + 1);
+                var title = document.createElement('span');
+                title.textContent = step.dataset.title || '';
+                entry.appendChild(number);
+                entry.appendChild(title);
+                list.appendChild(entry);
+            });
+        }
+
+        Array.prototype.forEach.call(list.children, function (entry, position) {
+            entry.className = position === index ? 'current' : (position < index ? 'done' : '');
+            entry.setAttribute('aria-current', position === index ? 'step' : 'false');
+        });
+    }
+
+    function show(form, index) {
+        var all = steps(form);
+        if (all.length === 0) { return; }
+
+        index = Math.max(0, Math.min(index, all.length - 1));
+        all.forEach(function (step, position) { step.hidden = position !== index; });
+        form.dataset.step = String(index);
+
+        indicator(form, all, index);
+
+        var previous = form.querySelector('.rgw-step-prev');
+        var next = form.querySelector('.rgw-step-next');
+        var submit = form.querySelector('.rgw-step-submit');
+        var last = index === all.length - 1;
+
+        if (previous) { previous.hidden = index === 0; }
+        if (next) { next.hidden = last; }
+        if (submit) { submit.hidden = !last; }
+        if (last) { review(form); }
+
+        var heading = all[index].querySelector('h4');
+        if (heading && form.dataset.wizardStarted === 'true') { heading.scrollIntoView({ block: 'nearest' }); }
+        form.dataset.wizardStarted = 'true';
+    }
+
+    function firstInvalid(form) {
+        var all = steps(form);
+        for (var position = 0; position < all.length; position++) {
+            var incomplete = fields(all[position]).some(function (field) { return !field.checkValidity(); });
+            if (incomplete) { return position; }
+        }
+        return -1;
+    }
+
+    function wire(form) {
+        if (form.dataset.wizardReady === 'true') { return; }
+        form.dataset.wizardReady = 'true';
+        form.setAttribute('novalidate', 'novalidate');
+
+        form.addEventListener('click', function (event) {
+            var next = event.target.closest('.rgw-step-next');
+            var previous = event.target.closest('.rgw-step-prev');
+            if (!next && !previous) { return; }
+            if (next && next.form !== form) { return; }
+            if (previous && previous.form !== form) { return; }
+
+            event.preventDefault();
+            var index = parseInt(form.dataset.step || '0', 10);
+            if (previous) { show(form, index - 1); return; }
+
+            var all = steps(form);
+            if (validate(all[index])) { show(form, index + 1); }
+        });
+
+        form.addEventListener('submit', function (event) {
+            var broken = firstInvalid(form);
+            if (broken < 0) { return; }
+            event.preventDefault();
+            show(form, broken);
+            validate(steps(form)[broken]);
+        });
+
+        // Re-enable a step once the user starts fixing it.
+        form.addEventListener('input', function (event) {
+            var owner = event.target.closest('.rgw-invalid');
+            if (owner) { owner.classList.remove('rgw-invalid'); }
+        });
+
+        show(form, 0);
+    }
+
+    document.querySelectorAll('form.rgw-wizard').forEach(wire);
+
+    // Bootstrap 3 modals: start each wizard at step one every time it opens, and
+    // clear whatever error the previous attempt left behind.
+    if (window.jQuery) {
+        window.jQuery(document).on('shown.bs.modal', '.rgw-modal', function () {
+            var host = this;
+            host.querySelectorAll('form.rgw-wizard').forEach(function (form) {
+                delete form.dataset.wizardStarted;
+                show(form, 0);
+            });
+            var message = host.querySelector('.rgw-modal-message');
+            if (message) { message.style.display = 'none'; }
+            var focusable = host.querySelector('.rgw-step:not([hidden]) input:not([type=hidden]), .rgw-step:not([hidden]) select, .modal-body input:not([type=hidden]), .modal-body select');
+            if (focusable) { focusable.focus(); }
+        });
+    }
+})();

--- a/Web/Resgrid.Web/wwwroot/js/app/internal/checklists/checklists.js
+++ b/Web/Resgrid.Web/wwwroot/js/app/internal/checklists/checklists.js
@@ -7,15 +7,36 @@
     const types = ['Pass / Fail', 'Yes / No', 'Checkbox', 'Numeric reading', 'Quantity', 'Free text', 'Select list', 'Date', 'Photo', 'Signature'];
     const categories = ['Start of shift', 'Unit check', 'Personal gear', 'Annual review', 'Facility', 'Safety audit', 'Equipment check', 'Other'];
     const el = (tag, text, parent) => { const node = document.createElement(tag); if (text != null) node.textContent = text; if (parent) parent.appendChild(node); return node; };
-    function button(parent, text, action) { const node = el('button', tr(text), parent); node.type = 'button'; node.className = 'btn btn-default btn-sm'; node.addEventListener('click', action); return node; }
-    function field(parent, label, object, key, type, choices) {
-        const box = el('div', null, parent); box.className = 'form-group';
-        const caption = el('label', tr(label), box); const id = 'checklist-field-' + crypto.randomUUID(); caption.htmlFor = id;
-        const input = el(choices ? 'select' : type === 'textarea' ? 'textarea' : 'input', null, box);
-        input.id = id; input.className = type === 'checkbox' ? '' : 'form-control';
-        if (choices) choices.forEach(choice => { const option = el('option', choice[2] === false ? choice[1] : tr(choice[1]), input); option.value = choice[0]; });
-        else if (type !== 'textarea') input.type = type || 'text';
-        if (type === 'number') input.step = 'any';
+    function button(parent, text, action, className) { const node = el('button', tr(text), parent); node.type = 'button'; node.className = className || 'btn btn-default btn-sm'; node.addEventListener('click', action); return node; }
+    // A titled block whose caption sits inside the block's own header bar.
+    function panel(parent, title, className) {
+        const box = el('div', null, parent); box.className = 'panel panel-default' + (className ? ' ' + className : '');
+        const heading = el('div', null, box); heading.className = 'panel-heading rgw-builder-heading';
+        el('span', title, heading).className = 'rgw-builder-title';
+        const actions = el('span', null, heading); actions.className = 'rgw-builder-actions';
+        const body = el('div', null, box); body.className = 'panel-body';
+        return { box, actions, body };
+    }
+    const grid = parent => { const node = el('div', null, parent); node.className = 'rgw-grid'; return node; };
+    function field(parent, label, object, key, type, choices, wide) {
+        const box = el('div', null, parent); box.className = 'form-group' + (wide ? ' rgw-wide' : '');
+        const id = 'checklist-field-' + crypto.randomUUID();
+        let input;
+        if (type === 'checkbox') {
+            // Bootstrap's checkbox wrapper indents the label text away from the box.
+            const wrapper = el('div', null, box); wrapper.className = 'checkbox';
+            const caption = el('label', null, wrapper); caption.htmlFor = id;
+            input = el('input', null, caption); input.type = 'checkbox';
+            el('span', ' ' + tr(label), caption);
+        } else {
+            const caption = el('label', tr(label), box); caption.htmlFor = id;
+            input = el(choices ? 'select' : type === 'textarea' ? 'textarea' : 'input', null, box);
+            input.className = 'form-control';
+            if (choices) choices.forEach(choice => { const option = el('option', choice[2] === false ? choice[1] : tr(choice[1]), input); option.value = choice[0]; });
+            else if (type !== 'textarea') input.type = type || 'text';
+            if (type === 'number') input.step = 'any';
+        }
+        input.id = id;
         if (type === 'checkbox') input.checked = !!object[key]; else input.value = object[key] == null ? '' : object[key];
         input.addEventListener('input', () => { object[key] = type === 'checkbox' ? input.checked : type === 'number' ? input.value === '' ? null : Number(input.value) : input.value; });
         return input;
@@ -56,53 +77,70 @@
         const freshItem = () => ({ Id: crypto.randomUUID(), Name: '', Type: 0, Required: true, Critical: false, AllowNotApplicable: false, RequireNoteOnFail: true, RequirePhotoOnFail: false, Weight: 1, PassingValue: 'true', Options: [] });
         function render() {
             root.replaceChildren();
-            field(root, 'Checklist name', model, 'Name').maxLength = 200;
-            field(root, 'Instructions (do not include patient data)', model, 'Instructions', 'textarea').maxLength = 10000;
-            field(root, 'Category', model, 'Category', 'number', categories.map((name, i) => [i, name]));
+            const settings = grid(root);
+            field(settings, 'Checklist name', model, 'Name').maxLength = 200;
+            field(settings, 'Category', model, 'Category', 'number', categories.map((name, i) => [i, name]));
             const targets = [[0, 'Department'], [1, 'Unit'], [2, 'Group / station'], [3, 'Personnel']];
             if (root.dataset.assetsAvailable === 'true' || model.TargetType === 5) targets.push([5, 'InventoryAsset']);
-            field(root, 'Target type', model, 'TargetType', 'number', targets).addEventListener('change', () => { model.Sections.forEach(section => section.Items.forEach(item => { if (model.TargetType !== 1 && model.TargetType !== 5) item.SetUnitStateOnFail = false; if (model.TargetType !== 5) item.HoldAssetOnFail = false; })); render(); });
-            const threshold = field(root, 'Passing score (%)', model, 'PassThreshold', 'number'); threshold.min = 0; threshold.max = 100;
-            field(root, 'Require reported location', model, 'RequireLocation', 'checkbox');
-            field(root, 'Require a different authenticated member to witness the submission', model, 'RequiresIndependentWitness', 'checkbox');
+            field(settings, 'Target type', model, 'TargetType', 'number', targets).addEventListener('change', () => { model.Sections.forEach(section => section.Items.forEach(item => { if (model.TargetType !== 1 && model.TargetType !== 5) item.SetUnitStateOnFail = false; if (model.TargetType !== 5) item.HoldAssetOnFail = false; })); render(); });
+            const threshold = field(settings, 'Passing score (%)', model, 'PassThreshold', 'number'); threshold.min = 0; threshold.max = 100;
+            field(settings, 'Instructions (do not include patient data)', model, 'Instructions', 'textarea', null, true).maxLength = 10000;
+            const definitionToggles = el('div', null, settings); definitionToggles.className = 'form-group rgw-wide rgw-builder-toggles';
+            field(definitionToggles, 'Require reported location', model, 'RequireLocation', 'checkbox');
+            field(definitionToggles, 'Require a different authenticated member to witness the submission', model, 'RequiresIndependentWitness', 'checkbox');
+
             const earlier = [];
             model.Sections.forEach((section, si) => {
-                const sectionBox = el('fieldset', null, root); sectionBox.className = 'well'; el('legend', format('Section {0}', si + 1), sectionBox);
-                field(sectionBox, 'Section name', section, 'Name').maxLength = 200;
-                button(sectionBox, 'Move section up', () => move(model.Sections, si, -1, render));
-                button(sectionBox, 'Move section down', () => move(model.Sections, si, 1, render));
-                button(sectionBox, 'Remove section', () => { if (confirm(tr('Remove this section and its items from the draft?'))) { model.Sections.splice(si, 1); render(); } });
+                const sectionPanel = panel(root, format('Section {0}', si + 1), 'rgw-builder-section');
+                button(sectionPanel.actions, 'Move section up', () => move(model.Sections, si, -1, render), 'btn btn-default btn-xs');
+                button(sectionPanel.actions, 'Move section down', () => move(model.Sections, si, 1, render), 'btn btn-default btn-xs');
+                button(sectionPanel.actions, 'Remove section', () => { if (confirm(tr('Remove this section and its items from the draft?'))) { model.Sections.splice(si, 1); render(); } }, 'btn btn-danger btn-xs');
+                const sectionBox = sectionPanel.body;
+                field(grid(sectionBox), 'Section name', section, 'Name', 'text', null, true).maxLength = 200;
                 section.Items.forEach((item, ii) => {
-                    const box = el('fieldset', null, sectionBox); box.className = 'panel panel-default'; box.style.padding = '15px';
-                    el('legend', format('Item {0}', ii + 1), box);
-                    field(box, 'Question / check', item, 'Name').maxLength = 300;
-                    field(box, 'Item instructions', item, 'Instructions', 'textarea').maxLength = 5000;
-                    field(box, 'Answer type', item, 'Type', 'number', types.map((name, i) => [i, name])).addEventListener('change', render);
-                    [['Required', 'Required'], ['Critical failure overrides the score', 'Critical'], ['Allow N/A with a reason', 'AllowNotApplicable'], ['Require a note on failure', 'RequireNoteOnFail'], ['Require a photo on failure', 'RequirePhotoOnFail']].forEach(pair => field(box, pair[0], item, pair[1], 'checkbox'));
-                    field(box, 'CreateWorkOrderOnFail', item, 'CreateWorkOrderOnFail', 'checkbox').addEventListener('change', () => { if (!item.CreateWorkOrderOnFail) { item.SetUnitStateOnFail = false; item.HoldAssetOnFail = false; } render(); });
+                    const itemPanel = panel(sectionBox, format('Item {0}', ii + 1), 'rgw-builder-item');
+                    button(itemPanel.actions, 'Move item up', () => move(section.Items, ii, -1, render), 'btn btn-default btn-xs');
+                    button(itemPanel.actions, 'Move item down', () => move(section.Items, ii, 1, render), 'btn btn-default btn-xs');
+                    button(itemPanel.actions, 'Remove item', () => { if (confirm(tr('Remove this item from the draft?'))) { section.Items.splice(ii, 1); render(); } }, 'btn btn-danger btn-xs');
+                    const box = itemPanel.body;
+                    const basics = grid(box);
+                    field(basics, 'Question / check', item, 'Name', 'text', null, true).maxLength = 300;
+                    field(basics, 'Answer type', item, 'Type', 'number', types.map((name, i) => [i, name])).addEventListener('change', render);
+                    const weight = field(basics, 'Score weight (0 excludes this item from the score)', item, 'Weight', 'number'); weight.min = 0; weight.max = 1000;
+                    field(basics, 'Item instructions', item, 'Instructions', 'textarea', null, true).maxLength = 5000;
+
+                    const toggles = el('div', null, box); toggles.className = 'rgw-builder-toggles';
+                    [['Required', 'Required'], ['Critical failure overrides the score', 'Critical'], ['Allow N/A with a reason', 'AllowNotApplicable'], ['Require a note on failure', 'RequireNoteOnFail'], ['Require a photo on failure', 'RequirePhotoOnFail']].forEach(pair => field(toggles, pair[0], item, pair[1], 'checkbox'));
+                    field(toggles, 'CreateWorkOrderOnFail', item, 'CreateWorkOrderOnFail', 'checkbox').addEventListener('change', () => { if (!item.CreateWorkOrderOnFail) { item.SetUnitStateOnFail = false; item.HoldAssetOnFail = false; } render(); });
+
                     if (item.CreateWorkOrderOnFail) {
                         if (item.WorkOrderPriority == null) item.WorkOrderPriority = 1;
-                        field(box, 'WorkOrderPriority', item, 'WorkOrderPriority', 'number', [[0, 'WorkOrderPriorityLow'], [1, 'WorkOrderPriorityNormal'], [2, 'WorkOrderPriorityHigh'], [3, 'WorkOrderPriorityEmergency']]);
-                        if (model.TargetType === 1 || model.TargetType === 5) field(box, 'SetUnitStateOnFail', item, 'SetUnitStateOnFail', 'checkbox');
-                        if (model.TargetType === 5) field(box, 'HoldAssetOnFail', item, 'HoldAssetOnFail', 'checkbox');
-                        el('p', tr('ReadinessFailureHelp'), box);
+                        const readiness = grid(box);
+                        field(readiness, 'WorkOrderPriority', item, 'WorkOrderPriority', 'number', [[0, 'WorkOrderPriorityLow'], [1, 'WorkOrderPriorityNormal'], [2, 'WorkOrderPriorityHigh'], [3, 'WorkOrderPriorityEmergency']]);
+                        const readinessToggles = el('div', null, readiness); readinessToggles.className = 'form-group rgw-builder-toggles';
+                        if (model.TargetType === 1 || model.TargetType === 5) field(readinessToggles, 'SetUnitStateOnFail', item, 'SetUnitStateOnFail', 'checkbox');
+                        if (model.TargetType === 5) field(readinessToggles, 'HoldAssetOnFail', item, 'HoldAssetOnFail', 'checkbox');
+                        el('p', tr('ReadinessFailureHelp'), box).className = 'help-block';
                     }
-                    const weight = field(box, 'Score weight (0 excludes this item from the score)', item, 'Weight', 'number'); weight.min = 0; weight.max = 1000;
-                    if (item.Type === 1 || item.Type === 2) field(box, 'Passing answer', item, 'PassingValue', 'text', [['true', 'Yes / checked'], ['false', 'No / unchecked']]);
+
+                    const answer = grid(box);
+                    if (item.Type === 1 || item.Type === 2) field(answer, 'Passing answer', item, 'PassingValue', 'text', [['true', 'Yes / checked'], ['false', 'No / unchecked']]);
                     if (item.Type === 3 || item.Type === 4) {
-                        field(box, 'Units', item, 'Units').maxLength = 50;
-                        field(box, 'Minimum passing value (optional if maximum is set)', item, 'Minimum', 'number');
-                        field(box, 'Maximum passing value (optional if minimum is set)', item, 'Maximum', 'number');
+                        field(answer, 'Units', item, 'Units').maxLength = 50;
+                        field(answer, 'Minimum passing value (optional if maximum is set)', item, 'Minimum', 'number');
+                        field(answer, 'Maximum passing value (optional if minimum is set)', item, 'Maximum', 'number');
                     }
                     if (item.Type === 6) {
                         const options = { Lines: (item.Options || []).join('\n') };
-                        field(box, 'Choices (one per line)', options, 'Lines', 'textarea').addEventListener('input', () => { item.Options = options.Lines.split('\n').map(value => value.trim()).filter(Boolean); });
-                        field(box, 'Exact passing choice', item, 'PassingValue');
+                        field(answer, 'Choices (one per line)', options, 'Lines', 'textarea', null, true).addEventListener('input', () => { item.Options = options.Lines.split('\n').map(value => value.trim()).filter(Boolean); });
+                        field(answer, 'Exact passing choice', item, 'PassingValue');
                     }
+
+                    const conditions = grid(box);
                     [['VisibleWhen', 'Show only when'], ['RequiredWhen', 'Also required when']].forEach(pair => {
                         if (item[pair[0]] && !earlier.some(source => source.Id === item[pair[0]].ItemId)) item[pair[0]] = null;
                         const value = { ItemId: item[pair[0]] ? item[pair[0]].ItemId : '' };
-                        field(box, pair[1], value, 'ItemId', 'text', [['', 'Always / no condition']].concat(earlier.map(i => [i.Id, i.Name || tr('Unnamed earlier item'), false]))).addEventListener('change', () => {
+                        field(conditions, pair[1], value, 'ItemId', 'text', [['', 'Always / no condition']].concat(earlier.map(i => [i.Id, i.Name || tr('Unnamed earlier item'), false]))).addEventListener('change', () => {
                             item[pair[0]] = value.ItemId ? { ItemId: value.ItemId, EqualsValue: '' } : null; render();
                         });
                         if (item[pair[0]]) {
@@ -111,17 +149,14 @@
                             if (source && source.Type === 0) choices = [['', 'Choose'], ['pass', 'Pass'], ['fail', 'Fail']];
                             if (source && (source.Type === 1 || source.Type === 2)) choices = [['', 'Choose'], ['true', source.Type === 1 ? 'Yes' : 'Checked'], ['false', source.Type === 1 ? 'No' : 'Unchecked']];
                             if (source && source.Type === 6) choices = [['', 'Choose']].concat((source.Options || []).map(option => [option, option, false]));
-                            field(box, 'Answer that activates this condition', item[pair[0]], 'EqualsValue', source && source.Type === 7 ? 'date' : 'text', choices);
+                            field(conditions, 'Answer that activates this condition', item[pair[0]], 'EqualsValue', source && source.Type === 7 ? 'date' : 'text', choices);
                         }
                     });
                     earlier.push(item);
-                    button(box, 'Move item up', () => move(section.Items, ii, -1, render));
-                    button(box, 'Move item down', () => move(section.Items, ii, 1, render));
-                    button(box, 'Remove item', () => { if (confirm(tr('Remove this item from the draft?'))) { section.Items.splice(ii, 1); render(); } });
                 });
-                button(sectionBox, 'Add item', () => { section.Items.push(freshItem()); render(); });
+                button(sectionBox, 'Add item', () => { section.Items.push(freshItem()); render(); }, 'btn btn-default');
             });
-            button(root, 'Add section', () => { model.Sections.push({ Id: crypto.randomUUID(), Name: '', Items: [freshItem()] }); render(); });
+            button(root, 'Add section', () => { model.Sections.push({ Id: crypto.randomUUID(), Name: '', Items: [freshItem()] }); render(); }, 'btn btn-primary');
         }
         render(); bindSave(form, () => { form.elements.formJson.value = JSON.stringify(model); });
     }

--- a/Web/Resgrid.Web/wwwroot/js/app/internal/inventory/inventory-modern.js
+++ b/Web/Resgrid.Web/wwwroot/js/app/internal/inventory/inventory-modern.js
@@ -2,6 +2,18 @@
     'use strict';
     const settings = JSON.parse(document.getElementById('inventory-settings').textContent);
     const message = document.getElementById('inventory-message');
+    // A command posted from inside a modal reports back inside that modal; the page
+    // level banner is only used for commands that live on the page itself.
+    function notify(form, body, kind) {
+        const dialog = form && form.closest('.modal-content');
+        const target = (dialog && dialog.querySelector('.rgw-modal-message')) || message;
+        target.textContent = body;
+        target.className = target === message
+            ? 'alert ' + (kind || 'alert-info')
+            : 'alert rgw-modal-message rgw-visible ' + (kind || 'alert-info');
+        target.hidden = false;
+        if (target.scrollIntoView) target.scrollIntoView({ block: 'nearest' });
+    }
     function hidden(form, name, value) {
         let field = form.querySelector('input[name="' + name + '"]');
         if (!field) { field = document.createElement('input'); field.type = 'hidden'; field.name = name; form.appendChild(field); }
@@ -28,11 +40,11 @@
             const result = await response.json();
             if (!response.ok) throw new Error(result.message || settings.failed);
             const pendingAsset = form.dataset.inventoryCreateAsset === 'true' && !(result.currentLocationId || result.CurrentLocationId);
-            if (result.awaitingWitness || result.AwaitingWitness || pendingAsset) { message.textContent = settings.witness + ' ' + form.querySelector('[name="RequestId"]').value; message.hidden = false; return; }
+            if (result.awaitingWitness || result.AwaitingWitness || pendingAsset) { notify(form, settings.witness + ' ' + form.querySelector('[name="RequestId"]').value, 'alert-warning'); return; }
             const page = document.getElementById('inventory-page');
             ['__ResgridProtectedGrant', '__ResgridProtectedGrantExpiresOn'].forEach(name => { const field = form.querySelector('[name="' + name + '"]'); if (field) hidden(page, name, field.value); });
             page.submit();
-        } catch (error) { message.textContent = error.message || settings.failed; message.hidden = false; }
+        } catch (error) { notify(form, error.message || settings.failed, 'alert-danger'); }
         finally { delete form.dataset.sending; }
     }));
     });


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary
This PR delivers a broad UI cleanup across RMS, Inventory, Work Orders, and Checklists, while also tightening a few supporting behaviors in Records event handling and adding admin tooling for feature flags.

## What changed

### UI refresh for Checklists
- Reworked checklist pages to use a consistent workspace-style layout with shared page shells, tab navigation, toolbars, modals, and styling.
- Improved checklist definition, schedule, run, due, compliance, template, reminder, and history/detail screens.
- Converted longer checklist flows, such as schedule editing, into guided step-based forms with review steps and clearer validation.
- Moved actions like start run, excuse check, publish/retire, and witness attestation into modal workflows for a cleaner experience.
- Added richer empty states, status badges, report summaries, export/print actions, and help text throughout the checklist module.

### UI refresh for Inventory
- Added a shared inventory workspace shell and common form helpers to standardize layout and field rendering.
- Cleaned up the Purchasing and Operations areas with consistent tabs, filters, toolbars, cards, modals, and tables.
- Turned multi-step flows such as purchase order creation, physical count setup, and report generation into guided wizard-style experiences.
- Improved visibility of alerts, counts, valuation summaries, receipts, suppliers, and reports with better empty states and clearer actions.
- Updated inventory command feedback so actions launched from modals report back inside the modal instead of only at page level.

### UI refresh for Work Orders
- Added shared shell and tab navigation for the work order module.
- Updated index, detail, operations, reports, policy, recurrence, preventive maintenance, bulk operations, and locked screens to follow the new workspace pattern.
- Converted complex edit and recurrence forms into step-based workflows with review steps and clearer guidance.
- Moved many operational actions into modals, including status changes, assignments, comments, labor, parts, uploads, approvals, holds, deferrals, and vendor charges.
- Improved readability of work order activity, parts allocation, maintenance history, reports, and recurrence details with badges, summaries, and better table layouts.

### UI refresh for RMS / Records
- Reorganized Records navigation so Records now appears as a grouped, collapsible sidebar section rather than many separate top-level links.
- Added an “All records” navigation entry and grouped related Records destinations underneath it.
- Cleaned up several Records-related pages with shared shell styling, toolbars, and workspace layout patterns:
  - legal holds
  - evidence history and evidence capture
  - submission history and recovery
  - diff/comparison view
  - new run call flow
- Simplified the Incident Report details action area by grouping exports and secondary actions into dropdown menus.
- Localized file classification labels and participant-related labels in Records edit/details screens.
- Added activation call-to-action on the Records dashboard when the module is enabled but not yet activated.

### Shared workspace infrastructure
- Added shared CSS and JavaScript for:
  - workspace page styling
  - wizard/step navigation
  - review-step rendering
  - validation behavior for hidden wizard steps
  - modal wizard reset behavior
- Added reusable server-side helpers for rendering consistent form fields and layout components.

### Localization updates
- Added extensive new localized text for the updated UI patterns and guidance across:
  - Checklists
  - Inventory
  - Work Orders
  - Records
  - Common navigation
- Included translations for all supported language resource files touched by these modules.

## Supporting functional fixes

### Records outbox guard fix
- Refined Records domain event handling so the live-content guard only applies to event types that actually reference a record, incident report, or incident analysis.
- This prevents non-record Records events, such as definition-related or scope-only legal hold events, from being incorrectly rejected as missing or purged record content.
- Records events now require an aggregate type to be provided, ensuring the system can correctly decide whether record-content protection should apply.

### Records module state caching compatibility
- Marked `RecordsModuleState` as a protobuf contract so it can be safely cached and restored through the cache provider.

### Legal hold event behavior
- Adjusted legal hold event aggregation so scope-only holds are treated as their own aggregate, while holds tied to a specific record still retain record-level protection behavior.

### Repository/test cleanup
- Fixed an open-count projection alias in prevention repositories.
- Added regression and browser tests covering:
  - Records sidebar expand/collapse behavior
  - shared workspace wizard behavior
  - checklist link encoding safety
  - outbox live-content guard behavior for record vs non-record aggregates

## Tooling
### New console command for feature flags
- Added a new `FeatureFlags` console command that allows operators to:
  - list flags
  - list known application flag keys
  - inspect a specific flag
  - set global defaults
  - set or clear department overrides
  - change rollout percentages
- The command uses the same feature toggle service path as the application, so cache invalidation and audit behavior stay consistent.
<!-- kody-pr-summary:end -->